### PR TITLE
BAH-4298|Fix Patient relationship search input accepting complete ID

### DIFF
--- a/apps/registration/src/components/forms/patientRelationships/__tests__/usePatientRelationship.test.tsx
+++ b/apps/registration/src/components/forms/patientRelationships/__tests__/usePatientRelationship.test.tsx
@@ -267,7 +267,7 @@ describe('usePatientRelationship', () => {
       });
 
       expect(mockHandleSearch).toHaveBeenCalledWith(relationshipId, 'John');
-      expect(result.current.relationships[0].patientId).toBe('John');
+      expect(result.current.relationships[0].patientId).toBe('');
     });
 
     it('should handle patient selection and update relationship', () => {

--- a/apps/registration/src/components/forms/patientRelationships/usePatientRelationship.ts
+++ b/apps/registration/src/components/forms/patientRelationships/usePatientRelationship.ts
@@ -90,9 +90,8 @@ export const usePatientRelationship = ({
   const handlePatientSearch = useCallback(
     (rowId: string, searchValue: string) => {
       handleSearch(rowId, searchValue);
-      updateRelationship(rowId, RELATIONSHIP_FIELDS.PATIENT_ID, searchValue);
     },
-    [handleSearch, updateRelationship],
+    [handleSearch],
   );
 
   const handlePatientSelect = useCallback(


### PR DESCRIPTION
> [!NOTE]
> Thank you for your contribution. Please find the details of this pull request below.

**JIRA** → [BAH-4298](https://bahmni.atlassian.net/browse/BAH-4298)

Patient relationship search ComboBox was not accepting complete patient IDs. For example, when entering ID "ABC200036", the input would only accept up to "ABC20003" with characters disappearing during typing.

The handlePatientSearch function was calling updateRelationship to set patientId on every keystroke. This caused a conflict between the ComboBox's internal input state (what the user types) and the controlled React state, making characters disappear.

Removed the updateRelationship call from handlePatientSearch in usePatientRelationship.ts
- The patientId is now only set when a patient is selected from the dropdown (through handlePatientSelect)
- During typing, only search terms are tracked, allowing the ComboBox to manage its input freely


---

### **Reviewer(s)**

@bahnew/developers 
_Kindly review the proposed changes when convenient. Your feedback is appreciated._

---
