### PR TITLE
BAH-4355 | Fix. Default empty relationship

### DIFF
--- a/apps/registration/src/hooks/useUpdatePatient.ts
+++ b/apps/registration/src/hooks/useUpdatePatient.ts
@@ -141,7 +141,9 @@ function transformFormDataToPayload(
 
   const transformedRelationships = (relationships ?? [])
     .filter((rel) => {
-      return !rel.isExisting || rel.isDeleted;
+      if (rel.isDeleted) return true;
+      if (rel.isExisting) return false;
+      return rel.relationshipType && rel.patientUuid;
     })
     .map((rel) => {
       if (rel.isDeleted) {


### PR DESCRIPTION
> [!NOTE]
> Thank you for your contribution. Please find the details of this pull request below.

**JIRA** → [BAH-4355](https://bahmni.atlassian.net/browse/BAH-4355)

### **Description**
Problem:
When updating a patient with an empty default relationship row, the backend returns a 200 OK status but with an error message "The personUuid is not present." This causes the patient save to fail silently without proper error handling.

Root Cause:
Root Cause
Empty relationship rows with no relationship type or patient selected were being sent to the backend with undefined/empty values:
This caused the backend to throw an error even though the status was 200 OK.
Solution:
Added filtering logic to exclude empty relationship rows when updating a patient



### **Reviewer(s)**

@bahnew/developers 
_Kindly review the proposed changes when convenient. Your feedback is appreciated._

---
