### PR TITLE
BAH-4431 | Add. Pass Episode UUID as context for filtering observation forms

### DIFF
--- a/apps/clinical/src/components/consultationPad/ConsultationPad.tsx
+++ b/apps/clinical/src/components/consultationPad/ConsultationPad.tsx
@@ -83,12 +83,16 @@ const ConsultationPad: React.FC<ConsultationPadProps> = ({ onClose }) => {
   const practitionerState = useActivePractitioner();
   const { user: currentUser } = practitionerState;
 
+  const { episodeOfCare } = useClinicalAppData();
+
+  const episodeOfCareUuids: string[] = episodeOfCare.map((eoc) => eoc.uuid);
+
   // Fetch observation forms once at parent level to avoid redundant API calls
   const {
     forms: allObservationForms,
     isLoading: isObservationFormsLoading,
     error: observationFormsError,
-  } = useObservationFormsSearch();
+  } = useObservationFormsSearch('', episodeOfCareUuids);
 
   // Lift pinned forms state to parent - shared by both ObservationForms and ObservationFormsContainer
   const {
@@ -202,10 +206,6 @@ const ConsultationPad: React.FC<ConsultationPadProps> = ({ onClose }) => {
     selectedEncounterType &&
     encounterParticipants.length > 0
   );
-
-  const { episodeOfCare } = useClinicalAppData();
-
-  const episodeOfCareUuids: string[] = episodeOfCare.map((eoc) => eoc.uuid);
 
   // TODO: Extract Business Logic
   // 1. Create a consultationService to handle submission logic

--- a/apps/clinical/src/hooks/__tests__/useObservationFormsSearch.test.tsx
+++ b/apps/clinical/src/hooks/__tests__/useObservationFormsSearch.test.tsx
@@ -227,7 +227,7 @@ describe('useObservationFormsSearch', () => {
   });
 
   describe('episodeUuids filtering', () => {
-    it('should pass episodeUuids as comma-separated string to fetchObservationForms', async () => {
+    it('should pass episodeUuids array to fetchObservationForms', async () => {
       const episodeUuids = ['uuid-1', 'uuid-2'];
 
       const wrapper = createWrapper();
@@ -240,10 +240,10 @@ describe('useObservationFormsSearch', () => {
         expect(result.current.isLoading).toBe(false);
       });
 
-      expect(fetchObservationForms).toHaveBeenCalledWith('uuid-1,uuid-2');
+      expect(fetchObservationForms).toHaveBeenCalledWith(['uuid-1', 'uuid-2']);
     });
 
-    it('should pass undefined when episodeUuids is empty', async () => {
+    it('should pass empty array when episodeUuids is empty', async () => {
       const wrapper = createWrapper();
       const { result } = renderHook(() => useObservationFormsSearch('', []), {
         wrapper,
@@ -253,7 +253,7 @@ describe('useObservationFormsSearch', () => {
         expect(result.current.isLoading).toBe(false);
       });
 
-      expect(fetchObservationForms).toHaveBeenCalledWith(undefined);
+      expect(fetchObservationForms).toHaveBeenCalledWith([]);
     });
 
     it('should pass undefined when episodeUuids is not provided', async () => {

--- a/apps/clinical/src/hooks/__tests__/useObservationFormsSearch.test.tsx
+++ b/apps/clinical/src/hooks/__tests__/useObservationFormsSearch.test.tsx
@@ -1,9 +1,9 @@
 import {
-  getFormattedError,
   getCurrentUserPrivileges,
   fetchObservationForms,
 } from '@bahmni/services';
 import { UserPrivilegeProvider } from '@bahmni/widgets';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import React from 'react';
 import { I18nextProvider } from 'react-i18next';
@@ -16,7 +16,6 @@ import useObservationFormsSearch from '../useObservationFormsSearch';
 // Mock the common utils
 jest.mock('@bahmni/services', () => ({
   ...jest.requireActual('@bahmni/services'),
-  getFormattedError: jest.fn(),
   getCurrentUserPrivileges: jest.fn(),
   fetchObservationForms: jest.fn(),
 }));
@@ -42,13 +41,6 @@ jest.mock('../useDebounce', () => ({
   __esModule: true,
   default: jest.fn((value) => value),
 }));
-
-// Test wrapper with i18n and privilege providers
-const wrapper = ({ children }: { children: React.ReactNode }) => (
-  <I18nextProvider i18n={i18n}>
-    <UserPrivilegeProvider>{children}</UserPrivilegeProvider>
-  </I18nextProvider>
-);
 
 // Mock data shared across all tests
 const mockFormsData = [
@@ -83,12 +75,32 @@ const mockFormsData = [
 ];
 
 describe('useObservationFormsSearch', () => {
+  let queryClient: QueryClient;
+
+  const createWrapper = () => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+          staleTime: Infinity,
+          gcTime: Infinity,
+        },
+      },
+    });
+
+    const Wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>
+        <I18nextProvider i18n={i18n}>
+          <UserPrivilegeProvider>{children}</UserPrivilegeProvider>
+        </I18nextProvider>
+      </QueryClientProvider>
+    );
+    Wrapper.displayName = 'TestWrapper';
+    return Wrapper;
+  };
+
   beforeEach(() => {
     jest.clearAllMocks();
-    (getFormattedError as jest.Mock).mockReturnValue({
-      title: 'Error',
-      message: 'Something went wrong',
-    });
 
     // Reset useUserPrivilege mock to default state
     const { useUserPrivilege } = jest.requireMock('@bahmni/widgets');
@@ -114,8 +126,13 @@ describe('useObservationFormsSearch', () => {
     (fetchObservationForms as jest.Mock).mockResolvedValue(mockFormsData);
   });
 
+  afterEach(() => {
+    queryClient?.clear();
+  });
+
   describe('basic functionality', () => {
     it('should call fetchObservationForms service when hook is used', async () => {
+      const wrapper = createWrapper();
       const { result } = renderHook(() => useObservationFormsSearch(), {
         wrapper,
       });
@@ -133,32 +150,6 @@ describe('useObservationFormsSearch', () => {
       expect(result.current.error).toBeNull();
       expect(fetchObservationForms).toHaveBeenCalledTimes(1);
     });
-
-    it('should handle service error with fallback error message when formatted error has no message', async () => {
-      const serviceError = new Error('Service error');
-      (fetchObservationForms as jest.Mock).mockRejectedValue(serviceError);
-
-      // Mock getFormattedError to return an object with null/undefined message to test fallback
-      (getFormattedError as jest.Mock).mockReturnValue({
-        title: 'Error',
-        message: undefined,
-      });
-
-      const { result } = renderHook(() => useObservationFormsSearch(), {
-        wrapper,
-      });
-
-      await waitFor(() => {
-        expect(result.current.isLoading).toBe(false);
-      });
-
-      // The fallback should use the translation for ERROR_FETCHING_CONCEPTS
-      expect(result.current.error?.message).toBe(
-        'An unexpected error occurred. Please try again later.',
-      );
-      expect(result.current.forms).toEqual([]);
-      expect(getFormattedError).toHaveBeenCalledWith(serviceError);
-    });
   });
 
   describe('privilege filtering', () => {
@@ -171,6 +162,7 @@ describe('useObservationFormsSearch', () => {
 
       (getCurrentUserPrivileges as jest.Mock).mockResolvedValue(null);
 
+      const wrapper = createWrapper();
       const { result } = renderHook(() => useObservationFormsSearch(), {
         wrapper,
       });
@@ -199,6 +191,7 @@ describe('useObservationFormsSearch', () => {
         mockFormsData[0], // Only first form
       ]);
 
+      const wrapper = createWrapper();
       const { result } = renderHook(() => useObservationFormsSearch(), {
         wrapper,
       });
@@ -220,6 +213,7 @@ describe('useObservationFormsSearch', () => {
 
       (filterFormsByUserPrivileges as jest.Mock).mockReturnValue([]);
 
+      const wrapper = createWrapper();
       const { result } = renderHook(() => useObservationFormsSearch(), {
         wrapper,
       });
@@ -232,6 +226,50 @@ describe('useObservationFormsSearch', () => {
     });
   });
 
+  describe('episodeUuids filtering', () => {
+    it('should pass episodeUuids as comma-separated string to fetchObservationForms', async () => {
+      const episodeUuids = ['uuid-1', 'uuid-2'];
+
+      const wrapper = createWrapper();
+      const { result } = renderHook(
+        () => useObservationFormsSearch('', episodeUuids),
+        { wrapper },
+      );
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(fetchObservationForms).toHaveBeenCalledWith('uuid-1,uuid-2');
+    });
+
+    it('should pass undefined when episodeUuids is empty', async () => {
+      const wrapper = createWrapper();
+      const { result } = renderHook(() => useObservationFormsSearch('', []), {
+        wrapper,
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(fetchObservationForms).toHaveBeenCalledWith(undefined);
+    });
+
+    it('should pass undefined when episodeUuids is not provided', async () => {
+      const wrapper = createWrapper();
+      const { result } = renderHook(() => useObservationFormsSearch(), {
+        wrapper,
+      });
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
+
+      expect(fetchObservationForms).toHaveBeenCalledWith(undefined);
+    });
+  });
+
   describe('search functionality', () => {
     beforeEach(() => {
       // Mock privilege filtering to return all forms for search tests
@@ -241,6 +279,7 @@ describe('useObservationFormsSearch', () => {
     });
 
     it('should filter forms based on search term (case-insensitive)', async () => {
+      const wrapper = createWrapper();
       const { result } = renderHook(
         () => useObservationFormsSearch('PATIENT'),
         {
@@ -258,6 +297,7 @@ describe('useObservationFormsSearch', () => {
     });
 
     it('should handle multi-word search terms', async () => {
+      const wrapper = createWrapper();
       const { result } = renderHook(
         () => useObservationFormsSearch('patient history'),
         { wrapper },
@@ -272,6 +312,7 @@ describe('useObservationFormsSearch', () => {
     });
 
     it('should return all forms when search term is empty or whitespace', async () => {
+      const wrapper = createWrapper();
       const { result: emptyResult } = renderHook(
         () => useObservationFormsSearch(''),
         { wrapper },
@@ -284,9 +325,10 @@ describe('useObservationFormsSearch', () => {
       expect(emptyResult.current.forms).toHaveLength(3);
 
       // Test whitespace-only search
+      const wrapper2 = createWrapper();
       const { result: whitespaceResult } = renderHook(
         () => useObservationFormsSearch('   '),
-        { wrapper },
+        { wrapper: wrapper2 },
       );
 
       await waitFor(() => {
@@ -297,6 +339,7 @@ describe('useObservationFormsSearch', () => {
     });
 
     it('should search in name field only', async () => {
+      const wrapper = createWrapper();
       const { result } = renderHook(
         () => useObservationFormsSearch('examination'),
         {
@@ -314,6 +357,7 @@ describe('useObservationFormsSearch', () => {
     });
 
     it('should handle search with no matches', async () => {
+      const wrapper = createWrapper();
       const { result } = renderHook(
         () => useObservationFormsSearch('nonexistent'),
         {
@@ -329,6 +373,7 @@ describe('useObservationFormsSearch', () => {
     });
 
     it('should handle partial word matches', async () => {
+      const wrapper = createWrapper();
       const { result } = renderHook(() => useObservationFormsSearch('lab'), {
         wrapper,
       });

--- a/apps/clinical/src/hooks/useObservationFormsSearch.ts
+++ b/apps/clinical/src/hooks/useObservationFormsSearch.ts
@@ -1,11 +1,7 @@
-import {
-  fetchObservationForms,
-  getFormattedError,
-  ObservationForm,
-} from '@bahmni/services';
+import { fetchObservationForms, ObservationForm } from '@bahmni/services';
 import { useUserPrivilege } from '@bahmni/widgets';
-import { useEffect, useState, useMemo } from 'react';
-import { useTranslation } from 'react-i18next';
+import { useQuery } from '@tanstack/react-query';
+import { useMemo } from 'react';
 import { filterFormsByUserPrivileges } from '../components/forms/observations/utils/privilegeUtils';
 import useDebounce from './useDebounce';
 
@@ -24,35 +20,24 @@ interface UseObservationFormsSearchResult {
  */
 const useObservationFormsSearch = (
   searchTerm: string = '',
+  episodeUuids?: string[],
 ): UseObservationFormsSearchResult => {
-  const [allForms, setAllForms] = useState<ObservationForm[]>([]);
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<Error | null>(null);
   const debouncedSearchTerm = useDebounce(searchTerm);
-  const { t } = useTranslation();
   const { userPrivileges } = useUserPrivilege();
 
-  // Load all observation forms
-  useEffect(() => {
-    const fetchForms = async () => {
-      setIsLoading(true);
-      setError(null);
+  const episodeUuid =
+    episodeUuids && episodeUuids.length > 0
+      ? episodeUuids.join(',')
+      : undefined;
 
-      try {
-        const mappedForms = await fetchObservationForms();
-        setAllForms(mappedForms);
-      } catch (err) {
-        const formattedError = getFormattedError(err);
-        setError(
-          new Error(formattedError.message ?? t('ERROR_FETCHING_CONCEPTS')),
-        );
-      } finally {
-        setIsLoading(false);
-      }
-    };
-
-    fetchForms();
-  }, [t]);
+  const {
+    data: allForms = [],
+    isLoading,
+    error,
+  } = useQuery<ObservationForm[], Error>({
+    queryKey: ['observationForms', episodeUuid],
+    queryFn: () => fetchObservationForms(episodeUuid),
+  });
 
   // Filter forms based on user privileges and search term
   const filteredForms = useMemo(() => {

--- a/apps/clinical/src/hooks/useObservationFormsSearch.ts
+++ b/apps/clinical/src/hooks/useObservationFormsSearch.ts
@@ -25,18 +25,13 @@ const useObservationFormsSearch = (
   const debouncedSearchTerm = useDebounce(searchTerm);
   const { userPrivileges } = useUserPrivilege();
 
-  const episodeUuid =
-    episodeUuids && episodeUuids.length > 0
-      ? episodeUuids.join(',')
-      : undefined;
-
   const {
     data: allForms = [],
     isLoading,
     error,
   } = useQuery<ObservationForm[], Error>({
-    queryKey: ['observationForms', episodeUuid],
-    queryFn: () => fetchObservationForms(episodeUuid),
+    queryKey: ['observationForms', episodeUuids],
+    queryFn: () => fetchObservationForms(episodeUuids),
   });
 
   // Filter forms based on user privileges and search term

--- a/packages/bahmni-services/src/observationFormsService/__tests__/observationFormsService.test.ts
+++ b/packages/bahmni-services/src/observationFormsService/__tests__/observationFormsService.test.ts
@@ -66,7 +66,7 @@ describe('observationFormsService', () => {
 
       const result = await fetchObservationForms();
 
-      expect(mockFetch).toHaveBeenCalledWith(OBSERVATION_FORMS_URL);
+      expect(mockFetch).toHaveBeenCalledWith(OBSERVATION_FORMS_URL());
       expect(result).toEqual([
         {
           uuid: 'form-uuid-1',
@@ -264,6 +264,39 @@ describe('observationFormsService', () => {
       const result = await fetchObservationForms();
 
       expect(result).toEqual([]);
+    });
+
+    it('should append episodeUuid as query param when provided', async () => {
+      const episodeUuid = 'episode-uuid-123';
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => [],
+      });
+
+      (getUserPreferredLocale as jest.Mock).mockReturnValue('en');
+
+      await fetchObservationForms(episodeUuid);
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        OBSERVATION_FORMS_URL(episodeUuid),
+      );
+      expect(mockFetch.mock.calls[0][0]).toContain(
+        `?episodeUuid=${episodeUuid}`,
+      );
+    });
+
+    it('should use base URL without query params when episodeUuid is not provided', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => [],
+      });
+
+      (getUserPreferredLocale as jest.Mock).mockReturnValue('en');
+
+      await fetchObservationForms();
+
+      expect(mockFetch).toHaveBeenCalledWith(OBSERVATION_FORMS_URL());
+      expect(mockFetch.mock.calls[0][0]).not.toContain('?');
     });
   });
 

--- a/packages/bahmni-services/src/observationFormsService/__tests__/observationFormsService.test.ts
+++ b/packages/bahmni-services/src/observationFormsService/__tests__/observationFormsService.test.ts
@@ -266,8 +266,8 @@ describe('observationFormsService', () => {
       expect(result).toEqual([]);
     });
 
-    it('should append episodeUuid as query param when provided', async () => {
-      const episodeUuid = 'episode-uuid-123';
+    it('should append episodeUuid as query param when episodeUuids array is provided', async () => {
+      const episodeUuids = ['episode-uuid-123', 'episode-uuid-456'];
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: async () => [],
@@ -275,17 +275,17 @@ describe('observationFormsService', () => {
 
       (getUserPreferredLocale as jest.Mock).mockReturnValue('en');
 
-      await fetchObservationForms(episodeUuid);
+      await fetchObservationForms(episodeUuids);
 
       expect(mockFetch).toHaveBeenCalledWith(
-        OBSERVATION_FORMS_URL(episodeUuid),
+        OBSERVATION_FORMS_URL('episode-uuid-123,episode-uuid-456'),
       );
       expect(mockFetch.mock.calls[0][0]).toContain(
-        `?episodeUuid=${episodeUuid}`,
+        '?episodeUuid=episode-uuid-123,episode-uuid-456',
       );
     });
 
-    it('should use base URL without query params when episodeUuid is not provided', async () => {
+    it('should use base URL without query params when episodeUuids is not provided', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: async () => [],
@@ -294,6 +294,20 @@ describe('observationFormsService', () => {
       (getUserPreferredLocale as jest.Mock).mockReturnValue('en');
 
       await fetchObservationForms();
+
+      expect(mockFetch).toHaveBeenCalledWith(OBSERVATION_FORMS_URL());
+      expect(mockFetch.mock.calls[0][0]).not.toContain('?');
+    });
+
+    it('should use base URL without query params when episodeUuids is empty array', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => [],
+      });
+
+      (getUserPreferredLocale as jest.Mock).mockReturnValue('en');
+
+      await fetchObservationForms([]);
 
       expect(mockFetch).toHaveBeenCalledWith(OBSERVATION_FORMS_URL());
       expect(mockFetch.mock.calls[0][0]).not.toContain('?');

--- a/packages/bahmni-services/src/observationFormsService/constants.ts
+++ b/packages/bahmni-services/src/observationFormsService/constants.ts
@@ -2,8 +2,13 @@ import { OPENMRS_REST_V1 } from '../constants/app';
 
 export const FORM_METADATA_URL = (formUuid: string) =>
   OPENMRS_REST_V1 + `/form/${formUuid}?v=custom:(resources:(value))`;
-export const OBSERVATION_FORMS_URL =
-  OPENMRS_REST_V1 + '/bahmniie/form/latestPublishedForms';
+export const OBSERVATION_FORMS_URL = (episodeUuid?: string) => {
+  const baseUrl = OPENMRS_REST_V1 + '/bahmniie/form/latestPublishedForms';
+  if (episodeUuid) {
+    return baseUrl + `?episodeUuid=${episodeUuid}`;
+  }
+  return baseUrl;
+};
 export const USER_PINNED_PREFERENCE_URL = (userUuid: string) =>
   OPENMRS_REST_V1 + `/user/${userUuid}?v=full`;
 export const FORM_TRANSLATIONS_URL = (

--- a/packages/bahmni-services/src/observationFormsService/observationFormsService.ts
+++ b/packages/bahmni-services/src/observationFormsService/observationFormsService.ts
@@ -20,8 +20,10 @@ import {
   FormResponseData,
 } from './models';
 
-const fetchAndNormalizeFormsData = async (): Promise<FormApiResponse[]> => {
-  const response = await fetch(OBSERVATION_FORMS_URL);
+const fetchAndNormalizeFormsData = async (
+  episodeUuid?: string,
+): Promise<FormApiResponse[]> => {
+  const response = await fetch(OBSERVATION_FORMS_URL(episodeUuid));
 
   if (!response.ok) {
     throw new Error(
@@ -70,8 +72,10 @@ const transformToObservationForm = (
   };
 };
 
-export const fetchObservationForms = async (): Promise<ObservationForm[]> => {
-  const formsArray = await fetchAndNormalizeFormsData();
+export const fetchObservationForms = async (
+  episodeUuid?: string,
+): Promise<ObservationForm[]> => {
+  const formsArray = await fetchAndNormalizeFormsData(episodeUuid);
   const currentLocale = getUserPreferredLocale();
 
   return formsArray.map((form) =>

--- a/packages/bahmni-services/src/observationFormsService/observationFormsService.ts
+++ b/packages/bahmni-services/src/observationFormsService/observationFormsService.ts
@@ -21,9 +21,15 @@ import {
 } from './models';
 
 const fetchAndNormalizeFormsData = async (
-  episodeUuid?: string,
+  episodeUuids?: string[],
 ): Promise<FormApiResponse[]> => {
-  const response = await fetch(OBSERVATION_FORMS_URL(episodeUuid));
+  let episodeUuidString: string | undefined;
+
+  if (episodeUuids && episodeUuids.length > 0) {
+    episodeUuidString = episodeUuids.join(',');
+  }
+
+  const response = await fetch(OBSERVATION_FORMS_URL(episodeUuidString));
 
   if (!response.ok) {
     throw new Error(
@@ -73,9 +79,9 @@ const transformToObservationForm = (
 };
 
 export const fetchObservationForms = async (
-  episodeUuid?: string,
+  episodeUuids?: string[],
 ): Promise<ObservationForm[]> => {
-  const formsArray = await fetchAndNormalizeFormsData(episodeUuid);
+  const formsArray = await fetchAndNormalizeFormsData(episodeUuids);
   const currentLocale = getUserPreferredLocale();
 
   return formsArray.map((form) =>

--- a/packages/bahmni-widgets/src/forms/FormsTable.tsx
+++ b/packages/bahmni-widgets/src/forms/FormsTable.tsx
@@ -79,7 +79,7 @@ const FormsTable: React.FC<WidgetProps> = ({
   // Fetch published forms to get form UUIDs
   const { data: publishedForms = [] } = useQuery<ObservationForm[]>({
     queryKey: ['observationForms'],
-    queryFn: fetchObservationForms,
+    queryFn: () => fetchObservationForms(),
   });
 
   // Get form UUID by matching form name


### PR DESCRIPTION
> [!NOTE]
> Thank you for your contribution. Please find the details of this pull request below.

**JIRA** → [BAH-4431](https://bahmni.atlassian.net/browse/BAH-4431)

### **Description**
This PR enables filtering of observation forms based on clinical context. When the user is in context of an episode of care, then the episode uuid is passed as a url param to the `/openmrs/ws/rest/v1/bahmniie/form/latestPublishedForms?episodeUuid=<uuid>`. 

Note: The filtering is based on the implementation specific implementation of the `BahmniFormFilter` interface in the openmrs module.

---

### **Key Features**
- Enables passing of Episode of Care UUID in the api for fetching published forms.

---

### **Implementation Details**

* **Custom Hooks**
  Refactored the useObservationFormsSearch hook to remove custom implementation of API fetch

* **API Integration**
- /openmrs/ws/rest/v1/bahmniie/form/latestPublishedForms now supports passing `episodeUuid` when found in Clinical app context
 

---

### **Testing & Type Definitions**

* **Unit Tests**
 - Updated unit tests for the observation form search
---


> [!IMPORTANT]
> **Checklist**
>
> - [x] Code adheres to project linting and formatting standards.
> - [x] New components added to Storybook.
> - [x] Tests written and passing (unit + integration).
> - [x] Labels and text support i18n.
> - [x] Follows accessibility and responsive design guidelines.
> - [x] PR reviewed by at least one other developer.

---

### **Reviewer(s)**

@bahnew/developers 
_Kindly review the proposed changes when convenient. Your feedback is appreciated._

---
