### PR TITLE
BAH-4411 | Fix. Duplicate detection updated to allow different dosage medications

### DIFF
--- a/apps/clinical/src/components/forms/medications/MedicationsForm.tsx
+++ b/apps/clinical/src/components/forms/medications/MedicationsForm.tsx
@@ -27,7 +27,7 @@ import {
 import { useMedicationStore } from '../../../stores/medicationsStore';
 import {
   checkMedicationsOverlap,
-  medicationsMatchByCode,
+  medicationsMatchById,
 } from '../../../utils/fhir/medicationUtilities';
 import SelectedMedicationItem from './SelectedMedicationItem';
 import styles from './styles/MedicationsForm.module.scss';
@@ -189,7 +189,7 @@ const MedicationsForm: React.FC = React.memo(() => {
     return searchResults.map((item) => {
       const itemDisplayName = getMedicationDisplay(item);
       const isAlreadySelected = selectedMedications.some((selected) =>
-        medicationsMatchByCode(item, selected.medication),
+        medicationsMatchById(item, selected.medication),
       );
 
       return {

--- a/apps/clinical/src/components/forms/medications/__tests__/MedicationsForm.test.tsx
+++ b/apps/clinical/src/components/forms/medications/__tests__/MedicationsForm.test.tsx
@@ -673,33 +673,21 @@ describe('MedicationsForm', () => {
     const duplicateNotificationPattern =
       /one or more drugs you are trying to order are already active/i;
 
-    test('shows duplicate notification when medications have overlapping dates', async () => {
+    test('shows duplicate notification when same medication is added with overlapping dates', async () => {
       const med1: MedicationInputEntry = {
         ...mockSelectedMedication,
-        id: 'med-1',
+        id: 'entry-1',
         startDate: new Date('2025-01-01'),
         duration: 10,
         durationUnit: { code: 'd', display: 'Days', daysMultiplier: 1 },
-        medication: {
-          ...mockMedication,
-          code: {
-            coding: [{ code: 'code1', system: 'http://snomed.info/sct' }],
-          },
-        },
       };
 
       const med2: MedicationInputEntry = {
         ...mockSelectedMedication,
-        id: 'med-2',
+        id: 'entry-2',
         startDate: new Date('2025-01-05'),
         duration: 10,
         durationUnit: { code: 'd', display: 'Days', daysMultiplier: 1 },
-        medication: {
-          ...mockMedication,
-          code: {
-            coding: [{ code: 'code1', system: 'http://snomed.info/sct' }],
-          },
-        },
       };
 
       (useMedicationStore as unknown as jest.Mock).mockReturnValue({
@@ -716,33 +704,21 @@ describe('MedicationsForm', () => {
       });
     });
 
-    test('does not show duplicate notification when medications have non-overlapping dates', async () => {
+    test('does not show duplicate notification when same medication has non-overlapping dates', async () => {
       const med1: MedicationInputEntry = {
         ...mockSelectedMedication,
-        id: 'med-1',
+        id: 'entry-1',
         startDate: new Date('2025-01-01'),
         duration: 5,
         durationUnit: { code: 'd', display: 'Days', daysMultiplier: 1 },
-        medication: {
-          ...mockMedication,
-          code: {
-            coding: [{ code: 'code1', system: 'http://snomed.info/sct' }],
-          },
-        },
       };
 
       const med2: MedicationInputEntry = {
         ...mockSelectedMedication,
-        id: 'med-2',
+        id: 'entry-2',
         startDate: new Date('2025-01-10'),
         duration: 5,
         durationUnit: { code: 'd', display: 'Days', daysMultiplier: 1 },
-        medication: {
-          ...mockMedication,
-          code: {
-            coding: [{ code: 'code1', system: 'http://snomed.info/sct' }],
-          },
-        },
       };
 
       (useMedicationStore as unknown as jest.Mock).mockReturnValue({
@@ -759,32 +735,20 @@ describe('MedicationsForm', () => {
       });
     });
 
-    test('shows duplicate notification when STAT medication matches another with same code', async () => {
+    test('shows duplicate notification when STAT medication matches same drug', async () => {
       const statMed: MedicationInputEntry = {
         ...mockSelectedMedication,
-        id: 'stat-med',
+        id: 'entry-stat',
         isSTAT: true,
-        medication: {
-          ...mockMedication,
-          code: {
-            coding: [{ code: 'code1', system: 'http://snomed.info/sct' }],
-          },
-        },
       };
 
       const regularMed: MedicationInputEntry = {
         ...mockSelectedMedication,
-        id: 'regular-med',
+        id: 'entry-regular',
         isSTAT: false,
         startDate: new Date('2025-01-15'),
         duration: 5,
         durationUnit: { code: 'd', display: 'Days', daysMultiplier: 1 },
-        medication: {
-          ...mockMedication,
-          code: {
-            coding: [{ code: 'code1', system: 'http://snomed.info/sct' }],
-          },
-        },
       };
 
       (useMedicationStore as unknown as jest.Mock).mockReturnValue({
@@ -801,36 +765,24 @@ describe('MedicationsForm', () => {
       });
     });
 
-    test('shows duplicate notification for PRN medications with same code and overlapping dates', async () => {
+    test('shows duplicate notification for PRN medications with same drug and overlapping dates', async () => {
       const prnMed: MedicationInputEntry = {
         ...mockSelectedMedication,
-        id: 'prn-med',
+        id: 'entry-prn',
         isPRN: true,
         startDate: new Date('2025-01-01'),
         duration: 10,
         durationUnit: { code: 'd', display: 'Days', daysMultiplier: 1 },
-        medication: {
-          ...mockMedication,
-          code: {
-            coding: [{ code: 'code1', system: 'http://snomed.info/sct' }],
-          },
-        },
       };
 
       const scheduledMed: MedicationInputEntry = {
         ...mockSelectedMedication,
-        id: 'scheduled-med',
+        id: 'entry-scheduled',
         isPRN: false,
         isSTAT: false,
         startDate: new Date('2025-01-01'),
         duration: 10,
         durationUnit: { code: 'd', display: 'Days', daysMultiplier: 1 },
-        medication: {
-          ...mockMedication,
-          code: {
-            coding: [{ code: 'code1', system: 'http://snomed.info/sct' }],
-          },
-        },
       };
 
       (useMedicationStore as unknown as jest.Mock).mockReturnValue({
@@ -844,6 +796,48 @@ describe('MedicationsForm', () => {
         expect(
           screen.queryByText(duplicateNotificationPattern),
         ).toBeInTheDocument();
+      });
+    });
+
+    test('does not show duplicate notification for different formulations of the same concept', async () => {
+      const paracetamol500: Medication = {
+        ...mockMedication,
+        id: 'med-paracetamol-500',
+      };
+      const paracetamol650: Medication = {
+        ...mockMedication,
+        id: 'med-paracetamol-650',
+      };
+
+      const entry1: MedicationInputEntry = {
+        ...mockSelectedMedication,
+        id: 'entry-1',
+        medication: paracetamol500,
+        startDate: new Date('2025-01-01'),
+        duration: 10,
+        durationUnit: { code: 'd', display: 'Days', daysMultiplier: 1 },
+      };
+
+      const entry2: MedicationInputEntry = {
+        ...mockSelectedMedication,
+        id: 'entry-2',
+        medication: paracetamol650,
+        startDate: new Date('2025-01-01'),
+        duration: 10,
+        durationUnit: { code: 'd', display: 'Days', daysMultiplier: 1 },
+      };
+
+      (useMedicationStore as unknown as jest.Mock).mockReturnValue({
+        ...mockStore,
+        selectedMedications: [entry1, entry2],
+      });
+
+      render(<MedicationsForm />);
+
+      await waitFor(() => {
+        expect(
+          screen.queryByText(duplicateNotificationPattern),
+        ).not.toBeInTheDocument();
       });
     });
   });

--- a/apps/clinical/src/components/forms/medications/__tests__/__snapshots__/MedicationsForm.test.tsx.snap
+++ b/apps/clinical/src/components/forms/medications/__tests__/__snapshots__/MedicationsForm.test.tsx.snap
@@ -24,7 +24,7 @@ exports[`MedicationsForm Snapshot Tests matches snapshot with no medications 1`]
           <input
             aria-activedescendant=""
             aria-autocomplete="list"
-            aria-controls="downshift-_r_af_-menu"
+            aria-controls="downshift-_r_bu_-menu"
             aria-expanded="false"
             aria-haspopup="listbox"
             aria-label="Search to add medication"
@@ -40,11 +40,11 @@ exports[`MedicationsForm Snapshot Tests matches snapshot with no medications 1`]
             value=""
           />
           <button
-            aria-controls="downshift-_r_af_-menu"
+            aria-controls="downshift-_r_bu_-menu"
             aria-expanded="false"
             aria-label="Open"
             class="cds--list-box__menu-icon"
-            id="downshift-_r_af_-toggle-button"
+            id="downshift-_r_bu_-toggle-button"
             tabindex="-1"
             title="Open"
             type="button"
@@ -66,9 +66,9 @@ exports[`MedicationsForm Snapshot Tests matches snapshot with no medications 1`]
           </button>
         </div>
         <ul
-          aria-labelledby="downshift-_r_af_-label"
+          aria-labelledby="downshift-_r_bu_-label"
           class="cds--list-box__menu"
-          id="downshift-_r_af_-menu"
+          id="downshift-_r_bu_-menu"
           role="listbox"
           style="position: fixed; left: 0px; top: 0px; visibility: visible; transform: translate(0px, 0px);"
         />
@@ -102,7 +102,7 @@ exports[`MedicationsForm Snapshot Tests matches snapshot with selected medicatio
           <input
             aria-activedescendant=""
             aria-autocomplete="list"
-            aria-controls="downshift-_r_ai_-menu"
+            aria-controls="downshift-_r_c1_-menu"
             aria-expanded="false"
             aria-haspopup="listbox"
             aria-label="Search to add medication"
@@ -118,11 +118,11 @@ exports[`MedicationsForm Snapshot Tests matches snapshot with selected medicatio
             value=""
           />
           <button
-            aria-controls="downshift-_r_ai_-menu"
+            aria-controls="downshift-_r_c1_-menu"
             aria-expanded="false"
             aria-label="Open"
             class="cds--list-box__menu-icon"
-            id="downshift-_r_ai_-toggle-button"
+            id="downshift-_r_c1_-toggle-button"
             tabindex="-1"
             title="Open"
             type="button"
@@ -144,9 +144,9 @@ exports[`MedicationsForm Snapshot Tests matches snapshot with selected medicatio
           </button>
         </div>
         <ul
-          aria-labelledby="downshift-_r_ai_-label"
+          aria-labelledby="downshift-_r_c1_-label"
           class="cds--list-box__menu"
-          id="downshift-_r_ai_-menu"
+          id="downshift-_r_c1_-menu"
           role="listbox"
           style="position: fixed; left: 0px; top: 0px; visibility: visible; transform: translate(0px, 0px);"
         />
@@ -338,8 +338,8 @@ exports[`MedicationsForm Snapshot Tests matches snapshot with selected medicatio
                 >
                   <label
                     class="cds--label cds--visually-hidden"
-                    for="downshift-_r_an_-toggle-button"
-                    id="downshift-_r_an_-label"
+                    for="downshift-_r_c6_-toggle-button"
+                    id="downshift-_r_c6_-label"
                   >
                     Dosage unit
                   </label>
@@ -349,12 +349,12 @@ exports[`MedicationsForm Snapshot Tests matches snapshot with selected medicatio
                   >
                     <button
                       aria-activedescendant=""
-                      aria-controls="downshift-_r_an_-menu"
+                      aria-controls="downshift-_r_c6_-menu"
                       aria-expanded="false"
                       aria-haspopup="listbox"
                       aria-label="Dosage Unit"
                       class="cds--list-box__field"
-                      id="downshift-_r_an_-toggle-button"
+                      id="downshift-_r_c6_-toggle-button"
                       role="combobox"
                       tabindex="0"
                       title="Dosage unit"
@@ -390,9 +390,9 @@ exports[`MedicationsForm Snapshot Tests matches snapshot with selected medicatio
                       </div>
                     </button>
                     <ul
-                      aria-labelledby="downshift-_r_an_-label"
+                      aria-labelledby="downshift-_r_c6_-label"
                       class="cds--list-box__menu"
-                      id="downshift-_r_an_-menu"
+                      id="downshift-_r_c6_-menu"
                       role="listbox"
                       style="position: fixed; left: 0px; top: 0px; visibility: visible; transform: translate(0px, 0px);"
                     />
@@ -408,8 +408,8 @@ exports[`MedicationsForm Snapshot Tests matches snapshot with selected medicatio
                 >
                   <label
                     class="cds--label cds--visually-hidden"
-                    for="downshift-_r_aq_-toggle-button"
-                    id="downshift-_r_aq_-label"
+                    for="downshift-_r_c9_-toggle-button"
+                    id="downshift-_r_c9_-label"
                   >
                     Frequency
                   </label>
@@ -419,12 +419,12 @@ exports[`MedicationsForm Snapshot Tests matches snapshot with selected medicatio
                   >
                     <button
                       aria-activedescendant=""
-                      aria-controls="downshift-_r_aq_-menu"
+                      aria-controls="downshift-_r_c9_-menu"
                       aria-expanded="false"
                       aria-haspopup="listbox"
                       aria-label="Frequency"
                       class="cds--list-box__field"
-                      id="downshift-_r_aq_-toggle-button"
+                      id="downshift-_r_c9_-toggle-button"
                       role="combobox"
                       tabindex="0"
                       title="Frequency"
@@ -460,9 +460,9 @@ exports[`MedicationsForm Snapshot Tests matches snapshot with selected medicatio
                       </div>
                     </button>
                     <ul
-                      aria-labelledby="downshift-_r_aq_-label"
+                      aria-labelledby="downshift-_r_c9_-label"
                       class="cds--list-box__menu"
-                      id="downshift-_r_aq_-menu"
+                      id="downshift-_r_c9_-menu"
                       role="listbox"
                       style="position: fixed; left: 0px; top: 0px; visibility: visible; transform: translate(0px, 0px);"
                     />
@@ -565,8 +565,8 @@ exports[`MedicationsForm Snapshot Tests matches snapshot with selected medicatio
                 >
                   <label
                     class="cds--label cds--visually-hidden"
-                    for="downshift-_r_at_-toggle-button"
-                    id="downshift-_r_at_-label"
+                    for="downshift-_r_cc_-toggle-button"
+                    id="downshift-_r_cc_-label"
                   >
                     Duration unit
                   </label>
@@ -576,12 +576,12 @@ exports[`MedicationsForm Snapshot Tests matches snapshot with selected medicatio
                   >
                     <button
                       aria-activedescendant=""
-                      aria-controls="downshift-_r_at_-menu"
+                      aria-controls="downshift-_r_cc_-menu"
                       aria-expanded="false"
                       aria-haspopup="listbox"
                       aria-label="Duration Unit"
                       class="cds--list-box__field"
-                      id="downshift-_r_at_-toggle-button"
+                      id="downshift-_r_cc_-toggle-button"
                       role="combobox"
                       tabindex="0"
                       title="Duration unit"
@@ -617,9 +617,9 @@ exports[`MedicationsForm Snapshot Tests matches snapshot with selected medicatio
                       </div>
                     </button>
                     <ul
-                      aria-labelledby="downshift-_r_at_-label"
+                      aria-labelledby="downshift-_r_cc_-label"
                       class="cds--list-box__menu"
-                      id="downshift-_r_at_-menu"
+                      id="downshift-_r_cc_-menu"
                       role="listbox"
                       style="position: fixed; left: 0px; top: 0px; visibility: visible; transform: translate(0px, 0px);"
                     />
@@ -635,8 +635,8 @@ exports[`MedicationsForm Snapshot Tests matches snapshot with selected medicatio
                 >
                   <label
                     class="cds--label cds--visually-hidden"
-                    for="downshift-_r_b0_-toggle-button"
-                    id="downshift-_r_b0_-label"
+                    for="downshift-_r_cf_-toggle-button"
+                    id="downshift-_r_cf_-label"
                   >
                     Instructions
                   </label>
@@ -646,12 +646,12 @@ exports[`MedicationsForm Snapshot Tests matches snapshot with selected medicatio
                   >
                     <button
                       aria-activedescendant=""
-                      aria-controls="downshift-_r_b0_-menu"
+                      aria-controls="downshift-_r_cf_-menu"
                       aria-expanded="false"
                       aria-haspopup="listbox"
                       aria-label="Medication Instructions"
                       class="cds--list-box__field"
-                      id="downshift-_r_b0_-toggle-button"
+                      id="downshift-_r_cf_-toggle-button"
                       role="combobox"
                       tabindex="0"
                       title="Instructions"
@@ -687,9 +687,9 @@ exports[`MedicationsForm Snapshot Tests matches snapshot with selected medicatio
                       </div>
                     </button>
                     <ul
-                      aria-labelledby="downshift-_r_b0_-label"
+                      aria-labelledby="downshift-_r_cf_-label"
                       class="cds--list-box__menu"
-                      id="downshift-_r_b0_-menu"
+                      id="downshift-_r_cf_-menu"
                       role="listbox"
                       style="position: fixed; left: 0px; top: 0px; visibility: visible; transform: translate(0px, 0px);"
                     />
@@ -705,8 +705,8 @@ exports[`MedicationsForm Snapshot Tests matches snapshot with selected medicatio
                 >
                   <label
                     class="cds--label cds--visually-hidden"
-                    for="downshift-_r_b3_-toggle-button"
-                    id="downshift-_r_b3_-label"
+                    for="downshift-_r_ci_-toggle-button"
+                    id="downshift-_r_ci_-label"
                   >
                     Route
                   </label>
@@ -716,12 +716,12 @@ exports[`MedicationsForm Snapshot Tests matches snapshot with selected medicatio
                   >
                     <button
                       aria-activedescendant=""
-                      aria-controls="downshift-_r_b3_-menu"
+                      aria-controls="downshift-_r_ci_-menu"
                       aria-expanded="false"
                       aria-haspopup="listbox"
                       aria-label="Route"
                       class="cds--list-box__field"
-                      id="downshift-_r_b3_-toggle-button"
+                      id="downshift-_r_ci_-toggle-button"
                       role="combobox"
                       tabindex="0"
                       title="Route"
@@ -757,9 +757,9 @@ exports[`MedicationsForm Snapshot Tests matches snapshot with selected medicatio
                       </div>
                     </button>
                     <ul
-                      aria-labelledby="downshift-_r_b3_-label"
+                      aria-labelledby="downshift-_r_ci_-label"
                       class="cds--list-box__menu"
-                      id="downshift-_r_b3_-menu"
+                      id="downshift-_r_ci_-menu"
                       role="listbox"
                       style="position: fixed; left: 0px; top: 0px; visibility: visible; transform: translate(0px, 0px);"
                     />
@@ -853,7 +853,7 @@ exports[`MedicationsForm Snapshot Tests matches snapshot with selected medicatio
               >
                 <button
                   aria-label="Close Selected Item"
-                  aria-labelledby="tooltip-_r_b6_"
+                  aria-labelledby="tooltip-_r_cl_"
                   class="cds--btn cds--btn--lg cds--layout--size-lg cds--btn--primary cds--btn--icon-only"
                   data-testid="selected-item-close-button"
                   id="close-selected-item"
@@ -878,7 +878,7 @@ exports[`MedicationsForm Snapshot Tests matches snapshot with selected medicatio
               <span
                 aria-hidden="true"
                 class="cds--popover"
-                id="tooltip-_r_b6_"
+                id="tooltip-_r_cl_"
                 role="tooltip"
               >
                 <span

--- a/apps/clinical/src/components/forms/vaccinations/VaccinationForm.tsx
+++ b/apps/clinical/src/components/forms/vaccinations/VaccinationForm.tsx
@@ -29,7 +29,7 @@ import { useVaccinationStore } from '../../../stores/vaccinationsStore';
 import {
   checkMedicationsOverlap,
   isDuplicateMedication,
-  medicationsMatchByCode,
+  medicationsMatchById,
 } from '../../../utils/fhir/medicationUtilities';
 
 import SelectedVaccinationItem from './SelectedVaccinationItem';
@@ -211,7 +211,7 @@ const VaccinationForm: React.FC = React.memo(() => {
       const itemDisplayName = getMedicationDisplay(item);
 
       const isAlreadySelected = selectedVaccinations.some((selected) =>
-        medicationsMatchByCode(item, selected.medication),
+        medicationsMatchById(item, selected.medication),
       );
 
       return {

--- a/apps/clinical/src/constants/medications.ts
+++ b/apps/clinical/src/constants/medications.ts
@@ -3,6 +3,9 @@ import { DurationUnitOption } from '../models/medication';
 // Duration of the boundsPeriod validity window for STAT (immediate) orders
 export const STAT_ORDER_VALIDITY_MS = 5 * 60 * 1000; // 5 Minutes
 
+// Time window within which a STAT medication is considered a duplicate
+export const STAT_DUPLICATE_WINDOW_MS = 2 * 60 * 60 * 1000; // 2 Hours
+
 export const DURATION_UNIT_OPTIONS: DurationUnitOption[] = [
   {
     code: 'min',

--- a/apps/clinical/src/utils/fhir/__tests__/medicationUtilities.test.ts
+++ b/apps/clinical/src/utils/fhir/__tests__/medicationUtilities.test.ts
@@ -13,6 +13,61 @@ import {
   extractDoseForm,
 } from '../medicationUtilities';
 
+const makeMedication = (
+  id: string,
+  code?: string,
+  system = 'http://snomed.info/sct',
+): Medication => ({
+  resourceType: 'Medication',
+  id,
+  code: {
+    coding: [{ code: code ?? id, system }],
+  },
+});
+
+const makeEntry = (
+  overrides: Partial<MedicationInputEntry> & { medication: Medication },
+): MedicationInputEntry => ({
+  id: `entry-${Math.random().toString(36).slice(2)}`,
+  display: 'Test Medication',
+  dosage: 1,
+  dosageUnit: null,
+  frequency: null,
+  instruction: null,
+  route: null,
+  duration: 7,
+  durationUnit: { code: 'd', display: 'Day(s)', daysMultiplier: 1 },
+  isSTAT: false,
+  isPRN: false,
+  startDate: new Date('2025-01-01'),
+  dispenseQuantity: 10,
+  dispenseUnit: null,
+  errors: {},
+  hasBeenValidated: false,
+  ...overrides,
+});
+
+const makeActiveMed = (
+  overrides: Partial<FhirMedicationRequest> = {},
+): FhirMedicationRequest => ({
+  resourceType: 'MedicationRequest',
+  id: `mr-${Math.random().toString(36).slice(2)}`,
+  status: 'active',
+  intent: 'order',
+  subject: { reference: 'Patient/test-patient' },
+  medicationReference: { reference: 'Medication/backend-ref' },
+  authoredOn: '2025-01-01',
+  dosageInstruction: [
+    {
+      timing: {
+        event: ['2025-01-01'],
+        repeat: { duration: 7, durationUnit: 'd' },
+      },
+    },
+  ],
+  ...overrides,
+});
+
 describe('Medication Utilities', () => {
   describe('extractMedicationCodes', () => {
     test('extracts codes from Medication.code field', () => {
@@ -213,61 +268,6 @@ describe('Medication Utilities', () => {
   });
 
   describe('checkMedicationsOverlap', () => {
-    const makeMedication = (
-      id: string,
-      code?: string,
-      system = 'http://snomed.info/sct',
-    ): Medication => ({
-      resourceType: 'Medication',
-      id,
-      code: {
-        coding: [{ code: code ?? id, system }],
-      },
-    });
-
-    const makeEntry = (
-      overrides: Partial<MedicationInputEntry> & { medication: Medication },
-    ): MedicationInputEntry => ({
-      id: `entry-${Math.random().toString(36).slice(2)}`,
-      display: 'Test Medication',
-      dosage: 1,
-      dosageUnit: null,
-      frequency: null,
-      instruction: null,
-      route: null,
-      duration: 7,
-      durationUnit: { code: 'd', display: 'Day(s)', daysMultiplier: 1 },
-      isSTAT: false,
-      isPRN: false,
-      startDate: new Date('2025-01-01'),
-      dispenseQuantity: 10,
-      dispenseUnit: null,
-      errors: {},
-      hasBeenValidated: false,
-      ...overrides,
-    });
-
-    const makeActiveMed = (
-      overrides: Partial<FhirMedicationRequest> = {},
-    ): FhirMedicationRequest => ({
-      resourceType: 'MedicationRequest',
-      id: `mr-${Math.random().toString(36).slice(2)}`,
-      status: 'active',
-      intent: 'order',
-      subject: { reference: 'Patient/test-patient' },
-      medicationReference: { reference: 'Medication/med-abc' },
-      authoredOn: '2025-01-01',
-      dosageInstruction: [
-        {
-          timing: {
-            event: ['2025-01-01'],
-            repeat: { duration: 7, durationUnit: 'd' },
-          },
-        },
-      ],
-      ...overrides,
-    });
-
     test('returns false for empty selected medications', () => {
       const result = checkMedicationsOverlap([], [], {});
 
@@ -590,61 +590,6 @@ describe('Medication Utilities', () => {
   });
 
   describe('isDuplicateMedication', () => {
-    const makeMedication = (
-      id: string,
-      code?: string,
-      system = 'http://snomed.info/sct',
-    ): Medication => ({
-      resourceType: 'Medication',
-      id,
-      code: {
-        coding: [{ code: code ?? id, system }],
-      },
-    });
-
-    const makeEntry = (
-      overrides: Partial<MedicationInputEntry> & { medication: Medication },
-    ): MedicationInputEntry => ({
-      id: `entry-${Math.random().toString(36).slice(2)}`,
-      display: 'Test Medication',
-      dosage: 1,
-      dosageUnit: null,
-      frequency: null,
-      instruction: null,
-      route: null,
-      duration: 7,
-      durationUnit: { code: 'd', display: 'Day(s)', daysMultiplier: 1 },
-      isSTAT: false,
-      isPRN: false,
-      startDate: new Date('2025-01-01'),
-      dispenseQuantity: 10,
-      dispenseUnit: null,
-      errors: {},
-      hasBeenValidated: false,
-      ...overrides,
-    });
-
-    const makeActiveMed = (
-      overrides: Partial<FhirMedicationRequest> = {},
-    ): FhirMedicationRequest => ({
-      resourceType: 'MedicationRequest',
-      id: `mr-${Math.random().toString(36).slice(2)}`,
-      status: 'active',
-      intent: 'order',
-      subject: { reference: 'Patient/test-patient' },
-      medicationReference: { reference: 'Medication/backend-ref' },
-      authoredOn: '2025-01-01',
-      dosageInstruction: [
-        {
-          timing: {
-            event: ['2025-01-01'],
-            repeat: { duration: 7, durationUnit: 'd' },
-          },
-        },
-      ],
-      ...overrides,
-    });
-
     test('returns false when no matching medications exist', () => {
       const newMed = makeMedication('med-paracetamol-500');
 

--- a/apps/clinical/src/utils/fhir/__tests__/medicationUtilities.test.ts
+++ b/apps/clinical/src/utils/fhir/__tests__/medicationUtilities.test.ts
@@ -68,6 +68,30 @@ const makeActiveMed = (
   ...overrides,
 });
 
+const makeActiveMedWithRef = (
+  refId: string,
+  startDate = '2025-01-01',
+  duration = 7,
+  durationUnit = 'd',
+  extraOverrides: Partial<FhirMedicationRequest> = {},
+): FhirMedicationRequest =>
+  makeActiveMed({
+    medicationReference: { reference: `Medication/${refId}` },
+    dosageInstruction: [
+      {
+        timing: {
+          event: [startDate],
+          repeat: { duration, durationUnit },
+        },
+      },
+    ],
+    ...extraOverrides,
+  });
+
+const makeMedMap = (
+  ...pairs: [string, Medication][]
+): Record<string, Medication> => Object.fromEntries(pairs);
+
 describe('Medication Utilities', () => {
   describe('extractMedicationCodes', () => {
     test('extracts codes from Medication.code field', () => {
@@ -310,22 +334,11 @@ describe('Medication Utilities', () => {
         startDate: new Date('2025-01-03'),
         duration: 7,
       });
-      const activeMed = makeActiveMed({
-        medicationReference: {
-          reference: 'Medication/med-paracetamol-500-ref',
-        },
-        dosageInstruction: [
-          {
-            timing: {
-              event: ['2025-01-01'],
-              repeat: { duration: 7, durationUnit: 'd' },
-            },
-          },
-        ],
-      });
-      const medicationMap: Record<string, Medication> = {
-        'med-paracetamol-500-ref': medResource,
-      };
+      const activeMed = makeActiveMedWithRef('med-paracetamol-500-ref');
+      const medicationMap = makeMedMap([
+        'med-paracetamol-500-ref',
+        medResource,
+      ]);
 
       const result = checkMedicationsOverlap(
         [statEntry],
@@ -343,15 +356,17 @@ describe('Medication Utilities', () => {
         startDate: new Date('2025-01-03'),
         duration: 7,
       });
-      const statActiveMed = makeActiveMed({
-        medicationReference: {
-          reference: 'Medication/med-paracetamol-500-ref',
-        },
-        priority: 'stat',
-      });
-      const medicationMap: Record<string, Medication> = {
-        'med-paracetamol-500-ref': medResource,
-      };
+      const statActiveMed = makeActiveMedWithRef(
+        'med-paracetamol-500-ref',
+        '2025-01-01',
+        7,
+        'd',
+        { priority: 'stat' },
+      );
+      const medicationMap = makeMedMap([
+        'med-paracetamol-500-ref',
+        medResource,
+      ]);
 
       const result = checkMedicationsOverlap(
         [regularEntry],
@@ -389,22 +404,11 @@ describe('Medication Utilities', () => {
         startDate: new Date('2025-01-03'),
         duration: 7,
       });
-      const activeMed = makeActiveMed({
-        medicationReference: {
-          reference: 'Medication/med-paracetamol-500-ref',
-        },
-        dosageInstruction: [
-          {
-            timing: {
-              event: ['2025-01-01'],
-              repeat: { duration: 7, durationUnit: 'd' },
-            },
-          },
-        ],
-      });
-      const medicationMap: Record<string, Medication> = {
-        'med-paracetamol-500-ref': medResource,
-      };
+      const activeMed = makeActiveMedWithRef('med-paracetamol-500-ref');
+      const medicationMap = makeMedMap([
+        'med-paracetamol-500-ref',
+        medResource,
+      ]);
 
       const result = checkMedicationsOverlap(
         [entry],
@@ -422,22 +426,11 @@ describe('Medication Utilities', () => {
         startDate: new Date('2025-02-01'),
         duration: 7,
       });
-      const activeMed = makeActiveMed({
-        medicationReference: {
-          reference: 'Medication/med-paracetamol-500-ref',
-        },
-        dosageInstruction: [
-          {
-            timing: {
-              event: ['2025-01-01'],
-              repeat: { duration: 7, durationUnit: 'd' },
-            },
-          },
-        ],
-      });
-      const medicationMap: Record<string, Medication> = {
-        'med-paracetamol-500-ref': medResource,
-      };
+      const activeMed = makeActiveMedWithRef('med-paracetamol-500-ref');
+      const medicationMap = makeMedMap([
+        'med-paracetamol-500-ref',
+        medResource,
+      ]);
 
       const result = checkMedicationsOverlap(
         [entry],
@@ -506,20 +499,8 @@ describe('Medication Utilities', () => {
         startDate: new Date('2025-01-03'),
         duration: 7,
       });
-      const activeMed = makeActiveMed({
-        medicationReference: { reference: 'Medication/backend-ref' },
-        dosageInstruction: [
-          {
-            timing: {
-              event: ['2025-01-01'],
-              repeat: { duration: 7, durationUnit: 'd' },
-            },
-          },
-        ],
-      });
-      const medicationMap: Record<string, Medication> = {
-        'backend-ref': paracetamol500,
-      };
+      const activeMed = makeActiveMedWithRef('backend-ref');
+      const medicationMap = makeMedMap(['backend-ref', paracetamol500]);
 
       const result = checkMedicationsOverlap(
         [entry],
@@ -552,7 +533,6 @@ describe('Medication Utilities', () => {
       const yesterday = new Date();
       yesterday.setDate(yesterday.getDate() - 1);
       yesterday.setHours(0, 0, 0, 0);
-
       const today = new Date();
       today.setHours(0, 0, 0, 0);
 
@@ -562,22 +542,15 @@ describe('Medication Utilities', () => {
         startDate: today,
         duration: 1,
       });
-      const activeMed = makeActiveMed({
-        medicationReference: {
-          reference: 'Medication/med-albendazole-200-ref',
-        },
-        dosageInstruction: [
-          {
-            timing: {
-              event: [yesterday.toISOString()],
-              repeat: { duration: 1, durationUnit: 'd' },
-            },
-          },
-        ],
-      });
-      const medicationMap: Record<string, Medication> = {
-        'med-albendazole-200-ref': medResource,
-      };
+      const activeMed = makeActiveMedWithRef(
+        'med-albendazole-200-ref',
+        yesterday.toISOString(),
+        1,
+      );
+      const medicationMap = makeMedMap([
+        'med-albendazole-200-ref',
+        medResource,
+      ]);
 
       const result = checkMedicationsOverlap(
         [entry],
@@ -608,20 +581,8 @@ describe('Medication Utilities', () => {
 
     test('returns true when same medication is active with overlapping dates', () => {
       const medResource = makeMedication('med-paracetamol-500');
-      const activeMed = makeActiveMed({
-        medicationReference: { reference: 'Medication/backend-ref' },
-        dosageInstruction: [
-          {
-            timing: {
-              event: ['2025-01-01'],
-              repeat: { duration: 7, durationUnit: 'd' },
-            },
-          },
-        ],
-      });
-      const medicationMap: Record<string, Medication> = {
-        'backend-ref': medResource,
-      };
+      const activeMed = makeActiveMedWithRef('backend-ref');
+      const medicationMap = makeMedMap(['backend-ref', medResource]);
 
       const result = isDuplicateMedication(
         medResource,
@@ -679,13 +640,16 @@ describe('Medication Utilities', () => {
 
     test('returns true when existing active medication is STAT', () => {
       const medResource = makeMedication('med-paracetamol-500');
-      const activeMed = makeActiveMed({
-        medicationReference: { reference: 'Medication/backend-ref' },
-        priority: 'stat',
-      });
-      const medicationMap: Record<string, Medication> = {
-        'backend-ref': medResource,
-      };
+      const activeMed = makeActiveMedWithRef(
+        'backend-ref',
+        '2025-01-01',
+        7,
+        'd',
+        {
+          priority: 'stat',
+        },
+      );
+      const medicationMap = makeMedMap(['backend-ref', medResource]);
 
       const result = isDuplicateMedication(
         medResource,
@@ -702,20 +666,8 @@ describe('Medication Utilities', () => {
 
     test('returns false when dates do not overlap', () => {
       const medResource = makeMedication('med-paracetamol-500');
-      const activeMed = makeActiveMed({
-        medicationReference: { reference: 'Medication/backend-ref' },
-        dosageInstruction: [
-          {
-            timing: {
-              event: ['2025-01-01'],
-              repeat: { duration: 3, durationUnit: 'd' },
-            },
-          },
-        ],
-      });
-      const medicationMap: Record<string, Medication> = {
-        'backend-ref': medResource,
-      };
+      const activeMed = makeActiveMedWithRef('backend-ref', '2025-01-01', 3);
+      const medicationMap = makeMedMap(['backend-ref', medResource]);
 
       const result = isDuplicateMedication(
         medResource,
@@ -739,20 +691,8 @@ describe('Medication Utilities', () => {
         'med-paracetamol-500',
         'paracetamol-concept',
       );
-      const activeMed = makeActiveMed({
-        medicationReference: { reference: 'Medication/backend-ref' },
-        dosageInstruction: [
-          {
-            timing: {
-              event: ['2025-01-01'],
-              repeat: { duration: 7, durationUnit: 'd' },
-            },
-          },
-        ],
-      });
-      const medicationMap: Record<string, Medication> = {
-        'backend-ref': existingMed,
-      };
+      const activeMed = makeActiveMedWithRef('backend-ref');
+      const medicationMap = makeMedMap(['backend-ref', existingMed]);
 
       const result = isDuplicateMedication(
         newMed,
@@ -769,20 +709,8 @@ describe('Medication Utilities', () => {
 
     test('handles duration=0 by defaulting to 1', () => {
       const medResource = makeMedication('med-paracetamol-500');
-      const activeMed = makeActiveMed({
-        medicationReference: { reference: 'Medication/backend-ref' },
-        dosageInstruction: [
-          {
-            timing: {
-              event: ['2025-01-01'],
-              repeat: { duration: 7, durationUnit: 'd' },
-            },
-          },
-        ],
-      });
-      const medicationMap: Record<string, Medication> = {
-        'backend-ref': medResource,
-      };
+      const activeMed = makeActiveMedWithRef('backend-ref');
+      const medicationMap = makeMedMap(['backend-ref', medResource]);
 
       const result = isDuplicateMedication(
         medResource,
@@ -801,25 +729,16 @@ describe('Medication Utilities', () => {
       const yesterday = new Date();
       yesterday.setDate(yesterday.getDate() - 1);
       yesterday.setHours(0, 0, 0, 0);
-
       const today = new Date();
       today.setHours(0, 0, 0, 0);
 
       const medResource = makeMedication('med-albendazole-200');
-      const activeMed = makeActiveMed({
-        medicationReference: { reference: 'Medication/backend-ref' },
-        dosageInstruction: [
-          {
-            timing: {
-              event: [yesterday.toISOString()],
-              repeat: { duration: 1, durationUnit: 'd' },
-            },
-          },
-        ],
-      });
-      const medicationMap: Record<string, Medication> = {
-        'backend-ref': medResource,
-      };
+      const activeMed = makeActiveMedWithRef(
+        'backend-ref',
+        yesterday.toISOString(),
+        1,
+      );
+      const medicationMap = makeMedMap(['backend-ref', medResource]);
 
       const result = isDuplicateMedication(
         medResource,

--- a/apps/clinical/src/utils/fhir/__tests__/medicationUtilities.test.ts
+++ b/apps/clinical/src/utils/fhir/__tests__/medicationUtilities.test.ts
@@ -135,9 +135,7 @@ describe('Medication Utilities', () => {
       const med2 = {
         id: 'med-2',
         code: {
-          coding: [
-            { code: 'ibuprofen-400', system: 'http://snomed.info/sct' },
-          ],
+          coding: [{ code: 'ibuprofen-400', system: 'http://snomed.info/sct' }],
         },
       };
 

--- a/apps/clinical/src/utils/fhir/__tests__/medicationUtilities.test.ts
+++ b/apps/clinical/src/utils/fhir/__tests__/medicationUtilities.test.ts
@@ -8,7 +8,8 @@ import {
   checkMedicationsOverlap,
   extractMedicationCodes,
   isDuplicateMedication,
-  medicationsMatchByCode,
+  medicationsMatchByConceptCode,
+  medicationsMatchById,
   extractDoseForm,
 } from '../medicationUtilities';
 
@@ -86,7 +87,7 @@ describe('Medication Utilities', () => {
         },
       };
 
-      const matches = medicationsMatchByCode(med1, med2);
+      const matches = medicationsMatchByConceptCode(med1, med2);
 
       expect(matches).toBe(true);
     });
@@ -98,16 +99,13 @@ describe('Medication Utilities', () => {
     });
   });
 
-  describe('medicationsMatchByCode', () => {
+  describe('medicationsMatchByConceptCode', () => {
     test('matches medications with identical SNOMED codes', () => {
       const med1 = {
         id: 'med-1',
         code: {
           coding: [
-            {
-              code: 'paracetamol-500',
-              system: 'http://snomed.info/sct',
-            },
+            { code: 'paracetamol-500', system: 'http://snomed.info/sct' },
           ],
         },
       };
@@ -116,17 +114,12 @@ describe('Medication Utilities', () => {
         id: 'med-2',
         code: {
           coding: [
-            {
-              code: 'paracetamol-500',
-              system: 'http://snomed.info/sct',
-            },
+            { code: 'paracetamol-500', system: 'http://snomed.info/sct' },
           ],
         },
       };
 
-      const matches = medicationsMatchByCode(med1, med2);
-
-      expect(matches).toBe(true);
+      expect(medicationsMatchByConceptCode(med1, med2)).toBe(true);
     });
 
     test('does not match medications with different codes', () => {
@@ -134,10 +127,7 @@ describe('Medication Utilities', () => {
         id: 'med-1',
         code: {
           coding: [
-            {
-              code: 'paracetamol-500',
-              system: 'http://snomed.info/sct',
-            },
+            { code: 'paracetamol-500', system: 'http://snomed.info/sct' },
           ],
         },
       };
@@ -146,45 +136,52 @@ describe('Medication Utilities', () => {
         id: 'med-2',
         code: {
           coding: [
-            {
-              code: 'ibuprofen-400',
-              system: 'http://snomed.info/sct',
-            },
+            { code: 'ibuprofen-400', system: 'http://snomed.info/sct' },
           ],
         },
       };
 
-      const matches = medicationsMatchByCode(med1, med2);
-
-      expect(matches).toBe(false);
+      expect(medicationsMatchByConceptCode(med1, med2)).toBe(false);
     });
 
     test('matches OpenMRS concepts by code value alone', () => {
-      const med1 = {
-        id: 'med-1',
-        code: {
-          coding: [
-            {
-              code: '5000',
-            },
-          ],
-        },
-      };
+      const med1 = { id: 'med-1', code: { coding: [{ code: '5000' }] } };
+      const med2 = { id: 'med-2', code: { coding: [{ code: '5000' }] } };
 
-      const med2 = {
-        id: 'med-2',
-        code: {
-          coding: [
-            {
-              code: '5000',
-            },
-          ],
-        },
-      };
+      expect(medicationsMatchByConceptCode(med1, med2)).toBe(true);
+    });
+  });
 
-      const matches = medicationsMatchByCode(med1, med2);
+  describe('medicationsMatchById', () => {
+    test('matches medications with the same ID', () => {
+      const med1 = { id: 'med-paracetamol-500', code: {} };
+      const med2 = { id: 'med-paracetamol-500', code: {} };
 
-      expect(matches).toBe(true);
+      expect(medicationsMatchById(med1, med2)).toBe(true);
+    });
+
+    test('does not match medications with different IDs', () => {
+      const med1 = { id: 'med-paracetamol-500', code: {} };
+      const med2 = { id: 'med-paracetamol-650', code: {} };
+
+      expect(medicationsMatchById(med1, med2)).toBe(false);
+    });
+
+    test('returns false when either medication is null or undefined', () => {
+      const med = { id: 'med-1', code: {} };
+
+      expect(medicationsMatchById(null, med)).toBe(false);
+      expect(medicationsMatchById(med, null)).toBe(false);
+      expect(medicationsMatchById(null, null)).toBe(false);
+      expect(medicationsMatchById(undefined, undefined)).toBe(false);
+    });
+
+    test('returns false when either medication has no ID', () => {
+      const medWithId = { id: 'med-1', code: {} };
+      const medWithoutId = { code: {} };
+
+      expect(medicationsMatchById(medWithId, medWithoutId)).toBe(false);
+      expect(medicationsMatchById(medWithoutId, medWithId)).toBe(false);
     });
   });
 
@@ -219,13 +216,14 @@ describe('Medication Utilities', () => {
 
   describe('checkMedicationsOverlap', () => {
     const makeMedication = (
-      code: string,
+      id: string,
+      code?: string,
       system = 'http://snomed.info/sct',
     ): Medication => ({
       resourceType: 'Medication',
-      id: `med-${code}`,
+      id,
       code: {
-        coding: [{ code, system }],
+        coding: [{ code: code ?? id, system }],
       },
     });
 
@@ -278,8 +276,8 @@ describe('Medication Utilities', () => {
       expect(result).toBe(false);
     });
 
-    test('returns true when two selected medications with same FHIR code have overlapping dates', () => {
-      const med = makeMedication('paracetamol-500');
+    test('returns true when same medication is added twice with overlapping dates', () => {
+      const med = makeMedication('med-paracetamol-500');
       const entry1 = makeEntry({
         medication: med,
         startDate: new Date('2025-01-01'),
@@ -296,8 +294,8 @@ describe('Medication Utilities', () => {
       expect(result).toBe(true);
     });
 
-    test('returns true when a STAT medication is paired with another selected medication with same code', () => {
-      const med = makeMedication('paracetamol-500');
+    test('returns true when a STAT medication is paired with same medication', () => {
+      const med = makeMedication('med-paracetamol-500');
       const entry1 = makeEntry({ medication: med, isSTAT: true });
       const entry2 = makeEntry({ medication: med });
 
@@ -306,8 +304,8 @@ describe('Medication Utilities', () => {
       expect(result).toBe(true);
     });
 
-    test('returns true when selected STAT medication matches an active backend medication with same code', () => {
-      const medResource = makeMedication('paracetamol-500');
+    test('returns true when selected STAT medication matches an active backend medication', () => {
+      const medResource = makeMedication('med-paracetamol-500');
       const statEntry = makeEntry({
         medication: medResource,
         isSTAT: true,
@@ -315,7 +313,9 @@ describe('Medication Utilities', () => {
         duration: 7,
       });
       const activeMed = makeActiveMed({
-        medicationReference: { reference: 'Medication/active-1' },
+        medicationReference: {
+          reference: 'Medication/med-paracetamol-500-ref',
+        },
         dosageInstruction: [
           {
             timing: {
@@ -326,7 +326,7 @@ describe('Medication Utilities', () => {
         ],
       });
       const medicationMap: Record<string, Medication> = {
-        'active-1': medResource,
+        'med-paracetamol-500-ref': medResource,
       };
 
       const result = checkMedicationsOverlap(
@@ -338,19 +338,21 @@ describe('Medication Utilities', () => {
       expect(result).toBe(true);
     });
 
-    test('returns true when active backend medication is STAT and selected medication has same code', () => {
-      const medResource = makeMedication('paracetamol-500');
+    test('returns true when active backend medication is STAT and selected medication is the same drug', () => {
+      const medResource = makeMedication('med-paracetamol-500');
       const regularEntry = makeEntry({
         medication: medResource,
         startDate: new Date('2025-01-03'),
         duration: 7,
       });
       const statActiveMed = makeActiveMed({
-        medicationReference: { reference: 'Medication/active-1' },
+        medicationReference: {
+          reference: 'Medication/med-paracetamol-500-ref',
+        },
         priority: 'stat',
       });
       const medicationMap: Record<string, Medication> = {
-        'active-1': medResource,
+        'med-paracetamol-500-ref': medResource,
       };
 
       const result = checkMedicationsOverlap(
@@ -362,8 +364,8 @@ describe('Medication Utilities', () => {
       expect(result).toBe(true);
     });
 
-    test('returns true when PRN medications have same code and overlapping dates', () => {
-      const med = makeMedication('paracetamol-500');
+    test('returns true when PRN medications with same ID have overlapping dates', () => {
+      const med = makeMedication('med-paracetamol-500');
       const entry1 = makeEntry({
         medication: med,
         isPRN: true,
@@ -382,15 +384,17 @@ describe('Medication Utilities', () => {
       expect(result).toBe(true);
     });
 
-    test('returns true when selected medication overlaps with existing backend medication', () => {
-      const medResource = makeMedication('paracetamol-500');
+    test('returns true when selected medication overlaps with active backend medication', () => {
+      const medResource = makeMedication('med-paracetamol-500');
       const entry = makeEntry({
         medication: medResource,
         startDate: new Date('2025-01-03'),
         duration: 7,
       });
       const activeMed = makeActiveMed({
-        medicationReference: { reference: 'Medication/active-1' },
+        medicationReference: {
+          reference: 'Medication/med-paracetamol-500-ref',
+        },
         dosageInstruction: [
           {
             timing: {
@@ -401,7 +405,7 @@ describe('Medication Utilities', () => {
         ],
       });
       const medicationMap: Record<string, Medication> = {
-        'active-1': medResource,
+        'med-paracetamol-500-ref': medResource,
       };
 
       const result = checkMedicationsOverlap(
@@ -413,15 +417,17 @@ describe('Medication Utilities', () => {
       expect(result).toBe(true);
     });
 
-    test('returns false when selected and existing medications have same code but non-overlapping dates', () => {
-      const medResource = makeMedication('paracetamol-500');
+    test('returns false when same medication has non-overlapping dates', () => {
+      const medResource = makeMedication('med-paracetamol-500');
       const entry = makeEntry({
         medication: medResource,
         startDate: new Date('2025-02-01'),
         duration: 7,
       });
       const activeMed = makeActiveMed({
-        medicationReference: { reference: 'Medication/active-1' },
+        medicationReference: {
+          reference: 'Medication/med-paracetamol-500-ref',
+        },
         dosageInstruction: [
           {
             timing: {
@@ -432,7 +438,7 @@ describe('Medication Utilities', () => {
         ],
       });
       const medicationMap: Record<string, Medication> = {
-        'active-1': medResource,
+        'med-paracetamol-500-ref': medResource,
       };
 
       const result = checkMedicationsOverlap(
@@ -444,9 +450,9 @@ describe('Medication Utilities', () => {
       expect(result).toBe(false);
     });
 
-    test('returns false when medications have different codes', () => {
-      const med1 = makeMedication('paracetamol-500');
-      const med2 = makeMedication('ibuprofen-400');
+    test('returns false when different medications have overlapping dates', () => {
+      const med1 = makeMedication('med-paracetamol-500');
+      const med2 = makeMedication('med-ibuprofen-400');
       const entry1 = makeEntry({
         medication: med1,
         startDate: new Date('2025-01-01'),
@@ -463,8 +469,71 @@ describe('Medication Utilities', () => {
       expect(result).toBe(false);
     });
 
+    test('returns false for different formulations of the same concept with overlapping dates', () => {
+      const paracetamol500 = makeMedication(
+        'med-paracetamol-500',
+        'paracetamol-concept',
+      );
+      const paracetamol650 = makeMedication(
+        'med-paracetamol-650',
+        'paracetamol-concept',
+      );
+      const entry1 = makeEntry({
+        medication: paracetamol500,
+        startDate: new Date('2025-01-01'),
+        duration: 7,
+      });
+      const entry2 = makeEntry({
+        medication: paracetamol650,
+        startDate: new Date('2025-01-01'),
+        duration: 7,
+      });
+
+      const result = checkMedicationsOverlap([entry1, entry2], [], {});
+
+      expect(result).toBe(false);
+    });
+
+    test('returns false for different formulations against active backend medication', () => {
+      const paracetamol500 = makeMedication(
+        'med-paracetamol-500',
+        'paracetamol-concept',
+      );
+      const paracetamol650 = makeMedication(
+        'med-paracetamol-650',
+        'paracetamol-concept',
+      );
+      const entry = makeEntry({
+        medication: paracetamol650,
+        startDate: new Date('2025-01-03'),
+        duration: 7,
+      });
+      const activeMed = makeActiveMed({
+        medicationReference: { reference: 'Medication/backend-ref' },
+        dosageInstruction: [
+          {
+            timing: {
+              event: ['2025-01-01'],
+              repeat: { duration: 7, durationUnit: 'd' },
+            },
+          },
+        ],
+      });
+      const medicationMap: Record<string, Medication> = {
+        'backend-ref': paracetamol500,
+      };
+
+      const result = checkMedicationsOverlap(
+        [entry],
+        [activeMed],
+        medicationMap,
+      );
+
+      expect(result).toBe(false);
+    });
+
     test('handles duration=0 by defaulting to 1', () => {
-      const med = makeMedication('paracetamol-500');
+      const med = makeMedication('med-paracetamol-500');
       const entry1 = makeEntry({
         medication: med,
         startDate: new Date('2025-01-01'),
@@ -489,14 +558,16 @@ describe('Medication Utilities', () => {
       const today = new Date();
       today.setHours(0, 0, 0, 0);
 
-      const medResource = makeMedication('albendazole-200');
+      const medResource = makeMedication('med-albendazole-200');
       const entry = makeEntry({
         medication: medResource,
         startDate: today,
         duration: 1,
       });
       const activeMed = makeActiveMed({
-        medicationReference: { reference: 'Medication/active-1' },
+        medicationReference: {
+          reference: 'Medication/med-albendazole-200-ref',
+        },
         dosageInstruction: [
           {
             timing: {
@@ -507,7 +578,7 @@ describe('Medication Utilities', () => {
         ],
       });
       const medicationMap: Record<string, Medication> = {
-        'active-1': medResource,
+        'med-albendazole-200-ref': medResource,
       };
 
       const result = checkMedicationsOverlap(
@@ -522,13 +593,14 @@ describe('Medication Utilities', () => {
 
   describe('isDuplicateMedication', () => {
     const makeMedication = (
-      code: string,
+      id: string,
+      code?: string,
       system = 'http://snomed.info/sct',
     ): Medication => ({
       resourceType: 'Medication',
-      id: `med-${code}`,
+      id,
       code: {
-        coding: [{ code, system }],
+        coding: [{ code: code ?? id, system }],
       },
     });
 
@@ -562,7 +634,7 @@ describe('Medication Utilities', () => {
       status: 'active',
       intent: 'order',
       subject: { reference: 'Patient/test-patient' },
-      medicationReference: { reference: 'Medication/active-1' },
+      medicationReference: { reference: 'Medication/backend-ref' },
       authoredOn: '2025-01-01',
       dosageInstruction: [
         {
@@ -576,7 +648,7 @@ describe('Medication Utilities', () => {
     });
 
     test('returns false when no matching medications exist', () => {
-      const newMed = makeMedication('paracetamol-500');
+      const newMed = makeMedication('med-paracetamol-500');
 
       const result = isDuplicateMedication(
         newMed,
@@ -591,11 +663,10 @@ describe('Medication Utilities', () => {
       expect(result).toBe(false);
     });
 
-    test('returns true when new medication matches existing active medication by code with overlapping dates', () => {
-      const newMed = makeMedication('paracetamol-500');
-      const existingMedResource = makeMedication('paracetamol-500');
+    test('returns true when same medication is active with overlapping dates', () => {
+      const medResource = makeMedication('med-paracetamol-500');
       const activeMed = makeActiveMed({
-        medicationReference: { reference: 'Medication/active-1' },
+        medicationReference: { reference: 'Medication/backend-ref' },
         dosageInstruction: [
           {
             timing: {
@@ -606,7 +677,138 @@ describe('Medication Utilities', () => {
         ],
       });
       const medicationMap: Record<string, Medication> = {
-        'active-1': existingMedResource,
+        'backend-ref': medResource,
+      };
+
+      const result = isDuplicateMedication(
+        medResource,
+        new Date('2025-01-03'),
+        7,
+        'd',
+        [activeMed],
+        [],
+        medicationMap,
+      );
+
+      expect(result).toBe(true);
+    });
+
+    test('returns true when same medication is already selected', () => {
+      const med = makeMedication('med-paracetamol-500');
+      const selectedEntry = makeEntry({ medication: med });
+
+      const result = isDuplicateMedication(
+        med,
+        new Date('2025-01-01'),
+        7,
+        'd',
+        [],
+        [selectedEntry],
+        {},
+      );
+
+      expect(result).toBe(true);
+    });
+
+    test('returns false for different formulation already selected', () => {
+      const newMed = makeMedication(
+        'med-paracetamol-650',
+        'paracetamol-concept',
+      );
+      const selectedMed = makeMedication(
+        'med-paracetamol-500',
+        'paracetamol-concept',
+      );
+      const selectedEntry = makeEntry({ medication: selectedMed });
+
+      const result = isDuplicateMedication(
+        newMed,
+        new Date('2025-01-01'),
+        7,
+        'd',
+        [],
+        [selectedEntry],
+        {},
+      );
+
+      expect(result).toBe(false);
+    });
+
+    test('returns true when existing active medication is STAT', () => {
+      const medResource = makeMedication('med-paracetamol-500');
+      const activeMed = makeActiveMed({
+        medicationReference: { reference: 'Medication/backend-ref' },
+        priority: 'stat',
+      });
+      const medicationMap: Record<string, Medication> = {
+        'backend-ref': medResource,
+      };
+
+      const result = isDuplicateMedication(
+        medResource,
+        new Date('2025-03-01'),
+        7,
+        'd',
+        [activeMed],
+        [],
+        medicationMap,
+      );
+
+      expect(result).toBe(true);
+    });
+
+    test('returns false when dates do not overlap', () => {
+      const medResource = makeMedication('med-paracetamol-500');
+      const activeMed = makeActiveMed({
+        medicationReference: { reference: 'Medication/backend-ref' },
+        dosageInstruction: [
+          {
+            timing: {
+              event: ['2025-01-01'],
+              repeat: { duration: 3, durationUnit: 'd' },
+            },
+          },
+        ],
+      });
+      const medicationMap: Record<string, Medication> = {
+        'backend-ref': medResource,
+      };
+
+      const result = isDuplicateMedication(
+        medResource,
+        new Date('2025-02-01'),
+        7,
+        'd',
+        [activeMed],
+        [],
+        medicationMap,
+      );
+
+      expect(result).toBe(false);
+    });
+
+    test('returns false for different formulation active in backend with overlapping dates', () => {
+      const newMed = makeMedication(
+        'med-paracetamol-650',
+        'paracetamol-concept',
+      );
+      const existingMed = makeMedication(
+        'med-paracetamol-500',
+        'paracetamol-concept',
+      );
+      const activeMed = makeActiveMed({
+        medicationReference: { reference: 'Medication/backend-ref' },
+        dosageInstruction: [
+          {
+            timing: {
+              event: ['2025-01-01'],
+              repeat: { duration: 7, durationUnit: 'd' },
+            },
+          },
+        ],
+      });
+      const medicationMap: Record<string, Medication> = {
+        'backend-ref': existingMed,
       };
 
       const result = isDuplicateMedication(
@@ -619,88 +821,13 @@ describe('Medication Utilities', () => {
         medicationMap,
       );
 
-      expect(result).toBe(true);
-    });
-
-    test('returns true when new medication matches an already-selected medication by code', () => {
-      const newMed = makeMedication('paracetamol-500');
-      const selectedEntry = makeEntry({
-        medication: makeMedication('paracetamol-500'),
-      });
-
-      const result = isDuplicateMedication(
-        newMed,
-        new Date('2025-01-01'),
-        7,
-        'd',
-        [],
-        [selectedEntry],
-        {},
-      );
-
-      expect(result).toBe(true);
-    });
-
-    test('returns true when existing medication is STAT and codes match', () => {
-      const newMed = makeMedication('paracetamol-500');
-      const existingMedResource = makeMedication('paracetamol-500');
-      const activeMed = makeActiveMed({
-        medicationReference: { reference: 'Medication/active-1' },
-        priority: 'stat',
-      });
-      const medicationMap: Record<string, Medication> = {
-        'active-1': existingMedResource,
-      };
-
-      const result = isDuplicateMedication(
-        newMed,
-        new Date('2025-03-01'),
-        7,
-        'd',
-        [activeMed],
-        [],
-        medicationMap,
-      );
-
-      expect(result).toBe(true);
-    });
-
-    test('returns false when dates do not overlap even though codes match', () => {
-      const newMed = makeMedication('paracetamol-500');
-      const existingMedResource = makeMedication('paracetamol-500');
-      const activeMed = makeActiveMed({
-        medicationReference: { reference: 'Medication/active-1' },
-        dosageInstruction: [
-          {
-            timing: {
-              event: ['2025-01-01'],
-              repeat: { duration: 3, durationUnit: 'd' },
-            },
-          },
-        ],
-      });
-      const medicationMap: Record<string, Medication> = {
-        'active-1': existingMedResource,
-      };
-
-      const result = isDuplicateMedication(
-        newMed,
-        new Date('2025-02-01'),
-        7,
-        'd',
-        [activeMed],
-        [],
-        medicationMap,
-      );
-
       expect(result).toBe(false);
     });
 
     test('handles duration=0 by defaulting to 1', () => {
-      const newMed = makeMedication('paracetamol-500');
-      const existingMedResource = makeMedication('paracetamol-500');
+      const medResource = makeMedication('med-paracetamol-500');
       const activeMed = makeActiveMed({
-        medicationReference: { reference: 'Medication/active-1' },
+        medicationReference: { reference: 'Medication/backend-ref' },
         dosageInstruction: [
           {
             timing: {
@@ -711,11 +838,11 @@ describe('Medication Utilities', () => {
         ],
       });
       const medicationMap: Record<string, Medication> = {
-        'active-1': existingMedResource,
+        'backend-ref': medResource,
       };
 
       const result = isDuplicateMedication(
-        newMed,
+        medResource,
         new Date('2025-01-01'),
         0,
         'd',
@@ -735,10 +862,9 @@ describe('Medication Utilities', () => {
       const today = new Date();
       today.setHours(0, 0, 0, 0);
 
-      const newMed = makeMedication('albendazole-200');
-      const existingMedResource = makeMedication('albendazole-200');
+      const medResource = makeMedication('med-albendazole-200');
       const activeMed = makeActiveMed({
-        medicationReference: { reference: 'Medication/active-1' },
+        medicationReference: { reference: 'Medication/backend-ref' },
         dosageInstruction: [
           {
             timing: {
@@ -749,11 +875,11 @@ describe('Medication Utilities', () => {
         ],
       });
       const medicationMap: Record<string, Medication> = {
-        'active-1': existingMedResource,
+        'backend-ref': medResource,
       };
 
       const result = isDuplicateMedication(
-        newMed,
+        medResource,
         today,
         1,
         'd',

--- a/apps/clinical/src/utils/fhir/__tests__/medicationUtilities.test.ts
+++ b/apps/clinical/src/utils/fhir/__tests__/medicationUtilities.test.ts
@@ -349,19 +349,37 @@ describe('Medication Utilities', () => {
       expect(result).toBe(true);
     });
 
-    test('returns true when active backend medication is STAT and selected medication is the same drug', () => {
+    test('returns true when non-STAT selected medication is on the same day as backend STAT', () => {
       const medResource = makeMedication('med-paracetamol-500');
+      const today = new Date();
+      today.setHours(10, 0, 0, 0);
       const regularEntry = makeEntry({
         medication: medResource,
-        startDate: new Date('2025-01-03'),
+        startDate: new Date(),
         duration: 7,
       });
       const statActiveMed = makeActiveMedWithRef(
         'med-paracetamol-500-ref',
-        '2025-01-01',
+        today.toISOString(),
         7,
         'd',
-        { priority: 'stat' },
+        {
+          priority: 'stat',
+          dosageInstruction: [
+            {
+              timing: {
+                repeat: {
+                  boundsPeriod: {
+                    start: today.toISOString(),
+                    end: new Date(
+                      today.getTime() + 5 * 60 * 1000,
+                    ).toISOString(),
+                  },
+                },
+              },
+            },
+          ],
+        },
       );
       const medicationMap = makeMedMap([
         'med-paracetamol-500-ref',
@@ -375,6 +393,145 @@ describe('Medication Utilities', () => {
       );
 
       expect(result).toBe(true);
+    });
+
+    test('returns false when non-STAT selected medication is on a future day vs backend STAT', () => {
+      const medResource = makeMedication('med-paracetamol-500');
+      const today = new Date();
+      today.setHours(10, 0, 0, 0);
+      const tomorrow = new Date();
+      tomorrow.setDate(tomorrow.getDate() + 1);
+      tomorrow.setHours(0, 0, 0, 0);
+      const regularEntry = makeEntry({
+        medication: medResource,
+        startDate: tomorrow,
+        duration: 7,
+      });
+      const statActiveMed = makeActiveMedWithRef(
+        'med-paracetamol-500-ref',
+        today.toISOString(),
+        7,
+        'd',
+        {
+          priority: 'stat',
+          dosageInstruction: [
+            {
+              timing: {
+                repeat: {
+                  boundsPeriod: {
+                    start: today.toISOString(),
+                    end: new Date(
+                      today.getTime() + 5 * 60 * 1000,
+                    ).toISOString(),
+                  },
+                },
+              },
+            },
+          ],
+        },
+      );
+      const medicationMap = makeMedMap([
+        'med-paracetamol-500-ref',
+        medResource,
+      ]);
+
+      const result = checkMedicationsOverlap(
+        [regularEntry],
+        [statActiveMed],
+        medicationMap,
+      );
+
+      expect(result).toBe(false);
+    });
+
+    test('returns true when STAT selected medication is within 2 hours of backend STAT', () => {
+      const medResource = makeMedication('med-paracetamol-500');
+      const oneHourAgo = new Date(Date.now() - 1 * 60 * 60 * 1000);
+      const statEntry = makeEntry({
+        medication: medResource,
+        isSTAT: true,
+        startDate: new Date(),
+      });
+      const statActiveMed = makeActiveMedWithRef(
+        'med-paracetamol-500-ref',
+        oneHourAgo.toISOString(),
+        7,
+        'd',
+        {
+          priority: 'stat',
+          dosageInstruction: [
+            {
+              timing: {
+                repeat: {
+                  boundsPeriod: {
+                    start: oneHourAgo.toISOString(),
+                    end: new Date(
+                      oneHourAgo.getTime() + 5 * 60 * 1000,
+                    ).toISOString(),
+                  },
+                },
+              },
+            },
+          ],
+        },
+      );
+      const medicationMap = makeMedMap([
+        'med-paracetamol-500-ref',
+        medResource,
+      ]);
+
+      const result = checkMedicationsOverlap(
+        [statEntry],
+        [statActiveMed],
+        medicationMap,
+      );
+
+      expect(result).toBe(true);
+    });
+
+    test('returns false when STAT selected medication is more than 2 hours after backend STAT', () => {
+      const medResource = makeMedication('med-paracetamol-500');
+      const threeHoursAgo = new Date(Date.now() - 3 * 60 * 60 * 1000);
+      const statEntry = makeEntry({
+        medication: medResource,
+        isSTAT: true,
+        startDate: new Date(),
+      });
+      const statActiveMed = makeActiveMedWithRef(
+        'med-paracetamol-500-ref',
+        threeHoursAgo.toISOString(),
+        7,
+        'd',
+        {
+          priority: 'stat',
+          dosageInstruction: [
+            {
+              timing: {
+                repeat: {
+                  boundsPeriod: {
+                    start: threeHoursAgo.toISOString(),
+                    end: new Date(
+                      threeHoursAgo.getTime() + 5 * 60 * 1000,
+                    ).toISOString(),
+                  },
+                },
+              },
+            },
+          ],
+        },
+      );
+      const medicationMap = makeMedMap([
+        'med-paracetamol-500-ref',
+        medResource,
+      ]);
+
+      const result = checkMedicationsOverlap(
+        [statEntry],
+        [statActiveMed],
+        medicationMap,
+      );
+
+      expect(result).toBe(false);
     });
 
     test('returns true when PRN medications with same ID have overlapping dates', () => {
@@ -638,22 +795,38 @@ describe('Medication Utilities', () => {
       expect(result).toBe(false);
     });
 
-    test('returns true when existing active medication is STAT', () => {
+    test('returns true when new medication is on the same day as existing STAT medication', () => {
       const medResource = makeMedication('med-paracetamol-500');
+      const today = new Date();
+      today.setHours(10, 0, 0, 0);
       const activeMed = makeActiveMedWithRef(
         'backend-ref',
-        '2025-01-01',
+        today.toISOString(),
         7,
         'd',
         {
           priority: 'stat',
+          dosageInstruction: [
+            {
+              timing: {
+                repeat: {
+                  boundsPeriod: {
+                    start: today.toISOString(),
+                    end: new Date(
+                      today.getTime() + 5 * 60 * 1000,
+                    ).toISOString(),
+                  },
+                },
+              },
+            },
+          ],
         },
       );
       const medicationMap = makeMedMap(['backend-ref', medResource]);
 
       const result = isDuplicateMedication(
         medResource,
-        new Date('2025-03-01'),
+        new Date(),
         7,
         'd',
         [activeMed],
@@ -662,6 +835,51 @@ describe('Medication Utilities', () => {
       );
 
       expect(result).toBe(true);
+    });
+
+    test('returns false when new medication is on a different day than existing STAT medication', () => {
+      const medResource = makeMedication('med-paracetamol-500');
+      const today = new Date();
+      today.setHours(10, 0, 0, 0);
+      const tomorrow = new Date();
+      tomorrow.setDate(tomorrow.getDate() + 1);
+      tomorrow.setHours(0, 0, 0, 0);
+      const activeMed = makeActiveMedWithRef(
+        'backend-ref',
+        today.toISOString(),
+        7,
+        'd',
+        {
+          priority: 'stat',
+          dosageInstruction: [
+            {
+              timing: {
+                repeat: {
+                  boundsPeriod: {
+                    start: today.toISOString(),
+                    end: new Date(
+                      today.getTime() + 5 * 60 * 1000,
+                    ).toISOString(),
+                  },
+                },
+              },
+            },
+          ],
+        },
+      );
+      const medicationMap = makeMedMap(['backend-ref', medResource]);
+
+      const result = isDuplicateMedication(
+        medResource,
+        tomorrow,
+        7,
+        'd',
+        [activeMed],
+        [],
+        medicationMap,
+      );
+
+      expect(result).toBe(false);
     });
 
     test('returns false when dates do not overlap', () => {

--- a/apps/clinical/src/utils/fhir/medicationUtilities.ts
+++ b/apps/clinical/src/utils/fhir/medicationUtilities.ts
@@ -4,6 +4,7 @@ import {
   MedicationRequest as FhirMedicationRequest,
 } from 'fhir/r4';
 
+import { STAT_DUPLICATE_WINDOW_MS } from '../../constants/medications';
 import { MedicationInputEntry } from '../../models/medication';
 
 import { FHIRCode, extractCodesFromConcept } from './codeUtilities';
@@ -38,6 +39,19 @@ export const isDateTodayOrPast = (
   dateAtMidnight.setHours(0, 0, 0, 0);
 
   return dateAtMidnight.getTime() <= today.getTime();
+};
+
+export const isStatMedicationWithinDuplicateWindow = (
+  med: FhirMedicationRequest,
+): boolean => {
+  const statCreationTime =
+    med.dosageInstruction?.[0]?.timing?.repeat?.boundsPeriod?.start ??
+    med.authoredOn;
+  if (!statCreationTime) return true;
+
+  const createdAt = new Date(statCreationTime).getTime();
+  const now = Date.now();
+  return now - createdAt < STAT_DUPLICATE_WINDOW_MS;
 };
 
 interface CodeableResource {
@@ -229,7 +243,21 @@ export const checkMedicationsOverlap = (
         const durationUnit =
           med.dosageInstruction?.[0]?.timing?.repeat?.durationUnit ?? 'd';
 
-        if (isImmediate || current.isSTAT) return true;
+        if (isImmediate) {
+          if (current.isSTAT) {
+            return isStatMedicationWithinDuplicateWindow(med);
+          }
+          const statDate = new Date(
+            med.dosageInstruction?.[0]?.timing?.repeat?.boundsPeriod?.start ??
+              med.authoredOn ??
+              '',
+          );
+          statDate.setHours(0, 0, 0, 0);
+          const selectedDate = new Date(current.startDate ?? '');
+          selectedDate.setHours(0, 0, 0, 0);
+          return statDate.getTime() === selectedDate.getTime();
+        }
+        if (current.isSTAT) return true;
         if (!startDate || !current.startDate) return false;
 
         if (!current.durationUnit) return false;
@@ -311,7 +339,13 @@ export const isDuplicateMedication = (
         med.dosageInstruction?.[0]?.timing?.event?.[0] ?? med.authoredOn;
 
       if (isImmediate) {
-        return true;
+        const statDate = new Date(
+          med.dosageInstruction?.[0]?.timing?.repeat?.boundsPeriod?.start ??
+            med.authoredOn ??
+            '',
+        );
+        statDate.setHours(0, 0, 0, 0);
+        return newStartDateNormalized.getTime() === statDate.getTime();
       }
 
       if (!startDate) {

--- a/apps/clinical/src/utils/fhir/medicationUtilities.ts
+++ b/apps/clinical/src/utils/fhir/medicationUtilities.ts
@@ -41,17 +41,34 @@ export const isDateTodayOrPast = (
   return dateAtMidnight.getTime() <= today.getTime();
 };
 
+export const getStatCreationTime = (
+  med: FhirMedicationRequest,
+): string | undefined =>
+  med.dosageInstruction?.[0]?.timing?.repeat?.boundsPeriod?.start ??
+  med.authoredOn;
+
 export const isStatMedicationWithinDuplicateWindow = (
   med: FhirMedicationRequest,
 ): boolean => {
-  const statCreationTime =
-    med.dosageInstruction?.[0]?.timing?.repeat?.boundsPeriod?.start ??
-    med.authoredOn;
+  const statCreationTime = getStatCreationTime(med);
   if (!statCreationTime) return true;
 
   const createdAt = new Date(statCreationTime).getTime();
-  const now = Date.now();
-  return now - createdAt < STAT_DUPLICATE_WINDOW_MS;
+  return Date.now() - createdAt < STAT_DUPLICATE_WINDOW_MS;
+};
+
+export const isStatMedicationOnSameDay = (
+  med: FhirMedicationRequest,
+  compareDate: Date | string,
+): boolean => {
+  const statCreationTime = getStatCreationTime(med);
+  if (!statCreationTime) return true;
+
+  const statDate = new Date(statCreationTime);
+  statDate.setHours(0, 0, 0, 0);
+  const otherDate = new Date(compareDate);
+  otherDate.setHours(0, 0, 0, 0);
+  return statDate.getTime() === otherDate.getTime();
 };
 
 interface CodeableResource {
@@ -247,15 +264,7 @@ export const checkMedicationsOverlap = (
           if (current.isSTAT) {
             return isStatMedicationWithinDuplicateWindow(med);
           }
-          const statDate = new Date(
-            med.dosageInstruction?.[0]?.timing?.repeat?.boundsPeriod?.start ??
-              med.authoredOn ??
-              '',
-          );
-          statDate.setHours(0, 0, 0, 0);
-          const selectedDate = new Date(current.startDate ?? '');
-          selectedDate.setHours(0, 0, 0, 0);
-          return statDate.getTime() === selectedDate.getTime();
+          return isStatMedicationOnSameDay(med, current.startDate ?? '');
         }
         if (current.isSTAT) return true;
         if (!startDate || !current.startDate) return false;
@@ -339,13 +348,7 @@ export const isDuplicateMedication = (
         med.dosageInstruction?.[0]?.timing?.event?.[0] ?? med.authoredOn;
 
       if (isImmediate) {
-        const statDate = new Date(
-          med.dosageInstruction?.[0]?.timing?.repeat?.boundsPeriod?.start ??
-            med.authoredOn ??
-            '',
-        );
-        statDate.setHours(0, 0, 0, 0);
-        return newStartDateNormalized.getTime() === statDate.getTime();
+        return isStatMedicationOnSameDay(med, newStartDateNormalized);
       }
 
       if (!startDate) {

--- a/apps/clinical/src/utils/fhir/medicationUtilities.ts
+++ b/apps/clinical/src/utils/fhir/medicationUtilities.ts
@@ -74,7 +74,7 @@ export const extractMedicationCodes = (
   return codes;
 };
 
-export const medicationsMatchByCode = (
+export const medicationsMatchByConceptCode = (
   medication1: CodeableResource | unknown,
   medication2: CodeableResource | unknown,
 ): boolean => {
@@ -105,6 +105,16 @@ export const medicationsMatchByCode = (
   }
 
   return false;
+};
+
+export const medicationsMatchById = (
+  medication1: CodeableResource | unknown,
+  medication2: CodeableResource | unknown,
+): boolean => {
+  if (!medication1 || !medication2) return false;
+  const med1 = medication1 as { id?: string };
+  const med2 = medication2 as { id?: string };
+  return !!med1.id && !!med2.id && med1.id === med2.id;
 };
 
 export const extractMedicationRefId = (
@@ -154,7 +164,7 @@ export const checkMedicationsOverlap = (
     for (let j = i + 1; j < selectedMedications.length; j++) {
       const other = selectedMedications[j];
 
-      if (!medicationsMatchByCode(current.medication, other.medication)) {
+      if (!medicationsMatchById(current.medication, other.medication)) {
         continue;
       }
 
@@ -206,7 +216,7 @@ export const checkMedicationsOverlap = (
 
         if (
           !medicationResource ||
-          !medicationsMatchByCode(current.medication, medicationResource)
+          !medicationsMatchById(current.medication, medicationResource)
         ) {
           return false;
         }
@@ -291,7 +301,7 @@ export const isDuplicateMedication = (
 
       if (
         !medicationResource ||
-        !medicationsMatchByCode(newMedication, medicationResource)
+        !medicationsMatchById(newMedication, medicationResource)
       ) {
         return false;
       }
@@ -337,7 +347,7 @@ export const isDuplicateMedication = (
 
   const isSelectedDuplicate = selectedMedications.some(
     (selected: MedicationInputEntry) => {
-      return medicationsMatchByCode(newMedication, selected.medication);
+      return medicationsMatchById(newMedication, selected.medication);
     },
   );
 


### PR DESCRIPTION
Summary                                                                                                                                      
                                                                                                                                               
  - Switched duplicate detection from concept code matching to medication resource ID matching, so different formulations of the same drug
  (e.g., Paracetamol 500mg Tablet vs Paracetamol 650mg Tablet) are no longer flagged as duplicates                                             
  - Removed PRN exclusion from duplicate checks — PRN medications now go through the same overlap detection as regular medications           
  - Renamed medicationsMatchByCode to medicationsMatchByConceptCode and added medicationsMatchById for clarity                                 
                                                                                                                                               
  Context

  BAH-4411 ACs were updated post-closure to redefine what constitutes a "duplicate medication." Previously, matching was done by FHIR concept code (shared across formulations). Now matching is by medication resource ID (unique per formulation), aligning FE behaviour with BE.

  What changed

  - MedicationsForm.tsx / VaccinationForm.tsx: Dropdown "Already added" check uses ID matching
  - Tests: 38 utility tests (up from 30), 28 form tests (up from 27) — added coverage for different formulations and medicationsMatchById edge cases

  Test plan

  - Add Paracetamol 500mg Tablet today, add same drug again — duplicate error shown
  - Add Paracetamol 500mg Tablet today, add Paracetamol 650mg Tablet today — no error (different formulation)
  - Add Paracetamol 500mg Tablet today, change to PRN, add same drug again — duplicate error shown
  - Add medication for future date, add same drug day after — no error (no +1 extension for future dates)
  - Add medication, click Done with duplicate error present — save blocked