### PR TITLE
BAH-4562 | [SPIKE] Investigate and prototype migration of atomic components in form2-controls to Carbon Design System

### DIFF
--- a/apps/clinical/src/components/forms/observations/ObservationFormsContainer.tsx
+++ b/apps/clinical/src/components/forms/observations/ObservationFormsContainer.tsx
@@ -6,7 +6,7 @@ import {
   SkeletonText,
 } from '@bahmni/design-system';
 import {
-  Container,
+  CarbonContainer,
   FormMetadata as Form2FormMetadata, // Aliased to disambiguate from FormMetadata type exported by @bahmni/services
 } from '@bahmni/form2-controls';
 import '@bahmni/form2-controls/dist/bundle.css';
@@ -82,9 +82,9 @@ const ObservationFormsContainer: React.FC<ObservationFormsContainerProps> = ({
   const [validationErrorMessage, setValidationErrorMessage] = useState<
     string | null
   >(null);
-  const formContainerRef = useRef<React.ComponentRef<typeof Container> | null>(
-    null,
-  );
+  const formContainerRef = useRef<React.ComponentRef<
+    typeof CarbonContainer
+  > | null>(null);
 
   const {
     observations,
@@ -363,7 +363,7 @@ const ObservationFormsContainer: React.FC<ObservationFormsContainerProps> = ({
         ) : error ? (
           <div>{error.message}</div>
         ) : formMetadata && patientUUID ? (
-          <Container
+          <CarbonContainer
             ref={formContainerRef}
             metadata={{
               ...(formMetadata.schema as Form2FormMetadata),
@@ -430,7 +430,7 @@ const ObservationFormsContainer: React.FC<ObservationFormsContainerProps> = ({
 
 const extractAndAppendNotesFromFormData = (
   formContainerRef: React.RefObject<React.ComponentRef<
-    typeof Container
+    typeof CarbonContainer
   > | null>,
   transformedObservations: Form2Observation[],
 ): void => {

--- a/apps/clinical/src/components/forms/observations/__tests__/ObservationFormsContainer.test.tsx
+++ b/apps/clinical/src/components/forms/observations/__tests__/ObservationFormsContainer.test.tsx
@@ -43,7 +43,7 @@ jest.mock('@bahmni/form2-controls', () => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const mockReact = require('react');
   return {
-    Container: mockReact.forwardRef((props: any, ref: any) => {
+    CarbonContainer: mockReact.forwardRef((props: any, ref: any) => {
       mockReact.useImperativeHandle(ref, () => ({
         getValue: mockGetValue,
         state: mockContainerState,

--- a/apps/clinical/src/components/forms/observations/styles/form2-controls-fixes.scss
+++ b/apps/clinical/src/components/forms/observations/styles/form2-controls-fixes.scss
@@ -91,14 +91,25 @@ button.abnormal-button:disabled {
 .form-builder-row .obs-control-select-wrapper .needsclick__control {
   width: 100% !important;
   max-width: 100% !important;
+  height: auto !important;
 }
 
+/**
+ * Use CSS grid to stack single-value and input-container in the same cell.
+ * This lets the grid row height be driven only by the single-value text,
+ * so the control stays at its default height for short text and auto-expands
+ * only when the selected text is long enough to wrap.
+ */
 .form-builder-row .obs-control-select-wrapper .needsclick__value-container {
+  display: grid !important;
+  grid-template-columns: 1fr !important;
   max-width: calc(100% - 40px) !important;
-  overflow: hidden !important;
+  overflow: visible !important;
 }
 
 .form-builder-row .obs-control-select-wrapper .needsclick__input-container {
+  grid-column: 1 !important;
+  grid-row: 1 !important;
   max-width: 100% !important;
   overflow: hidden !important;
 }
@@ -112,7 +123,12 @@ button.abnormal-button:disabled {
 }
 
 .form-builder-row .obs-control-select-wrapper .needsclick__single-value {
-  overflow: hidden !important;
-  text-overflow: ellipsis !important;
-  white-space: nowrap !important;
+  grid-column: 1 !important;
+  grid-row: 1 !important;
+  overflow: visible !important;
+  text-overflow: unset !important;
+  white-space: normal !important;
+  position: relative !important;
+  transform: none !important;
+  max-width: 100% !important;
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "private": true,
   "dependencies": {
-    "@bahmni/form2-controls": "0.0.3-dev.42",
+    "@bahmni/form2-controls": "0.0.3-dev.43",
     "@tanstack/react-query": "^5.85.5",
     "@types/fhir": "^0.0.41",
     "browser-image-compression": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "private": true,
   "dependencies": {
-    "@bahmni/form2-controls": "0.0.3-dev.43",
+    "@bahmni/form2-controls": "0.0.3-dev.47",
     "@tanstack/react-query": "^5.85.5",
     "@types/fhir": "^0.0.41",
     "browser-image-compression": "^2.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1058,10 +1058,10 @@
     "@babel/helper-string-parser" "^7.27.1"
     "@babel/helper-validator-identifier" "^7.27.1"
 
-"@bahmni/form2-controls@0.0.3-dev.42":
-  version "0.0.3-dev.42"
-  resolved "https://registry.npmjs.org/@bahmni/form2-controls/-/form2-controls-0.0.3-dev.42.tgz#3739fe8aa84a10c95f7a98bfbe4ad5d8bc0b4a14"
-  integrity sha512-q+iuo0WvlryL1xqNQ4GKleZbg1EBPnJWlWA+BhA0RqO9Z+Dc6E6ct0tkj9dXTj23WXvoCJdzEx9RUE2RiAdsNA==
+"@bahmni/form2-controls@0.0.3-dev.43":
+  version "0.0.3-dev.43"
+  resolved "https://registry.yarnpkg.com/@bahmni/form2-controls/-/form2-controls-0.0.3-dev.43.tgz#4a63d3af1b0e394e2b22c1970629fbcd95d6007c"
+  integrity sha512-W3+4UV6YEcphRvbvjbfvKmV+ShidG4+gwZbsNsUl2RtwipzAZs1aZB4lErszFQb1X48bvkcCe6yQnXqvAt5PoQ==
   dependencies:
     ajv "^8.17.1"
     base64-inline-loader "^1.1.0"
@@ -9690,10 +9690,10 @@ image-size@~0.5.0:
   resolved "https://registry.yarnpkg.com/image-size/-/image-size-0.5.5.tgz#09dfd4ab9d20e29eb1c3e80b8990378df9e3cb9c"
   integrity sha512-6TDAlDPZxUFCv+fuOkIoXT/V/f3Qbq8e37p+YOiYrUv3v9cc3/6x78VdfPgFVaB9dZYeLUfKgHRebpkm/oP2VQ==
 
-immutable@3.8.1:
-  version "3.8.1"
-  resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.1.tgz#200807f11ab0f72710ea485542de088075f68cd2"
-  integrity sha512-0R2q5f83L0h+zizu3lAA3ZR/mzEl04U1jVVXIqf2rQbZs9eX5YGtx1EFQuuJJHzVXH10ur6hGKehR8yBOQmZlQ==
+immutable@4.3.8:
+  version "4.3.8"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.3.8.tgz#02d183c7727fb2bb1d5d0380da0d779dce9296a7"
+  integrity sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw==
 
 immutable@^4.0.0:
   version "4.3.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1058,10 +1058,10 @@
     "@babel/helper-string-parser" "^7.27.1"
     "@babel/helper-validator-identifier" "^7.27.1"
 
-"@bahmni/form2-controls@0.0.3-dev.43":
-  version "0.0.3-dev.43"
-  resolved "https://registry.yarnpkg.com/@bahmni/form2-controls/-/form2-controls-0.0.3-dev.43.tgz#4a63d3af1b0e394e2b22c1970629fbcd95d6007c"
-  integrity sha512-W3+4UV6YEcphRvbvjbfvKmV+ShidG4+gwZbsNsUl2RtwipzAZs1aZB4lErszFQb1X48bvkcCe6yQnXqvAt5PoQ==
+"@bahmni/form2-controls@0.0.3-dev.47":
+  version "0.0.3-dev.47"
+  resolved "https://registry.yarnpkg.com/@bahmni/form2-controls/-/form2-controls-0.0.3-dev.47.tgz#545125930c6924bc3cf673d3f0b4e81739f21573"
+  integrity sha512-3Kh/QxcMdq6pStv4KkVASqSlRVLk/7r/KzKkZLEnGqpf2C0GebXVY8XjHW7wzlrLYVRyLpU5D0SBUKqtQOpAqQ==
   dependencies:
     ajv "^8.17.1"
     base64-inline-loader "^1.1.0"


### PR DESCRIPTION
### Description

Spike Branch for BAH-4562, where we have implemented CarbonContainer on top of Container Component which correctly renders bahmni-design-system carbon components . 
And if mapping of corresponding carbon component was not present , it will fallback to previous CSS components.
And it is backward compatible, whoever consumer app is using Container Component will not affect them.
Currently We have done migration for TextArea to bahmni-design-system Carbon Component.

Spike Findings Document - 
https://docs.google.com/document/d/1dy-jV3RrlffMTDkmE7CRrdTSujwpg7sN5euQtKk7-7E/edit?tab=t.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved observation form control layout and text rendering for select inputs — better wrapping, positioning, and visible overflow to show full values.

* **Chores**
  * Updated form container implementation and bumped form-control dependency to a newer dev release to ensure consistent form display.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Bahmni/bahmni-apps-frontend/pull/323?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->