### PR TITLE
BAH-4621 | Upgrade. Axios version to 1.15.0

### DIFF
--- a/packages/bahmni-services/package.json
+++ b/packages/bahmni-services/package.json
@@ -25,7 +25,7 @@
     "prepublishOnly": "yarn run build"
   },
   "dependencies": {
-    "axios": "^1.13.5",
+    "axios": "^1.15.0",
     "html-entities": "^2.6.0",
     "i18next": "^24.2.3",
     "i18next-browser-languagedetector": "^8.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6123,7 +6123,7 @@ axios@^1.11.0:
     form-data "^4.0.4"
     proxy-from-env "^1.1.0"
 
-axios@^1.12.0, axios@^1.13.5:
+axios@^1.12.0:
   version "1.13.5"
   resolved "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz#5e464688fa127e11a660a2c49441c009f6567a43"
   integrity sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==
@@ -6131,6 +6131,15 @@ axios@^1.12.0, axios@^1.13.5:
     follow-redirects "^1.15.11"
     form-data "^4.0.5"
     proxy-from-env "^1.1.0"
+
+axios@^1.15.0:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.15.0.tgz#0fcee91ef03d386514474904b27863b2c683bf4f"
+  integrity sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==
+  dependencies:
+    follow-redirects "^1.15.11"
+    form-data "^4.0.5"
+    proxy-from-env "^2.1.0"
 
 axobject-query@^4.1.0:
   version "4.1.0"
@@ -13290,6 +13299,11 @@ proxy-from-env@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
   integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
+
+proxy-from-env@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-2.1.0.tgz#a7487568adad577cfaaa7e88c49cab3ab3081aba"
+  integrity sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==
 
 prr@~1.0.1:
   version "1.0.1"


### PR DESCRIPTION
This PR deals with fixing the following vulnerability axios issue. 
__Issue__: CVE-2025-62718 - Critical severity vulnerability in axios

### Problem Details:

- __Current Version__: axios 1.13.5 (in `packages/bahmni-services/package.json`)
- __Vulnerable__: YES ❌
- __Fixed Version__: 1.15.0
- __Severity__: CRITICAL
- __Vulnerability__: Axios has a NO_PROXY Hostname Normalization Bypass leading to SSRF




Fix: Upgrade axios to 1.15.0