### PR TITLE
BAH-4613 | Remove. check for name attribute in cookie location

### DIFF
--- a/packages/bahmni-services/src/userService/__tests__/userService.test.ts
+++ b/packages/bahmni-services/src/userService/__tests__/userService.test.ts
@@ -282,14 +282,15 @@ describe('getUserLocation', () => {
     );
   });
 
-  it('should throw errors when login location name is missing', async () => {
+  it('should fetch user log in location successfully when only login location name is missing', async () => {
+    const userLocation = { uuid: 'b5da9afd-b29a-4cbf-91c9-ccf2aa5f799e' };
     const mockEncodedUserLocationCookie =
-      '%7B%22uuid%22%3A%225e232c47-8ff5-4c5c-8057-7e39a64fefa5%22%7D';
+      '%7B%22uuid%22%3A%22b5da9afd-b29a-4cbf-91c9-ccf2aa5f799e%22%7D';
     (getCookieByName as jest.Mock).mockReturnValue(
       mockEncodedUserLocationCookie,
     );
-    await expect(() => getUserLoginLocation()).toThrow(
-      'ERROR_FETCHING_USER_LOCATION_DETAILS',
-    );
+    const result = await getUserLoginLocation();
+    expect(getCookieByName).toHaveBeenCalledWith(BAHMNI_USER_LOCATION_COOKIE);
+    expect(result).toEqual(userLocation);
   });
 });

--- a/packages/bahmni-services/src/userService/userService.ts
+++ b/packages/bahmni-services/src/userService/userService.ts
@@ -54,7 +54,7 @@ export const getUserLoginLocation = (): UserLocation => {
   const userLocation: UserLocation = JSON.parse(
     decodeURIComponent(encodedUserLocation).replace(/^"(.*)"$/, '$1'),
   );
-  if (!userLocation.name || !userLocation.uuid)
+  if (!userLocation.uuid)
     throw new Error(i18next.t('ERROR_FETCHING_USER_LOCATION_DETAILS'));
   return userLocation;
 };


### PR DESCRIPTION
# PR Summary: [BAH-4613](https://bahmni.atlassian.net/browse/BAH-4613)

## 🎯 Objective
Remove the validation check for the `name` attribute in the user location cookie, allowing the application to function correctly when only the `uuid` is present.

**Rationale:** The `name` attribute in the user location cookie is not strictly required for the application to function. The `uuid` alone is sufficient to identify and use the user's location. This change makes the validation less strict and prevents unnecessary errors when the cookie only contains the `uuid`.


## 🔍 Impact
- **Low risk change** - Makes the validation less restrictive
- Improves resilience when user location cookie data is incomplete
- No breaking changes to existing functionality
- Only the `uuid` is now required, which is the minimum necessary information



[BAH-4613]: https://bahmni.atlassian.net/browse/BAH-4613?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ