### PR TITLE
BAH-4565 | Apply pagination for all display controls which have SortableDataTable (no Accordions) - DocumentsTable

### DIFF
--- a/apps/appointments/src/pages/admin/allServices/__tests__/__snapshots__/index.test.tsx.snap
+++ b/apps/appointments/src/pages/admin/allServices/__tests__/__snapshots__/index.test.tsx.snap
@@ -74,7 +74,7 @@ exports[`AllServicesPage Snapshot should match snapshot with services data 1`] =
             </h2>
           </div>
           <div
-            class="sortable-data-table _sortableDataTableBody_1xyik_1"
+            class="sortable-data-table _sortableDataTableBody_1w499_1"
             data-testid="all-services-sortable-data-table-test-id"
           >
             <div

--- a/packages/bahmni-design-system/src/molecules/sortableDataTable/SortableDataTable.tsx
+++ b/packages/bahmni-design-system/src/molecules/sortableDataTable/SortableDataTable.tsx
@@ -11,7 +11,7 @@ import {
   DataTableSkeleton,
 } from '@carbon/react';
 import classnames from 'classnames';
-import React, { useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import styles from './styles/SortableDataTable.module.scss';
 
 export interface SortableDataTableProps<T> {
@@ -47,8 +47,22 @@ export const SortableDataTable = <T extends { id: string }>({
   onPageChange,
 }: SortableDataTableProps<T>) => {
   const [currentPage, setCurrentPage] = useState(1);
-  const [internalPageSize, setInternalPageSize] = useState(
-    pageSize ?? rows?.length ?? 0,
+  const [internalPageSize, setInternalPageSize] = useState<number>(
+    pageSize ?? 0,
+  );
+
+  // Reset to page 1 when rows change to prevent showing a stale empty page
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [rows?.length]);
+
+  // useMemo must be called before early returns (Rules of Hooks)
+  const effectivePageSizes = useMemo(
+    () =>
+      pageSize !== undefined && !pageSizes.includes(pageSize)
+        ? [pageSize, ...pageSizes].sort((a, b) => a - b)
+        : pageSizes,
+    [pageSize, pageSizes],
   );
 
   if (errorStateMessage) {
@@ -90,13 +104,9 @@ export const SortableDataTable = <T extends { id: string }>({
 
   const rowMap = new Map(rows.map((row) => [row.id, row]));
 
-  const effectivePageSizes =
-    pageSize !== undefined && !pageSizes.includes(pageSize)
-      ? [pageSize, ...pageSizes].sort((a, b) => a - b)
-      : pageSizes;
-
-  const showPagination =
-    pageSize !== undefined && rows.length > internalPageSize;
+  // Use the pageSize prop (not internalPageSize) so pagination visibility
+  // is not affected by user's dropdown selection during the session
+  const showPagination = pageSize !== undefined && rows.length > pageSize;
 
   return (
     <div

--- a/packages/bahmni-design-system/src/molecules/sortableDataTable/SortableDataTable.tsx
+++ b/packages/bahmni-design-system/src/molecules/sortableDataTable/SortableDataTable.tsx
@@ -56,6 +56,10 @@ export const SortableDataTable = <T extends { id: string }>({
   );
 
   useEffect(() => {
+    if (pageSize !== undefined) setInternalPageSize(pageSize);
+  }, [pageSize]);
+
+  useEffect(() => {
     if (totalItems === undefined) {
       setCurrentPage(1);
     }

--- a/packages/bahmni-design-system/src/molecules/sortableDataTable/SortableDataTable.tsx
+++ b/packages/bahmni-design-system/src/molecules/sortableDataTable/SortableDataTable.tsx
@@ -90,11 +90,13 @@ export const SortableDataTable = <T extends { id: string }>({
 
   const rowMap = new Map(rows.map((row) => [row.id, row]));
 
-  const effectivePageSizes = pageSize !== undefined && !pageSizes.includes(pageSize)
-    ? [pageSize, ...pageSizes].sort((a, b) => a - b)
-    : pageSizes;
+  const effectivePageSizes =
+    pageSize !== undefined && !pageSizes.includes(pageSize)
+      ? [pageSize, ...pageSizes].sort((a, b) => a - b)
+      : pageSizes;
 
-  const showPagination = pageSize !== undefined && rows.length > internalPageSize;
+  const showPagination =
+    pageSize !== undefined && rows.length > internalPageSize;
 
   return (
     <div
@@ -110,9 +112,10 @@ export const SortableDataTable = <T extends { id: string }>({
           getTableProps,
         }) => {
           const startIndex = (currentPage - 1) * internalPageSize;
-          const paginatedRows = pageSize !== undefined
-            ? tableRows.slice(startIndex, startIndex + internalPageSize)
-            : tableRows;
+          const paginatedRows =
+            pageSize !== undefined
+              ? tableRows.slice(startIndex, startIndex + internalPageSize)
+              : tableRows;
 
           return (
             <Table {...getTableProps()} aria-label={ariaLabel} size="md">

--- a/packages/bahmni-design-system/src/molecules/sortableDataTable/SortableDataTable.tsx
+++ b/packages/bahmni-design-system/src/molecules/sortableDataTable/SortableDataTable.tsx
@@ -51,21 +51,16 @@ export const SortableDataTable = <T extends { id: string }>({
   page,
 }: SortableDataTableProps<T>) => {
   const [currentPage, setCurrentPage] = useState(1);
-  // 0 is safe when pageSize is undefined — internalPageSize is never used
-  // in slicing or rendering when pagination is disabled (guarded by pageSize !== undefined)
   const [internalPageSize, setInternalPageSize] = useState<number>(
     pageSize ?? 0,
   );
 
-  // Reset to page 1 when rows change to prevent showing a stale empty page
-  // In server-side mode (totalItems defined), page is controlled externally
   useEffect(() => {
     if (totalItems === undefined) {
       setCurrentPage(1);
     }
   }, [rows?.length, totalItems]);
 
-  // useMemo must be called before early returns (Rules of Hooks)
   const effectivePageSizes = useMemo(
     () =>
       pageSize !== undefined && !pageSizes.includes(pageSize)
@@ -113,8 +108,6 @@ export const SortableDataTable = <T extends { id: string }>({
 
   const rowMap = new Map(rows.map((row) => [row.id, row]));
 
-  // In server-side mode (totalItems defined), use server total for pagination visibility
-  // In client-side mode, use rows.length
   const showPagination =
     pageSize !== undefined &&
     (totalItems !== undefined ? totalItems > pageSize : rows.length > pageSize);
@@ -133,7 +126,6 @@ export const SortableDataTable = <T extends { id: string }>({
           getTableProps,
         }) => {
           const startIndex = (currentPage - 1) * internalPageSize;
-          // In server-side mode, rows are already the correct page — no slicing needed
           const paginatedRows =
             pageSize !== undefined && totalItems === undefined
               ? tableRows.slice(startIndex, startIndex + internalPageSize)

--- a/packages/bahmni-design-system/src/molecules/sortableDataTable/SortableDataTable.tsx
+++ b/packages/bahmni-design-system/src/molecules/sortableDataTable/SortableDataTable.tsx
@@ -28,6 +28,8 @@ export interface SortableDataTableProps<T> {
   pageSize?: number;
   pageSizes?: number[];
   onPageChange?: (page: number, pageSize: number) => void;
+  totalItems?: number;
+  page?: number;
 }
 
 export const SortableDataTable = <T extends { id: string }>({
@@ -45,6 +47,8 @@ export const SortableDataTable = <T extends { id: string }>({
   pageSize,
   pageSizes = [5, 10, 25, 50, 100],
   onPageChange,
+  totalItems,
+  page,
 }: SortableDataTableProps<T>) => {
   const [currentPage, setCurrentPage] = useState(1);
   const [internalPageSize, setInternalPageSize] = useState<number>(
@@ -52,9 +56,12 @@ export const SortableDataTable = <T extends { id: string }>({
   );
 
   // Reset to page 1 when rows change to prevent showing a stale empty page
+  // In server-side mode (totalItems defined), page is controlled externally
   useEffect(() => {
-    setCurrentPage(1);
-  }, [rows?.length]);
+    if (totalItems === undefined) {
+      setCurrentPage(1);
+    }
+  }, [rows?.length, totalItems]);
 
   // useMemo must be called before early returns (Rules of Hooks)
   const effectivePageSizes = useMemo(
@@ -104,9 +111,11 @@ export const SortableDataTable = <T extends { id: string }>({
 
   const rowMap = new Map(rows.map((row) => [row.id, row]));
 
-  // Use the pageSize prop (not internalPageSize) so pagination visibility
-  // is not affected by user's dropdown selection during the session
-  const showPagination = pageSize !== undefined && rows.length > pageSize;
+  // In server-side mode (totalItems defined), use server total for pagination visibility
+  // In client-side mode, use rows.length
+  const showPagination =
+    pageSize !== undefined &&
+    (totalItems !== undefined ? totalItems > pageSize : rows.length > pageSize);
 
   return (
     <div
@@ -122,8 +131,9 @@ export const SortableDataTable = <T extends { id: string }>({
           getTableProps,
         }) => {
           const startIndex = (currentPage - 1) * internalPageSize;
+          // In server-side mode, rows are already the correct page — no slicing needed
           const paginatedRows =
-            pageSize !== undefined
+            pageSize !== undefined && totalItems === undefined
               ? tableRows.slice(startIndex, startIndex + internalPageSize)
               : tableRows;
 
@@ -179,14 +189,16 @@ export const SortableDataTable = <T extends { id: string }>({
       {showPagination && (
         <div className={styles.sortableDataTablePagination}>
           <Pagination
-            page={currentPage}
+            page={page ?? currentPage}
             pageSize={internalPageSize}
             pageSizes={effectivePageSizes}
-            totalItems={rows.length}
-            onChange={({ page, pageSize: newPageSize }) => {
-              setCurrentPage(page);
+            totalItems={totalItems ?? rows.length}
+            onChange={({ page: newPage, pageSize: newPageSize }) => {
               setInternalPageSize(newPageSize);
-              onPageChange?.(page, newPageSize);
+              if (totalItems === undefined) {
+                setCurrentPage(newPage);
+              }
+              onPageChange?.(newPage, newPageSize);
             }}
           />
         </div>

--- a/packages/bahmni-design-system/src/molecules/sortableDataTable/SortableDataTable.tsx
+++ b/packages/bahmni-design-system/src/molecules/sortableDataTable/SortableDataTable.tsx
@@ -51,6 +51,8 @@ export const SortableDataTable = <T extends { id: string }>({
   page,
 }: SortableDataTableProps<T>) => {
   const [currentPage, setCurrentPage] = useState(1);
+  // 0 is safe when pageSize is undefined — internalPageSize is never used
+  // in slicing or rendering when pagination is disabled (guarded by pageSize !== undefined)
   const [internalPageSize, setInternalPageSize] = useState<number>(
     pageSize ?? 0,
   );

--- a/packages/bahmni-design-system/src/molecules/sortableDataTable/SortableDataTable.tsx
+++ b/packages/bahmni-design-system/src/molecules/sortableDataTable/SortableDataTable.tsx
@@ -1,5 +1,6 @@
 import {
   DataTable,
+  Pagination,
   Table,
   TableHead,
   TableRow,
@@ -10,7 +11,7 @@ import {
   DataTableSkeleton,
 } from '@carbon/react';
 import classnames from 'classnames';
-import React from 'react';
+import React, { useState } from 'react';
 import styles from './styles/SortableDataTable.module.scss';
 
 export interface SortableDataTableProps<T> {
@@ -24,6 +25,9 @@ export interface SortableDataTableProps<T> {
   renderCell?: (row: T, cellId: string) => React.ReactNode;
   className?: string;
   dataTestId?: string;
+  pageSize?: number;
+  pageSizes?: number[];
+  onPageChange?: (page: number, pageSize: number) => void;
 }
 
 export const SortableDataTable = <T extends { id: string }>({
@@ -38,7 +42,15 @@ export const SortableDataTable = <T extends { id: string }>({
   renderCell = (row, cellId) => (row as any)[cellId],
   className = 'sortable-data-table',
   dataTestId = 'sortable-data-table',
+  pageSize,
+  pageSizes = [5, 10, 25, 50, 100],
+  onPageChange,
 }: SortableDataTableProps<T>) => {
+  const [currentPage, setCurrentPage] = useState(1);
+  const [internalPageSize, setInternalPageSize] = useState(
+    pageSize ?? rows?.length ?? 0,
+  );
+
   if (errorStateMessage) {
     return (
       <p
@@ -78,6 +90,12 @@ export const SortableDataTable = <T extends { id: string }>({
 
   const rowMap = new Map(rows.map((row) => [row.id, row]));
 
+  const effectivePageSizes = pageSize !== undefined && !pageSizes.includes(pageSize)
+    ? [pageSize, ...pageSizes].sort((a, b) => a - b)
+    : pageSizes;
+
+  const showPagination = pageSize !== undefined && rows.length > internalPageSize;
+
   return (
     <div
       className={classnames(className, styles.sortableDataTableBody)}
@@ -90,54 +108,76 @@ export const SortableDataTable = <T extends { id: string }>({
           getHeaderProps,
           getRowProps,
           getTableProps,
-        }) => (
-          <Table {...getTableProps()} aria-label={ariaLabel} size="md">
-            <TableHead>
-              <TableRow>
-                {tableHeaders.map((header) => {
-                  const headerProps = getHeaderProps({
-                    header,
-                    isSortable:
-                      sortable.find((s) => s.key === header.key)?.sortable ??
-                      false,
-                  });
+        }) => {
+          const startIndex = (currentPage - 1) * internalPageSize;
+          const paginatedRows = pageSize !== undefined
+            ? tableRows.slice(startIndex, startIndex + internalPageSize)
+            : tableRows;
+
+          return (
+            <Table {...getTableProps()} aria-label={ariaLabel} size="md">
+              <TableHead>
+                <TableRow>
+                  {tableHeaders.map((header) => {
+                    const headerProps = getHeaderProps({
+                      header,
+                      isSortable:
+                        sortable.find((s) => s.key === header.key)?.sortable ??
+                        false,
+                    });
+                    return (
+                      <TableHeader
+                        {...headerProps}
+                        key={header.key}
+                        data-testid={`table-header-${header.key}`}
+                      >
+                        {header.header}
+                      </TableHeader>
+                    );
+                  })}
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {paginatedRows.map((row) => {
+                  const originalRow = rowMap.get(row.id);
+                  if (!originalRow) return null;
                   return (
-                    <TableHeader
-                      {...headerProps}
-                      key={header.key}
-                      data-testid={`table-header-${header.key}`}
+                    <TableRow
+                      {...getRowProps({ row })}
+                      key={row.id}
+                      data-testid={`table-row-${row.id}`}
                     >
-                      {header.header}
-                    </TableHeader>
+                      {row.cells.map((cell) => (
+                        <TableCell
+                          key={cell.id}
+                          data-testid={`table-cell-${row.id}-${cell.info.header}`}
+                        >
+                          {renderCell(originalRow, cell.info.header)}
+                        </TableCell>
+                      ))}
+                    </TableRow>
                   );
                 })}
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {tableRows.map((row) => {
-                const originalRow = rowMap.get(row.id);
-                if (!originalRow) return null;
-                return (
-                  <TableRow
-                    {...getRowProps({ row })}
-                    key={row.id}
-                    data-testid={`table-row-${row.id}`}
-                  >
-                    {row.cells.map((cell) => (
-                      <TableCell
-                        key={cell.id}
-                        data-testid={`table-cell-${row.id}-${cell.info.header}`}
-                      >
-                        {renderCell(originalRow, cell.info.header)}
-                      </TableCell>
-                    ))}
-                  </TableRow>
-                );
-              })}
-            </TableBody>
-          </Table>
-        )}
+              </TableBody>
+            </Table>
+          );
+        }}
       </DataTable>
+      {showPagination && (
+        <div className={styles.sortableDataTablePagination}>
+          <Pagination
+            page={currentPage}
+            pageSize={internalPageSize}
+            pageSizes={effectivePageSizes}
+            totalItems={rows.length}
+            onChange={({ page, pageSize: newPageSize }) => {
+              setCurrentPage(page);
+              setInternalPageSize(newPageSize);
+              onPageChange?.(page, newPageSize);
+            }}
+          />
+        </div>
+      )}
     </div>
   );
 };

--- a/packages/bahmni-design-system/src/molecules/sortableDataTable/__tests__/SortableDataTable.test.tsx
+++ b/packages/bahmni-design-system/src/molecules/sortableDataTable/__tests__/SortableDataTable.test.tsx
@@ -1,5 +1,6 @@
 import { DataTableHeader } from '@carbon/react';
 import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { axe, toHaveNoViolations } from 'jest-axe';
 import { SortableDataTable } from '../SortableDataTable';
 import '@testing-library/jest-dom';
@@ -339,6 +340,211 @@ describe('SortableDataTable', () => {
         />,
       );
       expect(await axe(container)).toHaveNoViolations();
+    });
+  });
+
+  describe('Pagination', () => {
+    const manyRows = Array.from({ length: 12 }, (_, i) => ({
+      id: `row-${i}`,
+      name: `Medication ${i + 1}`,
+      dosage: `${i + 1} Tablet`,
+      dosageUnit: 'Tablet',
+      instruction: 'Oral',
+      startDate: '01/01/2025',
+      orderDate: '01/01/2025',
+      orderedBy: `Dr. ${i + 1}`,
+      quantity: `${i + 1} Tablet`,
+      status: 'active',
+    }));
+
+    it('renders pagination when pageSize is provided and rows exceed pageSize', () => {
+      render(
+        <SortableDataTable
+          headers={mockHeaders}
+          rows={manyRows}
+          ariaLabel="Paginated Table"
+          renderCell={renderCell}
+          pageSize={5}
+        />,
+      );
+
+      expect(screen.getByRole('button', { name: /next page/i })).toBeInTheDocument();
+    });
+
+    it('does not render pagination when rows fit on one page', () => {
+      render(
+        <SortableDataTable
+          headers={mockHeaders}
+          rows={manyRows}
+          ariaLabel="No Pagination Table"
+          renderCell={renderCell}
+          pageSize={20}
+        />,
+      );
+
+      expect(screen.queryByRole('button', { name: /next page/i })).not.toBeInTheDocument();
+    });
+
+    it('does not render pagination when pageSize prop is not provided', () => {
+      render(
+        <SortableDataTable
+          headers={mockHeaders}
+          rows={manyRows}
+          ariaLabel="No Pagination Prop Table"
+          renderCell={renderCell}
+        />,
+      );
+
+      expect(screen.queryByRole('button', { name: /next page/i })).not.toBeInTheDocument();
+    });
+
+    it('displays only the first page rows when pageSize is provided', () => {
+      render(
+        <SortableDataTable
+          headers={mockHeaders}
+          rows={manyRows}
+          ariaLabel="First Page Table"
+          renderCell={renderCell}
+          pageSize={5}
+        />,
+      );
+
+      expect(screen.getByText('Medication 1')).toBeInTheDocument();
+      expect(screen.getByText('Medication 5')).toBeInTheDocument();
+      expect(screen.queryByText('Medication 6')).not.toBeInTheDocument();
+    });
+
+    it('navigates to next page showing correct rows', async () => {
+      const user = userEvent.setup();
+      render(
+        <SortableDataTable
+          headers={mockHeaders}
+          rows={manyRows}
+          ariaLabel="Next Page Table"
+          renderCell={renderCell}
+          pageSize={5}
+        />,
+      );
+
+      const nextButton = screen.getByRole('button', { name: /next page/i });
+      await user.click(nextButton);
+
+      expect(screen.getByText('Medication 6')).toBeInTheDocument();
+      expect(screen.queryByText('Medication 1')).not.toBeInTheDocument();
+    });
+
+    it('disables previous page button on first page', () => {
+      render(
+        <SortableDataTable
+          headers={mockHeaders}
+          rows={manyRows}
+          ariaLabel="Prev Disabled Table"
+          renderCell={renderCell}
+          pageSize={5}
+        />,
+      );
+
+      const prevButton = screen.getByRole('button', { name: /previous page/i });
+      expect(prevButton).toBeDisabled();
+    });
+
+    it('disables next page button on last page', async () => {
+      const user = userEvent.setup();
+      render(
+        <SortableDataTable
+          headers={mockHeaders}
+          rows={manyRows}
+          ariaLabel="Next Disabled Table"
+          renderCell={renderCell}
+          pageSize={10}
+        />,
+      );
+
+      const nextButton = screen.getByRole('button', { name: /next page/i });
+      await user.click(nextButton);
+
+      expect(screen.getByRole('button', { name: /next page/i })).toBeDisabled();
+    });
+
+    it('calls onPageChange callback when page changes', async () => {
+      const user = userEvent.setup();
+      const onPageChange = jest.fn();
+      render(
+        <SortableDataTable
+          headers={mockHeaders}
+          rows={manyRows}
+          ariaLabel="Callback Table"
+          renderCell={renderCell}
+          pageSize={5}
+          onPageChange={onPageChange}
+        />,
+      );
+
+      const nextButton = screen.getByRole('button', { name: /next page/i });
+      await user.click(nextButton);
+
+      expect(onPageChange).toHaveBeenCalledWith(2, 5);
+    });
+
+    it('changes page size when a new page size is selected', async () => {
+      const user = userEvent.setup();
+      const onPageChange = jest.fn();
+      render(
+        <SortableDataTable
+          headers={mockHeaders}
+          rows={manyRows}
+          ariaLabel="Page Size Table"
+          renderCell={renderCell}
+          pageSize={5}
+          pageSizes={[5, 10, 25]}
+          onPageChange={onPageChange}
+        />,
+      );
+
+      const select = screen.getByRole('combobox', { name: /items per page/i });
+      await user.selectOptions(select, '10');
+
+      expect(onPageChange).toHaveBeenCalledWith(1, 10);
+    });
+
+    it('maintains sort order across page changes', async () => {
+      const user = userEvent.setup();
+      render(
+        <SortableDataTable
+          headers={mockHeaders}
+          rows={manyRows}
+          ariaLabel="Sort Preserved Table"
+          renderCell={renderCell}
+          pageSize={5}
+        />,
+      );
+
+      // Sort by name descending
+      const nameHeader = screen.getByTestId('table-header-name');
+      await user.click(nameHeader); // asc
+      await user.click(nameHeader); // desc
+
+      // Capture page 1 rows
+      const page1Rows = screen
+        .getAllByRole('row')
+        .slice(1)
+        .map((r) => r.getAttribute('data-testid'));
+
+      // Go to page 2
+      await user.click(screen.getByRole('button', { name: /next page/i }));
+
+      const page2Rows = screen
+        .getAllByRole('row')
+        .slice(1)
+        .map((r) => r.getAttribute('data-testid'));
+
+      // Page 2 rows must be different from page 1 (sort applied across all pages)
+      expect(page2Rows).not.toEqual(page1Rows);
+
+      // No page 1 rows should appear on page 2
+      page1Rows.forEach((rowId) => {
+        expect(page2Rows).not.toContain(rowId);
+      });
     });
   });
 });

--- a/packages/bahmni-design-system/src/molecules/sortableDataTable/__tests__/SortableDataTable.test.tsx
+++ b/packages/bahmni-design-system/src/molecules/sortableDataTable/__tests__/SortableDataTable.test.tsx
@@ -368,7 +368,9 @@ describe('SortableDataTable', () => {
         />,
       );
 
-      expect(screen.getByRole('button', { name: /next page/i })).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /next page/i }),
+      ).toBeInTheDocument();
     });
 
     it('does not render pagination when rows fit on one page', () => {
@@ -382,7 +384,9 @@ describe('SortableDataTable', () => {
         />,
       );
 
-      expect(screen.queryByRole('button', { name: /next page/i })).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: /next page/i }),
+      ).not.toBeInTheDocument();
     });
 
     it('does not render pagination when pageSize prop is not provided', () => {
@@ -395,7 +399,9 @@ describe('SortableDataTable', () => {
         />,
       );
 
-      expect(screen.queryByRole('button', { name: /next page/i })).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: /next page/i }),
+      ).not.toBeInTheDocument();
     });
 
     it('displays only the first page rows when pageSize is provided', () => {

--- a/packages/bahmni-design-system/src/molecules/sortableDataTable/__tests__/SortableDataTable.test.tsx
+++ b/packages/bahmni-design-system/src/molecules/sortableDataTable/__tests__/SortableDataTable.test.tsx
@@ -1,5 +1,5 @@
 import { DataTableHeader } from '@carbon/react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe, toHaveNoViolations } from 'jest-axe';
 import { SortableDataTable } from '../SortableDataTable';
@@ -525,32 +525,115 @@ describe('SortableDataTable', () => {
         />,
       );
 
-      // Sort by name descending
+      // Sort ascending by name (first click)
       const nameHeader = screen.getByTestId('table-header-name');
-      await user.click(nameHeader); // asc
-      await user.click(nameHeader); // desc
+      await user.click(nameHeader);
 
-      // Capture page 1 rows
-      const page1Rows = screen
-        .getAllByRole('row')
-        .slice(1)
-        .map((r) => r.getAttribute('data-testid'));
+      // After ascending sort, alphabetical order is:
+      // Medication 1, Medication 10, Medication 11, Medication 12, Medication 2 … (page 1)
+      // Medication 3, Medication 4, Medication 5, Medication 6, Medication 7 … (page 2)
+      expect(screen.getByText('Medication 1')).toBeInTheDocument();
+      // Medication 3 should NOT be on page 1 (it falls on page 2 alphabetically)
+      expect(screen.queryByText('Medication 3')).not.toBeInTheDocument();
 
-      // Go to page 2
       await user.click(screen.getByRole('button', { name: /next page/i }));
 
-      const page2Rows = screen
-        .getAllByRole('row')
-        .slice(1)
-        .map((r) => r.getAttribute('data-testid'));
+      // Page 2 must show the next 5 items in the same sort order
+      expect(screen.getByText('Medication 3')).toBeInTheDocument();
+      // Medication 1 must no longer be visible (it was on page 1)
+      expect(screen.queryByText('Medication 1')).not.toBeInTheDocument();
+    });
 
-      // Page 2 rows must be different from page 1 (sort applied across all pages)
-      expect(page2Rows).not.toEqual(page1Rows);
+    it('displays page range text showing items for current page', () => {
+      render(
+        <SortableDataTable
+          headers={mockHeaders}
+          rows={manyRows}
+          ariaLabel="Range Text Table"
+          renderCell={renderCell}
+          pageSize={5}
+        />,
+      );
 
-      // No page 1 rows should appear on page 2
-      page1Rows.forEach((rowId) => {
-        expect(page2Rows).not.toContain(rowId);
+      // Carbon Pagination renders range e.g. "1–5 of 12 items"
+      expect(screen.getByText(/of 12 items/)).toBeInTheDocument();
+    });
+
+    it('displays page counter text', () => {
+      render(
+        <SortableDataTable
+          headers={mockHeaders}
+          rows={manyRows}
+          ariaLabel="Counter Text Table"
+          renderCell={renderCell}
+          pageSize={5}
+        />,
+      );
+
+      // 12 rows ÷ 5 per page = 3 pages — Carbon renders "of 3 pages" in multiple elements
+      expect(screen.getAllByText(/of 3 pages/).length).toBeGreaterThan(0);
+    });
+
+    it('resets to page 1 when rows prop changes', async () => {
+      const user = userEvent.setup();
+      const { rerender } = render(
+        <SortableDataTable
+          headers={mockHeaders}
+          rows={manyRows}
+          ariaLabel="Reset Page Table"
+          renderCell={renderCell}
+          pageSize={5}
+        />,
+      );
+
+      // Navigate to page 2
+      await user.click(screen.getByRole('button', { name: /next page/i }));
+      expect(screen.getByText('Medication 6')).toBeInTheDocument();
+
+      // Rows shrink — all fit on one page
+      rerender(
+        <SortableDataTable
+          headers={mockHeaders}
+          rows={manyRows.slice(0, 3)}
+          ariaLabel="Reset Page Table"
+          renderCell={renderCell}
+          pageSize={5}
+        />,
+      );
+
+      // useEffect resets currentPage to 1 asynchronously after rows.length changes
+      await waitFor(() => {
+        expect(screen.getByText('Medication 1')).toBeInTheDocument();
       });
+      // Pagination is hidden (3 rows < pageSize 5)
+      expect(
+        screen.queryByRole('button', { name: /next page/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('shows more rows after user increases page size via dropdown', async () => {
+      const user = userEvent.setup();
+      render(
+        <SortableDataTable
+          headers={mockHeaders}
+          rows={manyRows}
+          ariaLabel="Page Size Update Table"
+          renderCell={renderCell}
+          pageSize={5}
+          pageSizes={[5, 10, 25]}
+        />,
+      );
+
+      // Initially only first 5 rows visible
+      expect(screen.getByText('Medication 5')).toBeInTheDocument();
+      expect(screen.queryByText('Medication 6')).not.toBeInTheDocument();
+
+      // User changes page size to 10
+      const select = screen.getByRole('combobox', { name: /items per page/i });
+      await user.selectOptions(select, '10');
+
+      // All 10 rows now visible on page 1
+      expect(screen.getByText('Medication 6')).toBeInTheDocument();
     });
   });
 });

--- a/packages/bahmni-design-system/src/molecules/sortableDataTable/__tests__/SortableDataTable.test.tsx
+++ b/packages/bahmni-design-system/src/molecules/sortableDataTable/__tests__/SortableDataTable.test.tsx
@@ -636,4 +636,160 @@ describe('SortableDataTable', () => {
       expect(screen.getByText('Medication 6')).toBeInTheDocument();
     });
   });
+
+  describe('Server-side pagination (totalItems prop)', () => {
+    const serverPageRows = [
+      {
+        id: 'row-0',
+        name: 'Medication 1',
+        dosage: '1 Tablet',
+        dosageUnit: 'Tablet',
+        instruction: 'Oral',
+        startDate: '01/01/2025',
+        orderDate: '01/01/2025',
+        orderedBy: 'Dr. 1',
+        quantity: '1 Tablet',
+        status: 'active',
+      },
+      {
+        id: 'row-1',
+        name: 'Medication 2',
+        dosage: '2 Tablet',
+        dosageUnit: 'Tablet',
+        instruction: 'Oral',
+        startDate: '01/01/2025',
+        orderDate: '01/01/2025',
+        orderedBy: 'Dr. 2',
+        quantity: '2 Tablet',
+        status: 'active',
+      },
+    ];
+
+    it('renders pagination when totalItems exceeds pageSize', () => {
+      render(
+        <SortableDataTable
+          headers={mockHeaders}
+          rows={serverPageRows}
+          ariaLabel="Server Paginated Table"
+          renderCell={renderCell}
+          pageSize={2}
+          totalItems={10}
+          page={1}
+        />,
+      );
+
+      expect(
+        screen.getByRole('button', { name: /next page/i }),
+      ).toBeInTheDocument();
+    });
+
+    it('does not render pagination when totalItems equals pageSize', () => {
+      render(
+        <SortableDataTable
+          headers={mockHeaders}
+          rows={serverPageRows}
+          ariaLabel="Server No Pagination Table"
+          renderCell={renderCell}
+          pageSize={10}
+          totalItems={2}
+          page={1}
+        />,
+      );
+
+      expect(
+        screen.queryByRole('button', { name: /next page/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('renders all provided rows without client-side slicing in server-side mode', () => {
+      render(
+        <SortableDataTable
+          headers={mockHeaders}
+          rows={serverPageRows}
+          ariaLabel="Server All Rows Table"
+          renderCell={renderCell}
+          pageSize={2}
+          totalItems={20}
+          page={1}
+        />,
+      );
+
+      expect(screen.getByText('Medication 1')).toBeInTheDocument();
+      expect(screen.getByText('Medication 2')).toBeInTheDocument();
+    });
+
+    it('calls onPageChange when next page is clicked in server-side mode', async () => {
+      const user = userEvent.setup();
+      const onPageChange = jest.fn();
+
+      render(
+        <SortableDataTable
+          headers={mockHeaders}
+          rows={serverPageRows}
+          ariaLabel="Server Page Change Table"
+          renderCell={renderCell}
+          pageSize={2}
+          totalItems={10}
+          page={1}
+          onPageChange={onPageChange}
+        />,
+      );
+
+      await user.click(screen.getByRole('button', { name: /next page/i }));
+
+      expect(onPageChange).toHaveBeenCalledWith(2, 2);
+    });
+
+    it('renders pagination component when totalItems exceeds pageSize with controlled page', () => {
+      render(
+        <SortableDataTable
+          headers={mockHeaders}
+          rows={serverPageRows}
+          ariaLabel="Server Controlled Page Table"
+          renderCell={renderCell}
+          pageSize={2}
+          totalItems={10}
+          page={3}
+        />,
+      );
+
+      // Pagination should be rendered — prev/next buttons are present
+      expect(
+        screen.getByRole('button', { name: /previous page/i }),
+      ).toBeInTheDocument();
+    });
+
+    it('does not reset page internally when rows change in server-side mode', async () => {
+      const onPageChange = jest.fn();
+      const { rerender } = render(
+        <SortableDataTable
+          headers={mockHeaders}
+          rows={serverPageRows}
+          ariaLabel="Server No Reset Table"
+          renderCell={renderCell}
+          pageSize={2}
+          totalItems={10}
+          page={2}
+          onPageChange={onPageChange}
+        />,
+      );
+
+      // Simulate new page data arriving (rows change) — page should not reset
+      rerender(
+        <SortableDataTable
+          headers={mockHeaders}
+          rows={[{ ...serverPageRows[0], id: 'row-new', name: 'New Med' }]}
+          ariaLabel="Server No Reset Table"
+          renderCell={renderCell}
+          pageSize={2}
+          totalItems={10}
+          page={2}
+          onPageChange={onPageChange}
+        />,
+      );
+
+      // onPageChange should NOT have been called with page 1 (no reset)
+      expect(onPageChange).not.toHaveBeenCalledWith(1, expect.any(Number));
+    });
+  });
 });

--- a/packages/bahmni-design-system/src/molecules/sortableDataTable/styles/SortableDataTable.module.scss
+++ b/packages/bahmni-design-system/src/molecules/sortableDataTable/styles/SortableDataTable.module.scss
@@ -36,3 +36,8 @@
   text-align: center;
   border-top: 1px solid $border-subtle-02;
 }
+
+.sortableDataTablePagination {
+  background-color: $background;
+  border-top: 1px solid $border-subtle;
+}

--- a/packages/bahmni-services/src/documentReferenceService/__tests__/documentReferenceService.test.ts
+++ b/packages/bahmni-services/src/documentReferenceService/__tests__/documentReferenceService.test.ts
@@ -3,6 +3,7 @@ import { get } from '../../api';
 import {
   getDocumentReferences,
   getFormattedDocumentReferences,
+  getDocumentReferencePage,
 } from '../documentReferenceService';
 
 jest.mock('../../api');
@@ -10,7 +11,7 @@ jest.mock('../../api');
 const mockedGet = get as jest.MockedFunction<typeof get>;
 
 const PATIENT_UUID = 'test-patient-uuid';
-const BASE_URL = `/openmrs/ws/fhir2/R4/DocumentReference?patient=${PATIENT_UUID}&_sort=-date&_count=100`;
+const BASE_URL = `/openmrs/ws/fhir2/R4/DocumentReference?patient=${PATIENT_UUID}&_sort=-date,-period&_count=10`;
 
 const mockDocumentReference: DocumentReference = {
   resourceType: 'DocumentReference',
@@ -392,6 +393,142 @@ describe('documentReferenceService', () => {
       expect(mockedGet).toHaveBeenCalledWith(
         `${BASE_URL}&encounter=enc-uuid-1,enc-uuid-2`,
       );
+    });
+  });
+
+  describe('getDocumentReferencePage', () => {
+    it('fetches page using constructed URL with default count', async () => {
+      mockedGet.mockResolvedValueOnce(mockBundle);
+
+      await getDocumentReferencePage(PATIENT_UUID);
+
+      expect(mockedGet).toHaveBeenCalledWith(BASE_URL);
+    });
+
+    it('fetches page using constructed URL with custom count', async () => {
+      mockedGet.mockResolvedValueOnce(mockBundle);
+
+      await getDocumentReferencePage(PATIENT_UUID, undefined, 25);
+
+      const expectedUrl = `/openmrs/ws/fhir2/R4/DocumentReference?patient=${PATIENT_UUID}&_sort=-date,-period&_count=25`;
+      expect(mockedGet).toHaveBeenCalledWith(expectedUrl);
+    });
+
+    it('uses pageUrl directly when provided', async () => {
+      const pageUrl = '/openmrs/ws/fhir2/R4/DocumentReference?_page=2';
+      mockedGet.mockResolvedValueOnce(mockBundle);
+
+      await getDocumentReferencePage(
+        PATIENT_UUID,
+        undefined,
+        undefined,
+        pageUrl,
+      );
+
+      expect(mockedGet).toHaveBeenCalledWith(pageUrl);
+    });
+
+    it('returns documents array and total from bundle', async () => {
+      const bundleWithTotal: Bundle<DocumentReference> = {
+        ...mockBundle,
+        total: 42,
+      };
+      mockedGet.mockResolvedValueOnce(bundleWithTotal);
+
+      const result = await getDocumentReferencePage(PATIENT_UUID);
+
+      expect(result.total).toBe(42);
+      expect(result.documents).toHaveLength(1);
+      expect(result.documents[0]).toEqual(
+        expect.objectContaining({
+          id: 'doc-1',
+          documentIdentifier: 'Prescription_2024',
+        }),
+      );
+    });
+
+    it('falls back to entries length when bundle total is absent', async () => {
+      const bundleNoTotal: Bundle<DocumentReference> = {
+        resourceType: 'Bundle',
+        type: 'searchset',
+        entry: [{ resource: mockDocumentReference }],
+      };
+      mockedGet.mockResolvedValueOnce(bundleNoTotal);
+
+      const result = await getDocumentReferencePage(PATIENT_UUID);
+
+      expect(result.total).toBe(1);
+    });
+
+    it('extracts nextUrl from bundle link', async () => {
+      const nextUrl = '/openmrs/ws/fhir2/R4/DocumentReference?_page=2';
+      const bundleWithNext: Bundle<DocumentReference> = {
+        ...mockBundle,
+        total: 20,
+        link: [
+          { relation: 'self', url: BASE_URL },
+          { relation: 'next', url: nextUrl },
+        ],
+      };
+      mockedGet.mockResolvedValueOnce(bundleWithNext);
+
+      const result = await getDocumentReferencePage(PATIENT_UUID);
+
+      expect(result.nextUrl).toBe(nextUrl);
+      expect(result.prevUrl).toBeUndefined();
+    });
+
+    it('extracts prevUrl from bundle link', async () => {
+      const prevUrl = '/openmrs/ws/fhir2/R4/DocumentReference?_page=1';
+      const bundleWithPrev: Bundle<DocumentReference> = {
+        ...mockBundle,
+        total: 20,
+        link: [
+          { relation: 'self', url: BASE_URL },
+          { relation: 'previous', url: prevUrl },
+        ],
+      };
+      mockedGet.mockResolvedValueOnce(bundleWithPrev);
+
+      const result = await getDocumentReferencePage(PATIENT_UUID);
+
+      expect(result.prevUrl).toBe(prevUrl);
+      expect(result.nextUrl).toBeUndefined();
+    });
+
+    it('returns undefined nextUrl and prevUrl when no link in bundle', async () => {
+      mockedGet.mockResolvedValueOnce(mockBundle);
+
+      const result = await getDocumentReferencePage(PATIENT_UUID);
+
+      expect(result.nextUrl).toBeUndefined();
+      expect(result.prevUrl).toBeUndefined();
+    });
+
+    it('appends encounter filter when encounterUuids are provided', async () => {
+      mockedGet.mockResolvedValueOnce(mockBundle);
+      const encounterUuids = ['enc-uuid-1', 'enc-uuid-2'];
+
+      await getDocumentReferencePage(PATIENT_UUID, encounterUuids);
+
+      expect(mockedGet).toHaveBeenCalledWith(
+        `${BASE_URL}&encounter=enc-uuid-1,enc-uuid-2`,
+      );
+    });
+
+    it('returns empty documents array for empty bundle', async () => {
+      const emptyBundle: Bundle<DocumentReference> = {
+        resourceType: 'Bundle',
+        type: 'searchset',
+        total: 0,
+        entry: [],
+      };
+      mockedGet.mockResolvedValueOnce(emptyBundle);
+
+      const result = await getDocumentReferencePage(PATIENT_UUID);
+
+      expect(result.documents).toEqual([]);
+      expect(result.total).toBe(0);
     });
   });
 });

--- a/packages/bahmni-services/src/documentReferenceService/__tests__/documentReferenceService.test.ts
+++ b/packages/bahmni-services/src/documentReferenceService/__tests__/documentReferenceService.test.ts
@@ -11,7 +11,7 @@ jest.mock('../../api');
 const mockedGet = get as jest.MockedFunction<typeof get>;
 
 const PATIENT_UUID = 'test-patient-uuid';
-const BASE_URL = `/openmrs/ws/fhir2/R4/DocumentReference?patient=${PATIENT_UUID}&_sort=-date,-period&_count=10`;
+const BASE_URL = `/openmrs/ws/fhir2/R4/DocumentReference?patient=${PATIENT_UUID}&_sort=-date,-period&_count=10&_getpagesoffset=0`;
 
 const mockDocumentReference: DocumentReference = {
   resourceType: 'DocumentReference',
@@ -397,7 +397,7 @@ describe('documentReferenceService', () => {
   });
 
   describe('getDocumentReferencePage', () => {
-    it('fetches page using constructed URL with default count', async () => {
+    it('fetches page 1 with default count and offset 0', async () => {
       mockedGet.mockResolvedValueOnce(mockBundle);
 
       await getDocumentReferencePage(PATIENT_UUID);
@@ -405,27 +405,32 @@ describe('documentReferenceService', () => {
       expect(mockedGet).toHaveBeenCalledWith(BASE_URL);
     });
 
-    it('fetches page using constructed URL with custom count', async () => {
+    it('fetches page 1 with custom count and offset 0', async () => {
       mockedGet.mockResolvedValueOnce(mockBundle);
 
       await getDocumentReferencePage(PATIENT_UUID, undefined, 25);
 
-      const expectedUrl = `/openmrs/ws/fhir2/R4/DocumentReference?patient=${PATIENT_UUID}&_sort=-date,-period&_count=25`;
+      const expectedUrl = `/openmrs/ws/fhir2/R4/DocumentReference?patient=${PATIENT_UUID}&_sort=-date,-period&_count=25&_getpagesoffset=0`;
       expect(mockedGet).toHaveBeenCalledWith(expectedUrl);
     });
 
-    it('uses pageUrl directly when provided', async () => {
-      const pageUrl = '/openmrs/ws/fhir2/R4/DocumentReference?_page=2';
+    it('computes correct offset for page 2 (_getpagesoffset = count)', async () => {
       mockedGet.mockResolvedValueOnce(mockBundle);
 
-      await getDocumentReferencePage(
-        PATIENT_UUID,
-        undefined,
-        undefined,
-        pageUrl,
-      );
+      await getDocumentReferencePage(PATIENT_UUID, undefined, 10, 2);
 
-      expect(mockedGet).toHaveBeenCalledWith(pageUrl);
+      const expectedUrl = `/openmrs/ws/fhir2/R4/DocumentReference?patient=${PATIENT_UUID}&_sort=-date,-period&_count=10&_getpagesoffset=10`;
+      expect(mockedGet).toHaveBeenCalledWith(expectedUrl);
+    });
+
+    it('jumps directly to page 5 without traversing previous pages', async () => {
+      mockedGet.mockResolvedValueOnce(mockBundle);
+
+      await getDocumentReferencePage(PATIENT_UUID, undefined, 2, 5);
+
+      // offset = (5 - 1) * 2 = 8
+      const expectedUrl = `/openmrs/ws/fhir2/R4/DocumentReference?patient=${PATIENT_UUID}&_sort=-date,-period&_count=2&_getpagesoffset=8`;
+      expect(mockedGet).toHaveBeenCalledWith(expectedUrl);
     });
 
     it('returns documents array and total from bundle', async () => {
@@ -458,51 +463,6 @@ describe('documentReferenceService', () => {
       const result = await getDocumentReferencePage(PATIENT_UUID);
 
       expect(result.total).toBe(1);
-    });
-
-    it('extracts nextUrl from bundle link', async () => {
-      const nextUrl = '/openmrs/ws/fhir2/R4/DocumentReference?_page=2';
-      const bundleWithNext: Bundle<DocumentReference> = {
-        ...mockBundle,
-        total: 20,
-        link: [
-          { relation: 'self', url: BASE_URL },
-          { relation: 'next', url: nextUrl },
-        ],
-      };
-      mockedGet.mockResolvedValueOnce(bundleWithNext);
-
-      const result = await getDocumentReferencePage(PATIENT_UUID);
-
-      expect(result.nextUrl).toBe(nextUrl);
-      expect(result.prevUrl).toBeUndefined();
-    });
-
-    it('extracts prevUrl from bundle link', async () => {
-      const prevUrl = '/openmrs/ws/fhir2/R4/DocumentReference?_page=1';
-      const bundleWithPrev: Bundle<DocumentReference> = {
-        ...mockBundle,
-        total: 20,
-        link: [
-          { relation: 'self', url: BASE_URL },
-          { relation: 'previous', url: prevUrl },
-        ],
-      };
-      mockedGet.mockResolvedValueOnce(bundleWithPrev);
-
-      const result = await getDocumentReferencePage(PATIENT_UUID);
-
-      expect(result.prevUrl).toBe(prevUrl);
-      expect(result.nextUrl).toBeUndefined();
-    });
-
-    it('returns undefined nextUrl and prevUrl when no link in bundle', async () => {
-      mockedGet.mockResolvedValueOnce(mockBundle);
-
-      const result = await getDocumentReferencePage(PATIENT_UUID);
-
-      expect(result.nextUrl).toBeUndefined();
-      expect(result.prevUrl).toBeUndefined();
     });
 
     it('appends encounter filter when encounterUuids are provided', async () => {

--- a/packages/bahmni-services/src/documentReferenceService/__tests__/documentReferenceService.test.ts
+++ b/packages/bahmni-services/src/documentReferenceService/__tests__/documentReferenceService.test.ts
@@ -11,7 +11,7 @@ jest.mock('../../api');
 const mockedGet = get as jest.MockedFunction<typeof get>;
 
 const PATIENT_UUID = 'test-patient-uuid';
-const BASE_URL = `/openmrs/ws/fhir2/R4/DocumentReference?patient=${PATIENT_UUID}&_sort=-date,-period&_count=10&_getpagesoffset=0`;
+const BASE_URL = `/openmrs/ws/fhir2/R4/DocumentReference?patient=${PATIENT_UUID}&_sort=-date&_count=10&_getpagesoffset=0`;
 
 const mockDocumentReference: DocumentReference = {
   resourceType: 'DocumentReference',
@@ -410,7 +410,7 @@ describe('documentReferenceService', () => {
 
       await getDocumentReferencePage(PATIENT_UUID, undefined, 25);
 
-      const expectedUrl = `/openmrs/ws/fhir2/R4/DocumentReference?patient=${PATIENT_UUID}&_sort=-date,-period&_count=25&_getpagesoffset=0`;
+      const expectedUrl = `/openmrs/ws/fhir2/R4/DocumentReference?patient=${PATIENT_UUID}&_sort=-date&_count=25&_getpagesoffset=0`;
       expect(mockedGet).toHaveBeenCalledWith(expectedUrl);
     });
 
@@ -419,7 +419,7 @@ describe('documentReferenceService', () => {
 
       await getDocumentReferencePage(PATIENT_UUID, undefined, 10, 2);
 
-      const expectedUrl = `/openmrs/ws/fhir2/R4/DocumentReference?patient=${PATIENT_UUID}&_sort=-date,-period&_count=10&_getpagesoffset=10`;
+      const expectedUrl = `/openmrs/ws/fhir2/R4/DocumentReference?patient=${PATIENT_UUID}&_sort=-date&_count=10&_getpagesoffset=10`;
       expect(mockedGet).toHaveBeenCalledWith(expectedUrl);
     });
 
@@ -429,7 +429,7 @@ describe('documentReferenceService', () => {
       await getDocumentReferencePage(PATIENT_UUID, undefined, 2, 5);
 
       // offset = (5 - 1) * 2 = 8
-      const expectedUrl = `/openmrs/ws/fhir2/R4/DocumentReference?patient=${PATIENT_UUID}&_sort=-date,-period&_count=2&_getpagesoffset=8`;
+      const expectedUrl = `/openmrs/ws/fhir2/R4/DocumentReference?patient=${PATIENT_UUID}&_sort=-date&_count=2&_getpagesoffset=8`;
       expect(mockedGet).toHaveBeenCalledWith(expectedUrl);
     });
 

--- a/packages/bahmni-services/src/documentReferenceService/__tests__/documentReferenceService.test.ts
+++ b/packages/bahmni-services/src/documentReferenceService/__tests__/documentReferenceService.test.ts
@@ -11,7 +11,8 @@ jest.mock('../../api');
 const mockedGet = get as jest.MockedFunction<typeof get>;
 
 const PATIENT_UUID = 'test-patient-uuid';
-const BASE_URL = `/openmrs/ws/fhir2/R4/DocumentReference?patient=${PATIENT_UUID}&_sort=-date&_count=10&_getpagesoffset=0`;
+const BASE_URL = `/openmrs/ws/fhir2/R4/DocumentReference?patient=${PATIENT_UUID}&_sort=-date&_count=100&_getpagesoffset=0`;
+const PAGE_BASE_URL = `/openmrs/ws/fhir2/R4/DocumentReference?patient=${PATIENT_UUID}&_sort=-date&_count=10&_getpagesoffset=0`;
 
 const mockDocumentReference: DocumentReference = {
   resourceType: 'DocumentReference',
@@ -402,7 +403,7 @@ describe('documentReferenceService', () => {
 
       await getDocumentReferencePage(PATIENT_UUID);
 
-      expect(mockedGet).toHaveBeenCalledWith(BASE_URL);
+      expect(mockedGet).toHaveBeenCalledWith(PAGE_BASE_URL);
     });
 
     it('fetches page 1 with custom count and offset 0', async () => {
@@ -472,7 +473,7 @@ describe('documentReferenceService', () => {
       await getDocumentReferencePage(PATIENT_UUID, encounterUuids);
 
       expect(mockedGet).toHaveBeenCalledWith(
-        `${BASE_URL}&encounter=enc-uuid-1,enc-uuid-2`,
+        `${PAGE_BASE_URL}&encounter=enc-uuid-1,enc-uuid-2`,
       );
     });
 

--- a/packages/bahmni-services/src/documentReferenceService/constants.ts
+++ b/packages/bahmni-services/src/documentReferenceService/constants.ts
@@ -3,7 +3,7 @@ import { OPENMRS_FHIR_R4 } from '../constants/app';
 export const PATIENT_DOCUMENT_REFERENCES_URL = (
   patientUuid: string,
   encounterUuids?: string[],
-  count: number = 10,
+  count: number = 100,
   offset: number = 0,
 ): string => {
   const baseUrl = `${OPENMRS_FHIR_R4}/DocumentReference?patient=${patientUuid}&_sort=-date&_count=${count}&_getpagesoffset=${offset}`;

--- a/packages/bahmni-services/src/documentReferenceService/constants.ts
+++ b/packages/bahmni-services/src/documentReferenceService/constants.ts
@@ -3,11 +3,11 @@ import { OPENMRS_FHIR_R4 } from '../constants/app';
 export const PATIENT_DOCUMENT_REFERENCES_URL = (
   patientUuid: string,
   encounterUuids?: string[],
+  count: number = 10,
 ): string => {
-  const baseUrl = `${OPENMRS_FHIR_R4}/DocumentReference?patient=${patientUuid}&_sort=-date&_count=100`;
+  const baseUrl = `${OPENMRS_FHIR_R4}/DocumentReference?patient=${patientUuid}&_sort=-date,-period&_count=${count}`;
   if (encounterUuids && encounterUuids.length > 0) {
-    const encounterParam = encounterUuids.join(',');
-    return `${baseUrl}&encounter=${encounterParam}`;
+    return `${baseUrl}&encounter=${encounterUuids.join(',')}`;
   }
   return baseUrl;
 };

--- a/packages/bahmni-services/src/documentReferenceService/constants.ts
+++ b/packages/bahmni-services/src/documentReferenceService/constants.ts
@@ -6,7 +6,7 @@ export const PATIENT_DOCUMENT_REFERENCES_URL = (
   count: number = 10,
   offset: number = 0,
 ): string => {
-  const baseUrl = `${OPENMRS_FHIR_R4}/DocumentReference?patient=${patientUuid}&_sort=-date,-period&_count=${count}&_getpagesoffset=${offset}`;
+  const baseUrl = `${OPENMRS_FHIR_R4}/DocumentReference?patient=${patientUuid}&_sort=-date&_count=${count}&_getpagesoffset=${offset}`;
   if (encounterUuids && encounterUuids.length > 0) {
     return `${baseUrl}&encounter=${encounterUuids.join(',')}`;
   }

--- a/packages/bahmni-services/src/documentReferenceService/constants.ts
+++ b/packages/bahmni-services/src/documentReferenceService/constants.ts
@@ -4,8 +4,9 @@ export const PATIENT_DOCUMENT_REFERENCES_URL = (
   patientUuid: string,
   encounterUuids?: string[],
   count: number = 10,
+  offset: number = 0,
 ): string => {
-  const baseUrl = `${OPENMRS_FHIR_R4}/DocumentReference?patient=${patientUuid}&_sort=-date,-period&_count=${count}`;
+  const baseUrl = `${OPENMRS_FHIR_R4}/DocumentReference?patient=${patientUuid}&_sort=-date,-period&_count=${count}&_getpagesoffset=${offset}`;
   if (encounterUuids && encounterUuids.length > 0) {
     return `${baseUrl}&encounter=${encounterUuids.join(',')}`;
   }

--- a/packages/bahmni-services/src/documentReferenceService/documentReferenceService.ts
+++ b/packages/bahmni-services/src/documentReferenceService/documentReferenceService.ts
@@ -30,7 +30,7 @@ function mapDocumentReferencesToViewModels(
         documentType:
           doc.type?.coding?.[0]?.display ??
           doc.category?.[0]?.coding?.[0]?.display,
-        uploadedOn: doc.date ?? doc.context?.period?.start ?? '',
+        uploadedOn: doc.date ?? '',
         uploadedBy: doc.author?.[0]?.display,
         contentType: firstAttachment?.contentType,
         documentUrl: firstAttachment?.url ?? '',

--- a/packages/bahmni-services/src/documentReferenceService/documentReferenceService.ts
+++ b/packages/bahmni-services/src/documentReferenceService/documentReferenceService.ts
@@ -41,7 +41,7 @@ function mapDocumentReferencesToViewModels(
 
 /**
  * Fetches patient documents from the FHIR DocumentReference endpoint
- * Documents are sorted by date (latest first)
+ * The request includes _sort=-date; actual ordering depends on server support.
  * @param patientUuid - The UUID of the patient to fetch documents for
  * @param encounterUuids - Optional array of encounter UUIDs to filter documents
  * @returns Promise resolving to a FHIR Bundle containing DocumentReference resources
@@ -56,7 +56,8 @@ export async function getDocumentReferences(
 
 /**
  * Fetches and formats patient documents from the FHIR DocumentReference endpoint
- * Documents are sorted by date (latest first) and transformed to DocumentViewModel
+ * Returns documents transformed to DocumentViewModel; consumers are responsible
+ * for client-side sorting where server-side _sort=-date is unsupported.
  * @param patientUuid - The UUID of the patient to fetch documents for
  * @param encounterUuids - Optional array of encounter UUIDs to filter documents
  * @returns Promise resolving to an array of formatted DocumentViewModel objects

--- a/packages/bahmni-services/src/documentReferenceService/documentReferenceService.ts
+++ b/packages/bahmni-services/src/documentReferenceService/documentReferenceService.ts
@@ -30,7 +30,7 @@ function mapDocumentReferencesToViewModels(
         documentType:
           doc.type?.coding?.[0]?.display ??
           doc.category?.[0]?.coding?.[0]?.display,
-        uploadedOn: doc.date ?? '',
+        uploadedOn: doc.date ?? doc.context?.period?.start ?? '',
         uploadedBy: doc.author?.[0]?.display,
         contentType: firstAttachment?.contentType,
         documentUrl: firstAttachment?.url ?? '',

--- a/packages/bahmni-services/src/documentReferenceService/documentReferenceService.ts
+++ b/packages/bahmni-services/src/documentReferenceService/documentReferenceService.ts
@@ -72,3 +72,56 @@ export async function getFormattedDocumentReferences(
   );
   return mapDocumentReferencesToViewModels(entries);
 }
+
+export interface DocumentReferencePage {
+  documents: DocumentViewModel[];
+  total: number;
+  nextUrl?: string;
+  prevUrl?: string;
+}
+
+/**
+ * Fetches a single page of patient documents from the FHIR DocumentReference endpoint.
+ * Supports server-side pagination via FHIR Bundle link relations (next/previous).
+ * @param patientUuid - The UUID of the patient to fetch documents for
+ * @param encounterUuids - Optional array of encounter UUIDs to filter documents
+ * @param count - Number of items per page (default 10)
+ * @param pageUrl - If provided, fetch this URL directly (for next/prev navigation)
+ * @returns Promise resolving to a DocumentReferencePage with documents and pagination info
+ */
+export async function getDocumentReferencePage(
+  patientUuid: string,
+  encounterUuids?: string[],
+  count?: number,
+  pageUrl?: string,
+): Promise<DocumentReferencePage> {
+  let url: string;
+  if (pageUrl) {
+    // The FHIR server embeds its own hostname in link URLs (e.g. http://localhost/...).
+    // Strip the hostname and use only pathname + search so Axios resolves it against
+    // the actual server configured in the client, not the server's internal hostname.
+    try {
+      const parsed = new URL(pageUrl);
+      url = parsed.pathname + parsed.search;
+    } catch {
+      url = pageUrl;
+    }
+  } else {
+    url = PATIENT_DOCUMENT_REFERENCES_URL(patientUuid, encounterUuids, count);
+  }
+  const bundle = await get<Bundle<DocumentReference>>(url);
+
+  const entries = (bundle.entry ?? []).filter(
+    (entry): entry is { resource: DocumentReference } => !!entry.resource,
+  );
+
+  const nextUrl = bundle.link?.find((l) => l.relation === 'next')?.url;
+  const prevUrl = bundle.link?.find((l) => l.relation === 'previous')?.url;
+
+  return {
+    documents: mapDocumentReferencesToViewModels(entries),
+    total: bundle.total ?? entries.length,
+    nextUrl,
+    prevUrl,
+  };
+}

--- a/packages/bahmni-services/src/documentReferenceService/documentReferenceService.ts
+++ b/packages/bahmni-services/src/documentReferenceService/documentReferenceService.ts
@@ -76,52 +76,38 @@ export async function getFormattedDocumentReferences(
 export interface DocumentReferencePage {
   documents: DocumentViewModel[];
   total: number;
-  nextUrl?: string;
-  prevUrl?: string;
 }
 
 /**
- * Fetches a single page of patient documents from the FHIR DocumentReference endpoint.
- * Supports server-side pagination via FHIR Bundle link relations (next/previous).
+ * Fetches a single page of patient documents using offset-based pagination.
+ * Uses _getpagesoffset = (page - 1) * count to jump directly to any page.
  * @param patientUuid - The UUID of the patient to fetch documents for
  * @param encounterUuids - Optional array of encounter UUIDs to filter documents
  * @param count - Number of items per page (default 10)
- * @param pageUrl - If provided, fetch this URL directly (for next/prev navigation)
- * @returns Promise resolving to a DocumentReferencePage with documents and pagination info
+ * @param page - 1-based page number (default 1)
+ * @returns Promise resolving to a DocumentReferencePage with documents and total count
  */
 export async function getDocumentReferencePage(
   patientUuid: string,
   encounterUuids?: string[],
-  count?: number,
-  pageUrl?: string,
+  count: number = 10,
+  page: number = 1,
 ): Promise<DocumentReferencePage> {
-  let url: string;
-  if (pageUrl) {
-    // The FHIR server embeds its own hostname in link URLs (e.g. http://localhost/...).
-    // Strip the hostname and use only pathname + search so Axios resolves it against
-    // the actual server configured in the client, not the server's internal hostname.
-    try {
-      const parsed = new URL(pageUrl);
-      url = parsed.pathname + parsed.search;
-    } catch {
-      url = pageUrl;
-    }
-  } else {
-    url = PATIENT_DOCUMENT_REFERENCES_URL(patientUuid, encounterUuids, count);
-  }
+  const offset = (page - 1) * count;
+  const url = PATIENT_DOCUMENT_REFERENCES_URL(
+    patientUuid,
+    encounterUuids,
+    count,
+    offset,
+  );
   const bundle = await get<Bundle<DocumentReference>>(url);
 
   const entries = (bundle.entry ?? []).filter(
     (entry): entry is { resource: DocumentReference } => !!entry.resource,
   );
 
-  const nextUrl = bundle.link?.find((l) => l.relation === 'next')?.url;
-  const prevUrl = bundle.link?.find((l) => l.relation === 'previous')?.url;
-
   return {
     documents: mapDocumentReferencesToViewModels(entries),
     total: bundle.total ?? entries.length,
-    nextUrl,
-    prevUrl,
   };
 }

--- a/packages/bahmni-services/src/documentReferenceService/index.ts
+++ b/packages/bahmni-services/src/documentReferenceService/index.ts
@@ -1,6 +1,8 @@
 export {
   getDocumentReferences,
   getFormattedDocumentReferences,
+  getDocumentReferencePage,
+  type DocumentReferencePage,
 } from './documentReferenceService';
 export type { DocumentViewModel } from './models';
 export type { DocumentReference } from 'fhir/r4';

--- a/packages/bahmni-services/src/index.ts
+++ b/packages/bahmni-services/src/index.ts
@@ -303,6 +303,8 @@ export {
 export {
   getDocumentReferences,
   getFormattedDocumentReferences,
+  getDocumentReferencePage,
+  type DocumentReferencePage,
   type DocumentViewModel,
   type DocumentReference,
 } from './documentReferenceService';

--- a/packages/bahmni-widgets/src/documents/DocumentsTable.tsx
+++ b/packages/bahmni-widgets/src/documents/DocumentsTable.tsx
@@ -2,11 +2,18 @@ import { SortableDataTable, Modal, Link } from '@bahmni/design-system';
 import {
   useTranslation,
   formatDateTime,
-  getFormattedDocumentReferences,
+  getDocumentReferencePage,
+  DocumentReferencePage,
   DocumentViewModel,
 } from '@bahmni/services';
 import { useQuery } from '@tanstack/react-query';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { usePatientUUID } from '../hooks/usePatientUUID';
 import { useNotification } from '../notification';
 import { WidgetProps } from '../registry/model';
@@ -45,6 +52,17 @@ const DocumentsTable: React.FC<WidgetProps> = ({ config, encounterUuids }) => {
   const { t } = useTranslation();
   const { addNotification } = useNotification();
 
+  // Number() safely handles non-numeric config values (NaN → falsy → fallback 10)
+  const configPageSize = Number(config?.pageSize) || 10;
+
+  const [currentPage, setCurrentPage] = useState(1);
+  const [selectedPageSize, setSelectedPageSize] = useState(configPageSize);
+  const [currentFetchUrl, setCurrentFetchUrl] = useState<string | undefined>(
+    undefined,
+  );
+  const [serverTotal, setServerTotal] = useState<number | undefined>(undefined);
+  const pageUrlsCacheRef = useRef<Map<number, string>>(new Map());
+
   const handleViewAttachments = useCallback((doc: DocumentViewModel) => {
     setSelectedDoc(doc);
     setIsModalOpen(true);
@@ -61,10 +79,41 @@ const DocumentsTable: React.FC<WidgetProps> = ({ config, encounterUuids }) => {
   }, []);
 
   const { data, isLoading, isError, error } = useQuery({
-    queryKey: ['documents', patientUUID!, encounterUuids],
+    queryKey: [
+      'documents',
+      patientUUID!,
+      encounterUuids,
+      currentPage,
+      currentFetchUrl ?? null,
+      selectedPageSize,
+    ],
     enabled: !!patientUUID,
-    queryFn: () => getFormattedDocumentReferences(patientUUID!, encounterUuids),
+    queryFn: () =>
+      getDocumentReferencePage(
+        patientUUID!,
+        encounterUuids,
+        selectedPageSize,
+        currentFetchUrl,
+      ),
   });
+
+  // Update server total and cache next page URL when data arrives
+  useEffect(() => {
+    if (data) {
+      setServerTotal(data.total);
+      if (data.nextUrl) {
+        pageUrlsCacheRef.current.set(currentPage + 1, data.nextUrl);
+      }
+    }
+  }, [data, currentPage]);
+
+  // Reset pagination when patient changes
+  useEffect(() => {
+    setCurrentPage(1);
+    setCurrentFetchUrl(undefined);
+    setServerTotal(undefined);
+    pageUrlsCacheRef.current.clear();
+  }, [patientUUID]);
 
   useEffect(() => {
     if (isError) {
@@ -112,19 +161,42 @@ const DocumentsTable: React.FC<WidgetProps> = ({ config, encounterUuids }) => {
     return () => controller.abort();
   }, [isModalOpen, selectedDoc]);
 
+  const handlePageChange = useCallback(
+    (newPage: number, newPageSize: number) => {
+      if (newPageSize !== selectedPageSize) {
+        // Page size changed: reset to page 1, clear URL cache, re-fetch with new _count
+        setSelectedPageSize(newPageSize);
+        setCurrentPage(1);
+        setCurrentFetchUrl(undefined);
+        setServerTotal(undefined);
+        pageUrlsCacheRef.current.clear();
+      } else if (newPage === 1) {
+        setCurrentPage(1);
+        setCurrentFetchUrl(undefined);
+      } else {
+        const url = pageUrlsCacheRef.current.get(newPage);
+        if (url) {
+          setCurrentPage(newPage);
+          setCurrentFetchUrl(url);
+        }
+        // If URL not yet cached (e.g. user jumps pages), ignore the navigation
+      }
+    },
+    [selectedPageSize],
+  );
+
   const fields = useMemo(
     () => (config?.fields as string[]) ?? DEFAULT_DOCUMENT_FIELDS,
     [config?.fields],
   );
 
-  // Number() safely handles non-numeric config values (NaN → falsy → fallback 10)
-  const pageSize = Number(config?.pageSize) || 10;
-
-  // Client-side sort: Bahmni's FHIR translator does not populate DocumentReference.date,
-  // so _sort=-date in the API URL has no effect. Sort is applied here as a fallback.
+  // Client-side sort: applied per-page as a secondary sort. Server-side uses
+  // _sort=-date,-period: sorts by DocumentReference.date first (once backend populates it),
+  // falling back to context.period.start (currently populated by Bahmni) — no frontend
+  // change needed when the backend fix lands.
   const sortedData = useMemo(() => {
-    if (!data) return [];
-    return [...data].sort((a, b) => {
+    const docs = data?.documents ?? [];
+    return [...docs].sort((a, b) => {
       if (!a.uploadedOn && !b.uploadedOn) return 0;
       if (!a.uploadedOn) return 1;
       if (!b.uploadedOn) return -1;
@@ -202,7 +274,10 @@ const DocumentsTable: React.FC<WidgetProps> = ({ config, encounterUuids }) => {
           renderCell={renderCell}
           className={styles.documentsTableBody}
           dataTestId="documents-table"
-          pageSize={pageSize}
+          pageSize={selectedPageSize}
+          totalItems={serverTotal}
+          page={currentPage}
+          onPageChange={handlePageChange}
         />
       </div>
 

--- a/packages/bahmni-widgets/src/documents/DocumentsTable.tsx
+++ b/packages/bahmni-widgets/src/documents/DocumentsTable.tsx
@@ -117,6 +117,18 @@ const DocumentsTable: React.FC<WidgetProps> = ({ config, encounterUuids }) => {
     [config?.fields],
   );
 
+  const pageSize = (config?.pageSize as number) ?? 10;
+
+  const sortedData = useMemo(() => {
+    if (!data) return [];
+    return [...data].sort((a, b) => {
+      if (!a.uploadedOn && !b.uploadedOn) return 0;
+      if (!a.uploadedOn) return 1;
+      if (!b.uploadedOn) return -1;
+      return new Date(b.uploadedOn).getTime() - new Date(a.uploadedOn).getTime();
+    });
+  }, [data]);
+
   const headers = useMemo(() => createDocumentHeaders(fields, t), [fields, t]);
 
   const sortable = useMemo(
@@ -177,7 +189,7 @@ const DocumentsTable: React.FC<WidgetProps> = ({ config, encounterUuids }) => {
         <SortableDataTable
           headers={headers}
           ariaLabel={t('DOCUMENTS_TABLE_HEADING')}
-          rows={data ?? []}
+          rows={sortedData}
           loading={isLoading}
           errorStateMessage={isError ? error?.message : null}
           sortable={sortable}
@@ -185,6 +197,7 @@ const DocumentsTable: React.FC<WidgetProps> = ({ config, encounterUuids }) => {
           renderCell={renderCell}
           className={styles.documentsTableBody}
           dataTestId="documents-table"
+          pageSize={pageSize}
         />
       </div>
 

--- a/packages/bahmni-widgets/src/documents/DocumentsTable.tsx
+++ b/packages/bahmni-widgets/src/documents/DocumentsTable.tsx
@@ -3,7 +3,6 @@ import {
   useTranslation,
   formatDateTime,
   getDocumentReferencePage,
-  DocumentReferencePage,
   DocumentViewModel,
 } from '@bahmni/services';
 import { useQuery } from '@tanstack/react-query';
@@ -46,7 +45,6 @@ const DocumentsTable: React.FC<WidgetProps> = ({ config, encounterUuids }) => {
   const { t } = useTranslation();
   const { addNotification } = useNotification();
 
-  // Number() safely handles non-numeric config values (NaN → falsy → fallback 10)
   const configPageSize = Number(config?.pageSize) || 10;
 
   const [currentPage, setCurrentPage] = useState(1);
@@ -86,14 +84,12 @@ const DocumentsTable: React.FC<WidgetProps> = ({ config, encounterUuids }) => {
       ),
   });
 
-  // Update server total when data arrives
   useEffect(() => {
     if (data) {
       setServerTotal(data.total);
     }
   }, [data]);
 
-  // Reset pagination when patient changes
   useEffect(() => {
     setCurrentPage(1);
     setServerTotal(undefined);
@@ -148,13 +144,10 @@ const DocumentsTable: React.FC<WidgetProps> = ({ config, encounterUuids }) => {
   const handlePageChange = useCallback(
     (newPage: number, newPageSize: number) => {
       if (newPageSize !== selectedPageSize) {
-        // Page size changed: reset to page 1, re-fetch with new _count
         setSelectedPageSize(newPageSize);
         setCurrentPage(1);
         setServerTotal(undefined);
       } else {
-        // Offset-based pagination: any page can be fetched directly via
-        // _getpagesoffset = (page - 1) * _count — no cursor cache needed
         setCurrentPage(newPage);
       }
     },
@@ -166,7 +159,6 @@ const DocumentsTable: React.FC<WidgetProps> = ({ config, encounterUuids }) => {
     [config?.fields],
   );
 
-  // Client-side sort: applied per-page as a secondary sort. Server-side uses _sort=-date.
   const sortedData = useMemo(() => {
     const docs = data?.documents ?? [];
     return [...docs].sort((a, b) => {

--- a/packages/bahmni-widgets/src/documents/DocumentsTable.tsx
+++ b/packages/bahmni-widgets/src/documents/DocumentsTable.tsx
@@ -117,8 +117,11 @@ const DocumentsTable: React.FC<WidgetProps> = ({ config, encounterUuids }) => {
     [config?.fields],
   );
 
-  const pageSize = (config?.pageSize as number) ?? 10;
+  // Number() safely handles non-numeric config values (NaN → falsy → fallback 10)
+  const pageSize = Number(config?.pageSize) || 10;
 
+  // Client-side sort: Bahmni's FHIR translator does not populate DocumentReference.date,
+  // so _sort=-date in the API URL has no effect. Sort is applied here as a fallback.
   const sortedData = useMemo(() => {
     if (!data) return [];
     return [...data].sort((a, b) => {

--- a/packages/bahmni-widgets/src/documents/DocumentsTable.tsx
+++ b/packages/bahmni-widgets/src/documents/DocumentsTable.tsx
@@ -166,10 +166,7 @@ const DocumentsTable: React.FC<WidgetProps> = ({ config, encounterUuids }) => {
     [config?.fields],
   );
 
-  // Client-side sort: applied per-page as a secondary sort. Server-side uses
-  // _sort=-date,-period: sorts by DocumentReference.date first (once backend populates it),
-  // falling back to context.period.start (currently populated by Bahmni) — no frontend
-  // change needed when the backend fix lands.
+  // Client-side sort: applied per-page as a secondary sort. Server-side uses _sort=-date.
   const sortedData = useMemo(() => {
     const docs = data?.documents ?? [];
     return [...docs].sort((a, b) => {

--- a/packages/bahmni-widgets/src/documents/DocumentsTable.tsx
+++ b/packages/bahmni-widgets/src/documents/DocumentsTable.tsx
@@ -125,7 +125,9 @@ const DocumentsTable: React.FC<WidgetProps> = ({ config, encounterUuids }) => {
       if (!a.uploadedOn && !b.uploadedOn) return 0;
       if (!a.uploadedOn) return 1;
       if (!b.uploadedOn) return -1;
-      return new Date(b.uploadedOn).getTime() - new Date(a.uploadedOn).getTime();
+      return (
+        new Date(b.uploadedOn).getTime() - new Date(a.uploadedOn).getTime()
+      );
     });
   }, [data]);
 

--- a/packages/bahmni-widgets/src/documents/DocumentsTable.tsx
+++ b/packages/bahmni-widgets/src/documents/DocumentsTable.tsx
@@ -7,13 +7,7 @@ import {
   DocumentViewModel,
 } from '@bahmni/services';
 import { useQuery } from '@tanstack/react-query';
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { usePatientUUID } from '../hooks/usePatientUUID';
 import { useNotification } from '../notification';
 import { WidgetProps } from '../registry/model';
@@ -57,11 +51,7 @@ const DocumentsTable: React.FC<WidgetProps> = ({ config, encounterUuids }) => {
 
   const [currentPage, setCurrentPage] = useState(1);
   const [selectedPageSize, setSelectedPageSize] = useState(configPageSize);
-  const [currentFetchUrl, setCurrentFetchUrl] = useState<string | undefined>(
-    undefined,
-  );
   const [serverTotal, setServerTotal] = useState<number | undefined>(undefined);
-  const pageUrlsCacheRef = useRef<Map<number, string>>(new Map());
 
   const handleViewAttachments = useCallback((doc: DocumentViewModel) => {
     setSelectedDoc(doc);
@@ -84,7 +74,6 @@ const DocumentsTable: React.FC<WidgetProps> = ({ config, encounterUuids }) => {
       patientUUID!,
       encounterUuids,
       currentPage,
-      currentFetchUrl ?? null,
       selectedPageSize,
     ],
     enabled: !!patientUUID,
@@ -93,26 +82,21 @@ const DocumentsTable: React.FC<WidgetProps> = ({ config, encounterUuids }) => {
         patientUUID!,
         encounterUuids,
         selectedPageSize,
-        currentFetchUrl,
+        currentPage,
       ),
   });
 
-  // Update server total and cache next page URL when data arrives
+  // Update server total when data arrives
   useEffect(() => {
     if (data) {
       setServerTotal(data.total);
-      if (data.nextUrl) {
-        pageUrlsCacheRef.current.set(currentPage + 1, data.nextUrl);
-      }
     }
-  }, [data, currentPage]);
+  }, [data]);
 
   // Reset pagination when patient changes
   useEffect(() => {
     setCurrentPage(1);
-    setCurrentFetchUrl(undefined);
     setServerTotal(undefined);
-    pageUrlsCacheRef.current.clear();
   }, [patientUUID]);
 
   useEffect(() => {
@@ -164,22 +148,14 @@ const DocumentsTable: React.FC<WidgetProps> = ({ config, encounterUuids }) => {
   const handlePageChange = useCallback(
     (newPage: number, newPageSize: number) => {
       if (newPageSize !== selectedPageSize) {
-        // Page size changed: reset to page 1, clear URL cache, re-fetch with new _count
+        // Page size changed: reset to page 1, re-fetch with new _count
         setSelectedPageSize(newPageSize);
         setCurrentPage(1);
-        setCurrentFetchUrl(undefined);
         setServerTotal(undefined);
-        pageUrlsCacheRef.current.clear();
-      } else if (newPage === 1) {
-        setCurrentPage(1);
-        setCurrentFetchUrl(undefined);
       } else {
-        const url = pageUrlsCacheRef.current.get(newPage);
-        if (url) {
-          setCurrentPage(newPage);
-          setCurrentFetchUrl(url);
-        }
-        // If URL not yet cached (e.g. user jumps pages), ignore the navigation
+        // Offset-based pagination: any page can be fetched directly via
+        // _getpagesoffset = (page - 1) * _count — no cursor cache needed
+        setCurrentPage(newPage);
       }
     },
     [selectedPageSize],

--- a/packages/bahmni-widgets/src/documents/__tests__/DocumentsTable.integration.test.tsx
+++ b/packages/bahmni-widgets/src/documents/__tests__/DocumentsTable.integration.test.tsx
@@ -401,7 +401,7 @@ describe('DocumentsTable Integration', () => {
       expect(screen.getByText('Lab_Result_2024')).toBeInTheDocument();
     });
 
-    // Service called with page=2 (offset computed internally: (2-1)*2=2)
+    // Service called with page=2; service computes _getpagesoffset=(2-1)*2=2
     expect(mockedGetDocumentReferencePage).toHaveBeenLastCalledWith(
       'test-patient-uuid',
       undefined,
@@ -706,12 +706,9 @@ describe('DocumentsTable Integration', () => {
     });
 
     it('shows pagination when server total exceeds pageSize', async () => {
-      mockedGetDocumentReferencePage.mockResolvedValueOnce({
-        documents: [prescriptionDoc, xrayDoc],
-        total: 5,
-        nextUrl: '/openmrs/ws/fhir2/R4/DocumentReference?_page=2',
-        prevUrl: undefined,
-      });
+      mockedGetDocumentReferencePage.mockResolvedValueOnce(
+        wrapPage([prescriptionDoc, xrayDoc], 5),
+      );
 
       renderComponent({ config: { ...defaultConfig, pageSize: 2 } });
 

--- a/packages/bahmni-widgets/src/documents/__tests__/DocumentsTable.integration.test.tsx
+++ b/packages/bahmni-widgets/src/documents/__tests__/DocumentsTable.integration.test.tsx
@@ -321,12 +321,12 @@ describe('DocumentsTable Integration', () => {
     });
   });
 
-  it('renders documents in the order returned by the service (latest first)', async () => {
-    // API returns sorted by _sort=-date (latest first):
-    // prescriptionDoc: Jan 15, xrayDoc: Jan 10
+  it('sorts documents by uploadedOn descending regardless of service response order', async () => {
+    // Service returns in ascending order (oldest first) — component must sort descending
     mockedGetFormattedDocumentReferences.mockResolvedValueOnce([
-      prescriptionDoc,
-      xrayDoc,
+      labDoc,          // 2024-01-08 (oldest)
+      xrayDoc,         // 2024-01-10
+      prescriptionDoc, // 2024-01-15 (newest)
     ]);
 
     renderComponent();
@@ -336,9 +336,64 @@ describe('DocumentsTable Integration', () => {
     });
 
     const rows = screen.getAllByRole('row');
-    // rows[0] is the header row; data rows start at index 1
-    expect(rows[1]).toHaveTextContent('Prescription_2024');
-    expect(rows[2]).toHaveTextContent('XRay_Report_2024');
+    // rows[0] = header; component sorts descending so newest appears first
+    expect(rows[1]).toHaveTextContent('Prescription_2024'); // Jan 15 first
+    expect(rows[2]).toHaveTextContent('XRay_Report_2024');  // Jan 10 second
+    expect(rows[3]).toHaveTextContent('Lab_Result_2024');   // Jan 08 last
+  });
+
+  it('places documents with no uploadedOn date at the bottom', async () => {
+    const noDateDoc = {
+      ...prescriptionDoc,
+      id: 'doc-no-date',
+      documentIdentifier: 'No_Date_Doc',
+      uploadedOn: '',
+    };
+    mockedGetFormattedDocumentReferences.mockResolvedValueOnce([
+      noDateDoc,
+      xrayDoc,         // 2024-01-10
+      prescriptionDoc, // 2024-01-15
+    ]);
+
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByText('Prescription_2024')).toBeInTheDocument();
+    });
+
+    const rows = screen.getAllByRole('row');
+    expect(rows[1]).toHaveTextContent('Prescription_2024'); // Jan 15 first
+    expect(rows[2]).toHaveTextContent('XRay_Report_2024');  // Jan 10 second
+    expect(rows[3]).toHaveTextContent('No_Date_Doc');        // no date last
+  });
+
+  it('maintains date desc sort order when navigating to page 2', async () => {
+    const user = userEvent.setup();
+    // 4 docs in ascending order — component sorts desc, page 1 shows newest 2
+    mockedGetFormattedDocumentReferences.mockResolvedValueOnce([
+      labDoc,          // 2024-01-08 (oldest)
+      xrayDoc,         // 2024-01-10
+      prescriptionDoc, // 2024-01-15 (newest)
+      multiAttachmentDoc, // 2024-01-07
+    ]);
+
+    renderComponent({ config: { ...defaultConfig, pageSize: 2 } });
+
+    await waitFor(() => {
+      expect(screen.getByText('Prescription_2024')).toBeInTheDocument();
+    });
+
+    // Page 1: two newest docs
+    expect(screen.getByText('Prescription_2024')).toBeInTheDocument(); // Jan 15
+    expect(screen.getByText('XRay_Report_2024')).toBeInTheDocument();  // Jan 10
+    expect(screen.queryByText('Lab_Result_2024')).not.toBeInTheDocument();
+
+    // Navigate to page 2: next two in desc order
+    await user.click(screen.getByRole('button', { name: /next page/i }));
+
+    expect(screen.getByText('Lab_Result_2024')).toBeInTheDocument();        // Jan 08
+    expect(screen.getByText('MultiPage_Report_2024')).toBeInTheDocument();  // Jan 07
+    expect(screen.queryByText('Prescription_2024')).not.toBeInTheDocument();
   });
 
   it('accepts and passes pageSize configuration to SortableDataTable', async () => {
@@ -436,5 +491,93 @@ describe('DocumentsTable Integration', () => {
     await act(async () => {});
 
     expect(mockedGetFormattedDocumentReferences).not.toHaveBeenCalled();
+  });
+
+  describe('Pagination', () => {
+    beforeEach(() => {
+      (usePatientUUID as jest.Mock).mockReturnValue('test-patient-uuid');
+      mockedGetFormattedDocumentReferences.mockReset();
+    });
+
+    it('renders table with all documents loaded from service regardless of pageSize', async () => {
+      mockedGetFormattedDocumentReferences.mockResolvedValueOnce([
+        prescriptionDoc,
+        xrayDoc,
+        labDoc,
+      ]);
+
+      renderComponent({ config: { ...defaultConfig, pageSize: 10 } });
+
+      await waitFor(() => {
+        expect(screen.getByText('Prescription_2024')).toBeInTheDocument();
+      });
+
+      expect(screen.getByText('XRay_Report_2024')).toBeInTheDocument();
+      expect(screen.getByText('Lab_Result_2024')).toBeInTheDocument();
+    });
+
+    it('hides pagination when documents are fewer than or equal to pageSize', async () => {
+      mockedGetFormattedDocumentReferences.mockResolvedValueOnce([
+        prescriptionDoc,
+        xrayDoc,
+      ]);
+
+      renderComponent({ config: { ...defaultConfig, pageSize: 10 } });
+
+      await waitFor(() => {
+        expect(screen.getByText('Prescription_2024')).toBeInTheDocument();
+      });
+
+      expect(screen.queryByRole('button', { name: /next page/i })).not.toBeInTheDocument();
+    });
+
+    it('fetches all documents from service when pageSize is configured', async () => {
+      mockedGetFormattedDocumentReferences.mockResolvedValueOnce([
+        prescriptionDoc,
+        xrayDoc,
+        labDoc,
+      ]);
+
+      renderComponent({ config: { ...defaultConfig, pageSize: 5 } });
+
+      await waitFor(() => {
+        expect(mockedGetFormattedDocumentReferences).toHaveBeenCalledWith(
+          'test-patient-uuid',
+          undefined,
+        );
+      });
+    });
+
+    it('modal still works when pageSize is configured', async () => {
+      const user = userEvent.setup();
+      mockedGetFormattedDocumentReferences.mockResolvedValueOnce([
+        prescriptionDoc,
+      ]);
+
+      renderComponent({ config: { ...defaultConfig, pageSize: 10 } });
+
+      await waitFor(() => {
+        expect(screen.getByText('Prescription_2024')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByText('DOCUMENTS_VIEW_ATTACHMENTS'));
+
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    it('renders with default pageSize of 10 when not specified in config', async () => {
+      mockedGetFormattedDocumentReferences.mockResolvedValueOnce([
+        prescriptionDoc,
+        xrayDoc,
+      ]);
+
+      renderComponent();
+
+      await waitFor(() => {
+        expect(screen.getByText('Prescription_2024')).toBeInTheDocument();
+      });
+
+      expect(screen.getByText('XRay_Report_2024')).toBeInTheDocument();
+    });
   });
 });

--- a/packages/bahmni-widgets/src/documents/__tests__/DocumentsTable.integration.test.tsx
+++ b/packages/bahmni-widgets/src/documents/__tests__/DocumentsTable.integration.test.tsx
@@ -324,8 +324,8 @@ describe('DocumentsTable Integration', () => {
   it('sorts documents by uploadedOn descending regardless of service response order', async () => {
     // Service returns in ascending order (oldest first) — component must sort descending
     mockedGetFormattedDocumentReferences.mockResolvedValueOnce([
-      labDoc,          // 2024-01-08 (oldest)
-      xrayDoc,         // 2024-01-10
+      labDoc, // 2024-01-08 (oldest)
+      xrayDoc, // 2024-01-10
       prescriptionDoc, // 2024-01-15 (newest)
     ]);
 
@@ -338,8 +338,8 @@ describe('DocumentsTable Integration', () => {
     const rows = screen.getAllByRole('row');
     // rows[0] = header; component sorts descending so newest appears first
     expect(rows[1]).toHaveTextContent('Prescription_2024'); // Jan 15 first
-    expect(rows[2]).toHaveTextContent('XRay_Report_2024');  // Jan 10 second
-    expect(rows[3]).toHaveTextContent('Lab_Result_2024');   // Jan 08 last
+    expect(rows[2]).toHaveTextContent('XRay_Report_2024'); // Jan 10 second
+    expect(rows[3]).toHaveTextContent('Lab_Result_2024'); // Jan 08 last
   });
 
   it('places documents with no uploadedOn date at the bottom', async () => {
@@ -351,7 +351,7 @@ describe('DocumentsTable Integration', () => {
     };
     mockedGetFormattedDocumentReferences.mockResolvedValueOnce([
       noDateDoc,
-      xrayDoc,         // 2024-01-10
+      xrayDoc, // 2024-01-10
       prescriptionDoc, // 2024-01-15
     ]);
 
@@ -363,16 +363,16 @@ describe('DocumentsTable Integration', () => {
 
     const rows = screen.getAllByRole('row');
     expect(rows[1]).toHaveTextContent('Prescription_2024'); // Jan 15 first
-    expect(rows[2]).toHaveTextContent('XRay_Report_2024');  // Jan 10 second
-    expect(rows[3]).toHaveTextContent('No_Date_Doc');        // no date last
+    expect(rows[2]).toHaveTextContent('XRay_Report_2024'); // Jan 10 second
+    expect(rows[3]).toHaveTextContent('No_Date_Doc'); // no date last
   });
 
   it('maintains date desc sort order when navigating to page 2', async () => {
     const user = userEvent.setup();
     // 4 docs in ascending order — component sorts desc, page 1 shows newest 2
     mockedGetFormattedDocumentReferences.mockResolvedValueOnce([
-      labDoc,          // 2024-01-08 (oldest)
-      xrayDoc,         // 2024-01-10
+      labDoc, // 2024-01-08 (oldest)
+      xrayDoc, // 2024-01-10
       prescriptionDoc, // 2024-01-15 (newest)
       multiAttachmentDoc, // 2024-01-07
     ]);
@@ -385,14 +385,14 @@ describe('DocumentsTable Integration', () => {
 
     // Page 1: two newest docs
     expect(screen.getByText('Prescription_2024')).toBeInTheDocument(); // Jan 15
-    expect(screen.getByText('XRay_Report_2024')).toBeInTheDocument();  // Jan 10
+    expect(screen.getByText('XRay_Report_2024')).toBeInTheDocument(); // Jan 10
     expect(screen.queryByText('Lab_Result_2024')).not.toBeInTheDocument();
 
     // Navigate to page 2: next two in desc order
     await user.click(screen.getByRole('button', { name: /next page/i }));
 
-    expect(screen.getByText('Lab_Result_2024')).toBeInTheDocument();        // Jan 08
-    expect(screen.getByText('MultiPage_Report_2024')).toBeInTheDocument();  // Jan 07
+    expect(screen.getByText('Lab_Result_2024')).toBeInTheDocument(); // Jan 08
+    expect(screen.getByText('MultiPage_Report_2024')).toBeInTheDocument(); // Jan 07
     expect(screen.queryByText('Prescription_2024')).not.toBeInTheDocument();
   });
 
@@ -528,7 +528,9 @@ describe('DocumentsTable Integration', () => {
         expect(screen.getByText('Prescription_2024')).toBeInTheDocument();
       });
 
-      expect(screen.queryByRole('button', { name: /next page/i })).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: /next page/i }),
+      ).not.toBeInTheDocument();
     });
 
     it('fetches all documents from service when pageSize is configured', async () => {

--- a/packages/bahmni-widgets/src/documents/__tests__/DocumentsTable.integration.test.tsx
+++ b/packages/bahmni-widgets/src/documents/__tests__/DocumentsTable.integration.test.tsx
@@ -1,5 +1,5 @@
 import {
-  getFormattedDocumentReferences,
+  getDocumentReferencePage,
   useSubscribeConsultationSaved,
   DEFAULT_DATE_FORMAT_STORAGE_KEY,
 } from '@bahmni/services';
@@ -18,7 +18,7 @@ jest.mock('../../hooks/usePatientUUID', () => ({
 jest.mock('@bahmni/services', () => ({
   ...jest.requireActual('@bahmni/services'),
   useTranslation: () => ({ t: (key: string) => key }),
-  getFormattedDocumentReferences: jest.fn(),
+  getDocumentReferencePage: jest.fn(),
   useSubscribeConsultationSaved: jest.fn(),
 }));
 
@@ -30,10 +30,18 @@ globalThis.fetch = jest.fn(() =>
   } as Response),
 );
 
-const mockedGetFormattedDocumentReferences =
-  getFormattedDocumentReferences as jest.MockedFunction<
-    typeof getFormattedDocumentReferences
+const mockedGetDocumentReferencePage =
+  getDocumentReferencePage as jest.MockedFunction<
+    typeof getDocumentReferencePage
   >;
+
+const wrapPage = (documents: any[], nextUrl?: string, prevUrl?: string) => ({
+  documents,
+  total: documents.length,
+  nextUrl,
+  prevUrl,
+});
+
 const mockAddNotification = jest.fn();
 
 const prescriptionDoc = {
@@ -131,9 +139,9 @@ describe('DocumentsTable Integration', () => {
   });
 
   it('displays patient documents with all clinical information after fetch', async () => {
-    mockedGetFormattedDocumentReferences.mockResolvedValueOnce([
-      prescriptionDoc,
-    ]);
+    mockedGetDocumentReferencePage.mockResolvedValueOnce(
+      wrapPage([prescriptionDoc]),
+    );
 
     renderComponent();
 
@@ -149,7 +157,7 @@ describe('DocumentsTable Integration', () => {
   });
 
   it('shows empty state when patient has no recorded documents', async () => {
-    mockedGetFormattedDocumentReferences.mockResolvedValueOnce([]);
+    mockedGetDocumentReferencePage.mockResolvedValueOnce(wrapPage([]));
 
     renderComponent();
 
@@ -160,7 +168,7 @@ describe('DocumentsTable Integration', () => {
 
   it('shows error notification when document data cannot be fetched', async () => {
     const errorMessage = 'Failed to fetch documents';
-    mockedGetFormattedDocumentReferences.mockRejectedValueOnce(
+    mockedGetDocumentReferencePage.mockRejectedValueOnce(
       new Error(errorMessage),
     );
 
@@ -178,11 +186,9 @@ describe('DocumentsTable Integration', () => {
   });
 
   it('displays multiple documents with "View attachment/s" links (no icons)', async () => {
-    mockedGetFormattedDocumentReferences.mockResolvedValueOnce([
-      prescriptionDoc,
-      xrayDoc,
-      labDoc,
-    ]);
+    mockedGetDocumentReferencePage.mockResolvedValueOnce(
+      wrapPage([prescriptionDoc, xrayDoc, labDoc]),
+    );
 
     renderComponent();
 
@@ -205,9 +211,9 @@ describe('DocumentsTable Integration', () => {
 
   it('opens modal with PDF iframe when "View attachment/s" is clicked', async () => {
     const user = userEvent.setup();
-    mockedGetFormattedDocumentReferences.mockResolvedValueOnce([
-      prescriptionDoc,
-    ]);
+    mockedGetDocumentReferencePage.mockResolvedValueOnce(
+      wrapPage([prescriptionDoc]),
+    );
 
     renderComponent();
 
@@ -230,7 +236,7 @@ describe('DocumentsTable Integration', () => {
 
   it('opens modal with img element when image document link is clicked', async () => {
     const user = userEvent.setup();
-    mockedGetFormattedDocumentReferences.mockResolvedValueOnce([xrayDoc]);
+    mockedGetDocumentReferencePage.mockResolvedValueOnce(wrapPage([xrayDoc]));
 
     renderComponent();
 
@@ -247,9 +253,9 @@ describe('DocumentsTable Integration', () => {
 
   it('shows all attachments in modal for a document with multiple content entries', async () => {
     const user = userEvent.setup();
-    mockedGetFormattedDocumentReferences.mockResolvedValueOnce([
-      multiAttachmentDoc,
-    ]);
+    mockedGetDocumentReferencePage.mockResolvedValueOnce(
+      wrapPage([multiAttachmentDoc]),
+    );
 
     renderComponent();
 
@@ -270,9 +276,9 @@ describe('DocumentsTable Integration', () => {
 
   it('closes modal after clicking close button', async () => {
     const user = userEvent.setup();
-    mockedGetFormattedDocumentReferences.mockResolvedValueOnce([
-      prescriptionDoc,
-    ]);
+    mockedGetDocumentReferencePage.mockResolvedValueOnce(
+      wrapPage([prescriptionDoc]),
+    );
 
     renderComponent();
 
@@ -291,31 +297,35 @@ describe('DocumentsTable Integration', () => {
   });
 
   it('passes encounterUuids filter to service when provided', async () => {
-    mockedGetFormattedDocumentReferences.mockResolvedValueOnce([
-      prescriptionDoc,
-    ]);
+    mockedGetDocumentReferencePage.mockResolvedValueOnce(
+      wrapPage([prescriptionDoc]),
+    );
 
     const encounterUuids = ['encounter-uuid-1', 'encounter-uuid-2'];
     renderComponent({ encounterUuids });
 
     await waitFor(() => {
-      expect(mockedGetFormattedDocumentReferences).toHaveBeenCalledWith(
+      expect(mockedGetDocumentReferencePage).toHaveBeenCalledWith(
         'test-patient-uuid',
         encounterUuids,
+        10,
+        undefined,
       );
     });
   });
 
   it('calls service without encounter filter when encounterUuids is not provided', async () => {
-    mockedGetFormattedDocumentReferences.mockResolvedValueOnce([
-      prescriptionDoc,
-    ]);
+    mockedGetDocumentReferencePage.mockResolvedValueOnce(
+      wrapPage([prescriptionDoc]),
+    );
 
     renderComponent();
 
     await waitFor(() => {
-      expect(mockedGetFormattedDocumentReferences).toHaveBeenCalledWith(
+      expect(mockedGetDocumentReferencePage).toHaveBeenCalledWith(
         'test-patient-uuid',
+        undefined,
+        10,
         undefined,
       );
     });
@@ -323,11 +333,13 @@ describe('DocumentsTable Integration', () => {
 
   it('sorts documents by uploadedOn descending regardless of service response order', async () => {
     // Service returns in ascending order (oldest first) — component must sort descending
-    mockedGetFormattedDocumentReferences.mockResolvedValueOnce([
-      labDoc, // 2024-01-08 (oldest)
-      xrayDoc, // 2024-01-10
-      prescriptionDoc, // 2024-01-15 (newest)
-    ]);
+    mockedGetDocumentReferencePage.mockResolvedValueOnce(
+      wrapPage([
+        labDoc, // 2024-01-08 (oldest)
+        xrayDoc, // 2024-01-10
+        prescriptionDoc, // 2024-01-15 (newest)
+      ]),
+    );
 
     renderComponent();
 
@@ -349,11 +361,13 @@ describe('DocumentsTable Integration', () => {
       documentIdentifier: 'No_Date_Doc',
       uploadedOn: '',
     };
-    mockedGetFormattedDocumentReferences.mockResolvedValueOnce([
-      noDateDoc,
-      xrayDoc, // 2024-01-10
-      prescriptionDoc, // 2024-01-15
-    ]);
+    mockedGetDocumentReferencePage.mockResolvedValueOnce(
+      wrapPage([
+        noDateDoc,
+        xrayDoc, // 2024-01-10
+        prescriptionDoc, // 2024-01-15
+      ]),
+    );
 
     renderComponent();
 
@@ -367,15 +381,26 @@ describe('DocumentsTable Integration', () => {
     expect(rows[3]).toHaveTextContent('No_Date_Doc'); // no date last
   });
 
-  it('maintains date desc sort order when navigating to page 2', async () => {
+  it('navigates to page 2 when server provides nextUrl', async () => {
     const user = userEvent.setup();
-    // 4 docs in ascending order — component sorts desc, page 1 shows newest 2
-    mockedGetFormattedDocumentReferences.mockResolvedValueOnce([
-      labDoc, // 2024-01-08 (oldest)
-      xrayDoc, // 2024-01-10
-      prescriptionDoc, // 2024-01-15 (newest)
-      multiAttachmentDoc, // 2024-01-07
-    ]);
+    const nextPageUrl =
+      '/openmrs/ws/fhir2/R4/DocumentReference?patient=test-patient-uuid&_sort=-date&_count=2&_page=2';
+
+    // Page 1: newest 2 docs, server provides nextUrl
+    mockedGetDocumentReferencePage.mockResolvedValueOnce({
+      documents: [prescriptionDoc, xrayDoc],
+      total: 4,
+      nextUrl: nextPageUrl,
+      prevUrl: undefined,
+    });
+
+    // Page 2: older 2 docs
+    mockedGetDocumentReferencePage.mockResolvedValueOnce({
+      documents: [labDoc, multiAttachmentDoc],
+      total: 4,
+      nextUrl: undefined,
+      prevUrl: '/openmrs/ws/fhir2/R4/DocumentReference?_page=1',
+    });
 
     renderComponent({ config: { ...defaultConfig, pageSize: 2 } });
 
@@ -383,25 +408,25 @@ describe('DocumentsTable Integration', () => {
       expect(screen.getByText('Prescription_2024')).toBeInTheDocument();
     });
 
-    // Page 1: two newest docs
-    expect(screen.getByText('Prescription_2024')).toBeInTheDocument(); // Jan 15
-    expect(screen.getByText('XRay_Report_2024')).toBeInTheDocument(); // Jan 10
-    expect(screen.queryByText('Lab_Result_2024')).not.toBeInTheDocument();
+    // Page 1: first two docs visible
+    expect(screen.getByText('Prescription_2024')).toBeInTheDocument();
+    expect(screen.getByText('XRay_Report_2024')).toBeInTheDocument();
 
-    // Navigate to page 2: next two in desc order
+    // Navigate to page 2
     await user.click(screen.getByRole('button', { name: /next page/i }));
 
-    expect(screen.getByText('Lab_Result_2024')).toBeInTheDocument(); // Jan 08
-    expect(screen.getByText('MultiPage_Report_2024')).toBeInTheDocument(); // Jan 07
+    await waitFor(() => {
+      expect(screen.getByText('Lab_Result_2024')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('MultiPage_Report_2024')).toBeInTheDocument();
     expect(screen.queryByText('Prescription_2024')).not.toBeInTheDocument();
   });
 
   it('accepts and passes pageSize configuration to SortableDataTable', async () => {
-    mockedGetFormattedDocumentReferences.mockResolvedValueOnce([
-      prescriptionDoc,
-      xrayDoc,
-      labDoc,
-    ]);
+    mockedGetDocumentReferencePage.mockResolvedValueOnce(
+      wrapPage([prescriptionDoc, xrayDoc, labDoc]),
+    );
 
     // Render with pageSize configuration
     renderComponent({ config: { ...defaultConfig, pageSize: 2 } });
@@ -416,32 +441,30 @@ describe('DocumentsTable Integration', () => {
   });
 
   it('documents are fetched correctly when pageSize is configured', async () => {
-    mockedGetFormattedDocumentReferences.mockResolvedValueOnce([
-      prescriptionDoc,
-      xrayDoc,
-      labDoc,
-    ]);
+    mockedGetDocumentReferencePage.mockResolvedValueOnce(
+      wrapPage([prescriptionDoc, xrayDoc, labDoc]),
+    );
 
     // Render with pageSize=2
     renderComponent({ config: { ...defaultConfig, pageSize: 2 } });
 
     await waitFor(() => {
-      expect(mockedGetFormattedDocumentReferences).toHaveBeenCalled();
+      expect(mockedGetDocumentReferencePage).toHaveBeenCalled();
     });
 
-    // All documents should be fetched by the service
-    expect(mockedGetFormattedDocumentReferences).toHaveBeenCalledWith(
+    // Service is called with the configured pageSize
+    expect(mockedGetDocumentReferencePage).toHaveBeenCalledWith(
       'test-patient-uuid',
+      undefined,
+      2,
       undefined,
     );
   });
 
   it('renders documents correctly without pageSize configuration', async () => {
-    mockedGetFormattedDocumentReferences.mockResolvedValueOnce([
-      prescriptionDoc,
-      xrayDoc,
-      labDoc,
-    ]);
+    mockedGetDocumentReferencePage.mockResolvedValueOnce(
+      wrapPage([prescriptionDoc, xrayDoc, labDoc]),
+    );
 
     // Render with default config (no pageSize)
     renderComponent();
@@ -451,7 +474,7 @@ describe('DocumentsTable Integration', () => {
     });
 
     // All 3 documents should be fetchable from service
-    expect(mockedGetFormattedDocumentReferences).toHaveBeenCalled();
+    expect(mockedGetDocumentReferencePage).toHaveBeenCalled();
   });
 
   it('does not refetch documents when consultation saved for a different patient', async () => {
@@ -462,9 +485,9 @@ describe('DocumentsTable Integration', () => {
       },
     );
 
-    mockedGetFormattedDocumentReferences.mockResolvedValueOnce([
-      prescriptionDoc,
-    ]);
+    mockedGetDocumentReferencePage.mockResolvedValueOnce(
+      wrapPage([prescriptionDoc]),
+    );
 
     renderComponent();
 
@@ -478,33 +501,31 @@ describe('DocumentsTable Integration', () => {
 
     await act(async () => {});
 
-    expect(mockedGetFormattedDocumentReferences).toHaveBeenCalledTimes(1);
+    expect(mockedGetDocumentReferencePage).toHaveBeenCalledTimes(1);
   });
 
   it('does not call the API when patientUUID is null', async () => {
     (usePatientUUID as jest.Mock).mockReturnValue(null);
-    mockedGetFormattedDocumentReferences.mockResolvedValueOnce([]);
+    mockedGetDocumentReferencePage.mockResolvedValueOnce(wrapPage([]));
 
     renderComponent();
 
     // Wait a render cycle to ensure no query fires
     await act(async () => {});
 
-    expect(mockedGetFormattedDocumentReferences).not.toHaveBeenCalled();
+    expect(mockedGetDocumentReferencePage).not.toHaveBeenCalled();
   });
 
   describe('Pagination', () => {
     beforeEach(() => {
       (usePatientUUID as jest.Mock).mockReturnValue('test-patient-uuid');
-      mockedGetFormattedDocumentReferences.mockReset();
+      mockedGetDocumentReferencePage.mockReset();
     });
 
     it('renders table with all documents loaded from service regardless of pageSize', async () => {
-      mockedGetFormattedDocumentReferences.mockResolvedValueOnce([
-        prescriptionDoc,
-        xrayDoc,
-        labDoc,
-      ]);
+      mockedGetDocumentReferencePage.mockResolvedValueOnce(
+        wrapPage([prescriptionDoc, xrayDoc, labDoc]),
+      );
 
       renderComponent({ config: { ...defaultConfig, pageSize: 10 } });
 
@@ -516,11 +537,10 @@ describe('DocumentsTable Integration', () => {
       expect(screen.getByText('Lab_Result_2024')).toBeInTheDocument();
     });
 
-    it('hides pagination when documents are fewer than or equal to pageSize', async () => {
-      mockedGetFormattedDocumentReferences.mockResolvedValueOnce([
-        prescriptionDoc,
-        xrayDoc,
-      ]);
+    it('hides pagination when server total is fewer than or equal to pageSize', async () => {
+      mockedGetDocumentReferencePage.mockResolvedValueOnce(
+        wrapPage([prescriptionDoc, xrayDoc]),
+      );
 
       renderComponent({ config: { ...defaultConfig, pageSize: 10 } });
 
@@ -533,18 +553,18 @@ describe('DocumentsTable Integration', () => {
       ).not.toBeInTheDocument();
     });
 
-    it('fetches all documents from service when pageSize is configured', async () => {
-      mockedGetFormattedDocumentReferences.mockResolvedValueOnce([
-        prescriptionDoc,
-        xrayDoc,
-        labDoc,
-      ]);
+    it('fetches documents from service with configured pageSize', async () => {
+      mockedGetDocumentReferencePage.mockResolvedValueOnce(
+        wrapPage([prescriptionDoc, xrayDoc, labDoc]),
+      );
 
       renderComponent({ config: { ...defaultConfig, pageSize: 5 } });
 
       await waitFor(() => {
-        expect(mockedGetFormattedDocumentReferences).toHaveBeenCalledWith(
+        expect(mockedGetDocumentReferencePage).toHaveBeenCalledWith(
           'test-patient-uuid',
+          undefined,
+          5,
           undefined,
         );
       });
@@ -552,9 +572,9 @@ describe('DocumentsTable Integration', () => {
 
     it('modal still works when pageSize is configured', async () => {
       const user = userEvent.setup();
-      mockedGetFormattedDocumentReferences.mockResolvedValueOnce([
-        prescriptionDoc,
-      ]);
+      mockedGetDocumentReferencePage.mockResolvedValueOnce(
+        wrapPage([prescriptionDoc]),
+      );
 
       renderComponent({ config: { ...defaultConfig, pageSize: 10 } });
 
@@ -568,10 +588,9 @@ describe('DocumentsTable Integration', () => {
     });
 
     it('renders with default pageSize of 10 when not specified in config', async () => {
-      mockedGetFormattedDocumentReferences.mockResolvedValueOnce([
-        prescriptionDoc,
-        xrayDoc,
-      ]);
+      mockedGetDocumentReferencePage.mockResolvedValueOnce(
+        wrapPage([prescriptionDoc, xrayDoc]),
+      );
 
       renderComponent();
 
@@ -580,6 +599,25 @@ describe('DocumentsTable Integration', () => {
       });
 
       expect(screen.getByText('XRay_Report_2024')).toBeInTheDocument();
+    });
+
+    it('shows pagination when server total exceeds pageSize', async () => {
+      mockedGetDocumentReferencePage.mockResolvedValueOnce({
+        documents: [prescriptionDoc, xrayDoc],
+        total: 5,
+        nextUrl: '/openmrs/ws/fhir2/R4/DocumentReference?_page=2',
+        prevUrl: undefined,
+      });
+
+      renderComponent({ config: { ...defaultConfig, pageSize: 2 } });
+
+      await waitFor(() => {
+        expect(screen.getByText('Prescription_2024')).toBeInTheDocument();
+      });
+
+      expect(
+        screen.getByRole('button', { name: /next page/i }),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/packages/bahmni-widgets/src/documents/__tests__/DocumentsTable.integration.test.tsx
+++ b/packages/bahmni-widgets/src/documents/__tests__/DocumentsTable.integration.test.tsx
@@ -35,11 +35,9 @@ const mockedGetDocumentReferencePage =
     typeof getDocumentReferencePage
   >;
 
-const wrapPage = (documents: any[], nextUrl?: string, prevUrl?: string) => ({
+const wrapPage = (documents: any[], total?: number) => ({
   documents,
-  total: documents.length,
-  nextUrl,
-  prevUrl,
+  total: total ?? documents.length,
 });
 
 const mockAddNotification = jest.fn();
@@ -309,7 +307,7 @@ describe('DocumentsTable Integration', () => {
         'test-patient-uuid',
         encounterUuids,
         10,
-        undefined,
+        1,
       );
     });
   });
@@ -326,7 +324,7 @@ describe('DocumentsTable Integration', () => {
         'test-patient-uuid',
         undefined,
         10,
-        undefined,
+        1,
       );
     });
   });
@@ -381,26 +379,15 @@ describe('DocumentsTable Integration', () => {
     expect(rows[3]).toHaveTextContent('No_Date_Doc'); // no date last
   });
 
-  it('navigates to page 2 when server provides nextUrl', async () => {
+  it('navigates to page 2 via offset-based fetch', async () => {
     const user = userEvent.setup();
-    const nextPageUrl =
-      '/openmrs/ws/fhir2/R4/DocumentReference?patient=test-patient-uuid&_sort=-date&_count=2&_page=2';
 
-    // Page 1: newest 2 docs, server provides nextUrl
-    mockedGetDocumentReferencePage.mockResolvedValueOnce({
-      documents: [prescriptionDoc, xrayDoc],
-      total: 4,
-      nextUrl: nextPageUrl,
-      prevUrl: undefined,
-    });
-
-    // Page 2: older 2 docs
-    mockedGetDocumentReferencePage.mockResolvedValueOnce({
-      documents: [labDoc, multiAttachmentDoc],
-      total: 4,
-      nextUrl: undefined,
-      prevUrl: '/openmrs/ws/fhir2/R4/DocumentReference?_page=1',
-    });
+    mockedGetDocumentReferencePage.mockResolvedValueOnce(
+      wrapPage([prescriptionDoc, xrayDoc], 4),
+    );
+    mockedGetDocumentReferencePage.mockResolvedValueOnce(
+      wrapPage([labDoc, multiAttachmentDoc], 4),
+    );
 
     renderComponent({ config: { ...defaultConfig, pageSize: 2 } });
 
@@ -408,19 +395,136 @@ describe('DocumentsTable Integration', () => {
       expect(screen.getByText('Prescription_2024')).toBeInTheDocument();
     });
 
-    // Page 1: first two docs visible
-    expect(screen.getByText('Prescription_2024')).toBeInTheDocument();
-    expect(screen.getByText('XRay_Report_2024')).toBeInTheDocument();
-
-    // Navigate to page 2
     await user.click(screen.getByRole('button', { name: /next page/i }));
 
     await waitFor(() => {
       expect(screen.getByText('Lab_Result_2024')).toBeInTheDocument();
     });
 
-    expect(screen.getByText('MultiPage_Report_2024')).toBeInTheDocument();
+    // Service called with page=2 (offset computed internally: (2-1)*2=2)
+    expect(mockedGetDocumentReferencePage).toHaveBeenLastCalledWith(
+      'test-patient-uuid',
+      undefined,
+      2,
+      2,
+    );
     expect(screen.queryByText('Prescription_2024')).not.toBeInTheDocument();
+  });
+
+  it('navigates back to page 1 when previous button is clicked', async () => {
+    const user = userEvent.setup();
+
+    mockedGetDocumentReferencePage.mockResolvedValueOnce(
+      wrapPage([prescriptionDoc, xrayDoc], 4),
+    );
+    mockedGetDocumentReferencePage.mockResolvedValueOnce(
+      wrapPage([labDoc, multiAttachmentDoc], 4),
+    );
+    mockedGetDocumentReferencePage.mockResolvedValueOnce(
+      wrapPage([prescriptionDoc, xrayDoc], 4),
+    );
+
+    renderComponent({ config: { ...defaultConfig, pageSize: 2 } });
+
+    await waitFor(() => {
+      expect(screen.getByText('Prescription_2024')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: /next page/i }));
+    await waitFor(() => {
+      expect(screen.getByText('Lab_Result_2024')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: /previous page/i }));
+    await waitFor(() => {
+      expect(screen.getByText('Prescription_2024')).toBeInTheDocument();
+    });
+
+    // Service called with page=1 (offset=0)
+    expect(mockedGetDocumentReferencePage).toHaveBeenLastCalledWith(
+      'test-patient-uuid',
+      undefined,
+      2,
+      1,
+    );
+    expect(screen.queryByText('Lab_Result_2024')).not.toBeInTheDocument();
+  });
+
+  it('re-fetches from page 1 when page size is changed via dropdown', async () => {
+    const user = userEvent.setup();
+
+    mockedGetDocumentReferencePage.mockResolvedValueOnce(
+      wrapPage([prescriptionDoc, xrayDoc], 4),
+    );
+    mockedGetDocumentReferencePage.mockResolvedValueOnce(
+      wrapPage([prescriptionDoc, xrayDoc, labDoc, multiAttachmentDoc], 4),
+    );
+
+    renderComponent({ config: { ...defaultConfig, pageSize: 2 } });
+
+    await waitFor(() => {
+      expect(screen.getByText('Prescription_2024')).toBeInTheDocument();
+    });
+
+    const select = screen.getByRole('combobox', { name: /items per page/i });
+    await user.selectOptions(select, '5');
+
+    await waitFor(() => {
+      expect(mockedGetDocumentReferencePage).toHaveBeenCalledTimes(2);
+    });
+
+    // Re-fetch from page 1 with new page size
+    expect(mockedGetDocumentReferencePage).toHaveBeenLastCalledWith(
+      'test-patient-uuid',
+      undefined,
+      5,
+      1,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Lab_Result_2024')).toBeInTheDocument();
+    });
+  });
+
+  it('jumps directly to any page using offset (no sequential traversal needed)', async () => {
+    const user = userEvent.setup();
+
+    // Page 1 response (total=10 → 5 pages with pageSize=2)
+    mockedGetDocumentReferencePage.mockResolvedValueOnce(
+      wrapPage([prescriptionDoc, xrayDoc], 10),
+    );
+
+    // Page 5 response fetched directly via offset
+    mockedGetDocumentReferencePage.mockResolvedValueOnce(
+      wrapPage([labDoc, multiAttachmentDoc], 10),
+    );
+
+    renderComponent({ config: { ...defaultConfig, pageSize: 2 } });
+
+    await waitFor(() => {
+      expect(screen.getByText('Prescription_2024')).toBeInTheDocument();
+    });
+
+    // Jump to page 5 directly via page number combobox
+    const pageSelect = screen.getByRole('combobox', {
+      name: /page of \d+ pages/i,
+    });
+    await user.selectOptions(pageSelect, '5');
+
+    // Service called with page=5 directly (offset = (5-1)*2 = 8)
+    await waitFor(() => {
+      expect(mockedGetDocumentReferencePage).toHaveBeenCalledTimes(2);
+    });
+    expect(mockedGetDocumentReferencePage).toHaveBeenLastCalledWith(
+      'test-patient-uuid',
+      undefined,
+      2,
+      5,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Lab_Result_2024')).toBeInTheDocument();
+    });
   });
 
   it('accepts and passes pageSize configuration to SortableDataTable', async () => {
@@ -452,12 +556,12 @@ describe('DocumentsTable Integration', () => {
       expect(mockedGetDocumentReferencePage).toHaveBeenCalled();
     });
 
-    // Service is called with the configured pageSize
+    // Service is called with the configured pageSize and page 1
     expect(mockedGetDocumentReferencePage).toHaveBeenCalledWith(
       'test-patient-uuid',
       undefined,
       2,
-      undefined,
+      1,
     );
   });
 
@@ -565,7 +669,7 @@ describe('DocumentsTable Integration', () => {
           'test-patient-uuid',
           undefined,
           5,
-          undefined,
+          1,
         );
       });
     });

--- a/packages/bahmni-widgets/src/documents/__tests__/DocumentsTable.test.tsx
+++ b/packages/bahmni-widgets/src/documents/__tests__/DocumentsTable.test.tsx
@@ -785,6 +785,144 @@ describe('DocumentsTable', () => {
     });
   });
 
+  describe('Pagination', () => {
+    const manyDocs = Array.from({ length: 12 }, (_, i) => ({
+      id: `doc-page-${i}`,
+      documentIdentifier: `Document ${i + 1}`,
+      documentType: 'Notes',
+      uploadedOn: '2024-01-01T00:00:00Z',
+      uploadedBy: `Dr. ${i + 1}`,
+      contentType: 'application/pdf',
+      documentUrl: `100/doc-${i}.pdf`,
+      attachments: [{ url: `100/doc-${i}.pdf`, contentType: 'application/pdf' }],
+    }));
+
+    it('renders pagination when documents exceed default pageSize of 10', () => {
+      (useQuery as jest.Mock).mockReturnValue(mockQueryData(manyDocs));
+      renderComponent({ config: defaultConfig });
+
+      expect(screen.getByRole('button', { name: /next page/i })).toBeInTheDocument();
+    });
+
+    it('hides pagination when documents are fewer than or equal to pageSize', () => {
+      (useQuery as jest.Mock).mockReturnValue(
+        mockQueryData([mockPdfDocument, mockImageDocument]),
+      );
+      renderComponent({ config: { ...defaultConfig, pageSize: 10 } });
+
+      expect(screen.queryByRole('button', { name: /next page/i })).not.toBeInTheDocument();
+    });
+
+    it('respects config pageSize to show only that many rows per page', () => {
+      (useQuery as jest.Mock).mockReturnValue(mockQueryData(manyDocs));
+      renderComponent({ config: { ...defaultConfig, pageSize: 5 } });
+
+      expect(screen.getByText('Document 1')).toBeInTheDocument();
+      expect(screen.getByText('Document 5')).toBeInTheDocument();
+      expect(screen.queryByText('Document 6')).not.toBeInTheDocument();
+    });
+
+    it('navigates to next page showing different rows', async () => {
+      const user = userEvent.setup();
+      (useQuery as jest.Mock).mockReturnValue(mockQueryData(manyDocs));
+      renderComponent({ config: { ...defaultConfig, pageSize: 5 } });
+
+      const nextButton = screen.getByRole('button', { name: /next page/i });
+      await user.click(nextButton);
+
+      expect(screen.getByText('Document 6')).toBeInTheDocument();
+      expect(screen.queryByText('Document 1')).not.toBeInTheDocument();
+    });
+
+    it('modal still works on paginated documents', async () => {
+      const user = userEvent.setup();
+      (useQuery as jest.Mock).mockReturnValue(mockQueryData(manyDocs));
+      renderComponent({ config: { ...defaultConfig, pageSize: 5 } });
+
+      const nextButton = screen.getByRole('button', { name: /next page/i });
+      await user.click(nextButton);
+
+      const links = screen.getAllByText('DOCUMENTS_VIEW_ATTACHMENTS');
+      await user.click(links[0]);
+
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+  });
+
+  describe('Default Sort', () => {
+    it('sorts documents by uploadedOn descending by default', () => {
+      // Pass docs in ascending order (oldest first) — component must reverse them
+      (useQuery as jest.Mock).mockReturnValue(
+        mockQueryData([
+          mockGenericDocument,  // 2024-01-13 (oldest)
+          mockImageDocument,    // 2024-01-14
+          mockPdfDocument,      // 2024-01-15 (newest)
+        ]),
+      );
+      renderComponent({ config: defaultConfig });
+
+      const rows = screen.getAllByRole('row');
+      // rows[0] = header; data rows start at index 1
+      expect(rows[1]).toHaveTextContent('Test Document');  // Jan 15 — newest first
+      expect(rows[2]).toHaveTextContent('X-Ray Image');    // Jan 14
+      expect(rows[3]).toHaveTextContent('Clinical Notes'); // Jan 13 — oldest last
+    });
+
+    it('places documents with no uploadedOn at the bottom', () => {
+      const noDateDoc = {
+        ...mockPdfDocument,
+        id: 'doc-no-date',
+        documentIdentifier: 'No Date Doc',
+        uploadedOn: '',
+      };
+      (useQuery as jest.Mock).mockReturnValue(
+        mockQueryData([
+          noDateDoc,          // no date — should go to bottom
+          mockImageDocument,  // 2024-01-14
+          mockPdfDocument,    // 2024-01-15
+        ]),
+      );
+      renderComponent({ config: defaultConfig });
+
+      const rows = screen.getAllByRole('row');
+      expect(rows[1]).toHaveTextContent('Test Document');  // Jan 15 first
+      expect(rows[2]).toHaveTextContent('X-Ray Image');    // Jan 14 second
+      expect(rows[3]).toHaveTextContent('No Date Doc');    // no date last
+    });
+
+    it('maintains date desc sort order when navigating to page 2', async () => {
+      const user = userEvent.setup();
+      const pagedDocs = Array.from({ length: 12 }, (_, i) => ({
+        id: `sort-doc-${i}`,
+        documentIdentifier: `Doc ${String(i + 1).padStart(2, '0')}`,
+        documentType: 'Notes',
+        uploadedOn: `2024-01-${String(i + 1).padStart(2, '0')}T10:00:00Z`,
+        uploadedBy: 'Dr. Test',
+        contentType: 'application/pdf',
+        documentUrl: `100/doc-${i}.pdf`,
+        attachments: [{ url: `100/doc-${i}.pdf`, contentType: 'application/pdf' }],
+      }));
+
+      // Pass in ascending order — component must sort descending before paginating
+      (useQuery as jest.Mock).mockReturnValue(
+        mockQueryData(pagedDocs),
+      );
+      renderComponent({ config: { ...defaultConfig, pageSize: 5 } });
+
+      // Page 1: should show 5 newest (Doc 12 → Doc 08)
+      const page1Rows = screen.getAllByRole('row').slice(1);
+      expect(page1Rows[0]).toHaveTextContent('Doc 12');
+      expect(page1Rows[4]).toHaveTextContent('Doc 08');
+
+      // Navigate to page 2 — should show next 5 in desc order (Doc 07 → Doc 03)
+      await user.click(screen.getByRole('button', { name: /next page/i }));
+
+      const page2Rows = screen.getAllByRole('row').slice(1);
+      expect(page2Rows[0]).toHaveTextContent('Doc 07');
+      expect(page2Rows[4]).toHaveTextContent('Doc 03');
+    });
+  });
+
   describe('Accessibility', () => {
     it('passes accessibility tests with data', async () => {
       (useQuery as jest.Mock).mockReturnValue({

--- a/packages/bahmni-widgets/src/documents/__tests__/DocumentsTable.test.tsx
+++ b/packages/bahmni-widgets/src/documents/__tests__/DocumentsTable.test.tsx
@@ -25,7 +25,7 @@ jest.mock('@bahmni/services', () => ({
   ...jest.requireActual('@bahmni/services'),
   useTranslation: () => ({ t: (key: string) => key }),
   formatDateTime: () => ({ formattedResult: '15/01/2024 4:00 PM' }),
-  getDocumentReferences: jest.fn(),
+  getDocumentReferencePage: jest.fn(),
   useSubscribeConsultationSaved: jest.fn(),
 }));
 
@@ -117,7 +117,12 @@ const mockQueryData = (
   overrides: Partial<ReturnType<typeof useQuery>> = {},
 ) =>
   ({
-    data: documents,
+    data: {
+      documents,
+      total: documents.length,
+      nextUrl: undefined,
+      prevUrl: undefined,
+    },
     error: null,
     isError: false,
     isLoading: false,
@@ -948,13 +953,9 @@ describe('DocumentsTable', () => {
 
   describe('Accessibility', () => {
     it('passes accessibility tests with data', async () => {
-      (useQuery as jest.Mock).mockReturnValue({
-        data: [mockPdfDocument, mockImageDocument],
-        error: null,
-        isError: false,
-        isLoading: false,
-        refetch: jest.fn(),
-      });
+      (useQuery as jest.Mock).mockReturnValue(
+        mockQueryData([mockPdfDocument, mockImageDocument]),
+      );
 
       const { container } = renderComponent({ config: defaultConfig });
 
@@ -1021,13 +1022,7 @@ describe('DocumentsTable', () => {
 
     it('passes accessibility tests with modal open', async () => {
       const user = userEvent.setup();
-      (useQuery as jest.Mock).mockReturnValue({
-        data: [mockPdfDocument],
-        error: null,
-        isError: false,
-        isLoading: false,
-        refetch: jest.fn(),
-      });
+      (useQuery as jest.Mock).mockReturnValue(mockQueryData([mockPdfDocument]));
 
       const { container } = renderComponent({ config: defaultConfig });
 
@@ -1041,13 +1036,7 @@ describe('DocumentsTable', () => {
 
     it('closes modal when Escape key is pressed', async () => {
       const user = userEvent.setup();
-      (useQuery as jest.Mock).mockReturnValue({
-        data: [mockPdfDocument],
-        error: null,
-        isError: false,
-        isLoading: false,
-        refetch: jest.fn(),
-      });
+      (useQuery as jest.Mock).mockReturnValue(mockQueryData([mockPdfDocument]));
 
       renderComponent({ config: defaultConfig });
 
@@ -1063,13 +1052,7 @@ describe('DocumentsTable', () => {
 
     it('modal dialog is properly labelled with document identifier for screen readers', async () => {
       const user = userEvent.setup();
-      (useQuery as jest.Mock).mockReturnValue({
-        data: [mockPdfDocument],
-        error: null,
-        isError: false,
-        isLoading: false,
-        refetch: jest.fn(),
-      });
+      (useQuery as jest.Mock).mockReturnValue(mockQueryData([mockPdfDocument]));
 
       renderComponent({ config: defaultConfig });
 

--- a/packages/bahmni-widgets/src/documents/__tests__/DocumentsTable.test.tsx
+++ b/packages/bahmni-widgets/src/documents/__tests__/DocumentsTable.test.tsx
@@ -120,8 +120,6 @@ const mockQueryData = (
     data: {
       documents,
       total: documents.length,
-      nextUrl: undefined,
-      prevUrl: undefined,
     },
     error: null,
     isError: false,

--- a/packages/bahmni-widgets/src/documents/__tests__/DocumentsTable.test.tsx
+++ b/packages/bahmni-widgets/src/documents/__tests__/DocumentsTable.test.tsx
@@ -840,6 +840,23 @@ describe('DocumentsTable', () => {
       expect(screen.queryByText('Document 1')).not.toBeInTheDocument();
     });
 
+    it('shows more rows after user increases page size via dropdown', async () => {
+      const user = userEvent.setup();
+      (useQuery as jest.Mock).mockReturnValue(mockQueryData(manyDocs));
+      renderComponent({ config: { ...defaultConfig, pageSize: 5 } });
+
+      // Initially only 5 rows visible
+      expect(screen.getByText('Document 5')).toBeInTheDocument();
+      expect(screen.queryByText('Document 6')).not.toBeInTheDocument();
+
+      // User changes page size to 10
+      const select = screen.getByRole('combobox', { name: /items per page/i });
+      await user.selectOptions(select, '10');
+
+      // All 10 rows now visible
+      expect(screen.getByText('Document 6')).toBeInTheDocument();
+    });
+
     it('modal still works on paginated documents', async () => {
       const user = userEvent.setup();
       (useQuery as jest.Mock).mockReturnValue(mockQueryData(manyDocs));

--- a/packages/bahmni-widgets/src/documents/__tests__/DocumentsTable.test.tsx
+++ b/packages/bahmni-widgets/src/documents/__tests__/DocumentsTable.test.tsx
@@ -794,14 +794,18 @@ describe('DocumentsTable', () => {
       uploadedBy: `Dr. ${i + 1}`,
       contentType: 'application/pdf',
       documentUrl: `100/doc-${i}.pdf`,
-      attachments: [{ url: `100/doc-${i}.pdf`, contentType: 'application/pdf' }],
+      attachments: [
+        { url: `100/doc-${i}.pdf`, contentType: 'application/pdf' },
+      ],
     }));
 
     it('renders pagination when documents exceed default pageSize of 10', () => {
       (useQuery as jest.Mock).mockReturnValue(mockQueryData(manyDocs));
       renderComponent({ config: defaultConfig });
 
-      expect(screen.getByRole('button', { name: /next page/i })).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /next page/i }),
+      ).toBeInTheDocument();
     });
 
     it('hides pagination when documents are fewer than or equal to pageSize', () => {
@@ -810,7 +814,9 @@ describe('DocumentsTable', () => {
       );
       renderComponent({ config: { ...defaultConfig, pageSize: 10 } });
 
-      expect(screen.queryByRole('button', { name: /next page/i })).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: /next page/i }),
+      ).not.toBeInTheDocument();
     });
 
     it('respects config pageSize to show only that many rows per page', () => {
@@ -854,17 +860,17 @@ describe('DocumentsTable', () => {
       // Pass docs in ascending order (oldest first) — component must reverse them
       (useQuery as jest.Mock).mockReturnValue(
         mockQueryData([
-          mockGenericDocument,  // 2024-01-13 (oldest)
-          mockImageDocument,    // 2024-01-14
-          mockPdfDocument,      // 2024-01-15 (newest)
+          mockGenericDocument, // 2024-01-13 (oldest)
+          mockImageDocument, // 2024-01-14
+          mockPdfDocument, // 2024-01-15 (newest)
         ]),
       );
       renderComponent({ config: defaultConfig });
 
       const rows = screen.getAllByRole('row');
       // rows[0] = header; data rows start at index 1
-      expect(rows[1]).toHaveTextContent('Test Document');  // Jan 15 — newest first
-      expect(rows[2]).toHaveTextContent('X-Ray Image');    // Jan 14
+      expect(rows[1]).toHaveTextContent('Test Document'); // Jan 15 — newest first
+      expect(rows[2]).toHaveTextContent('X-Ray Image'); // Jan 14
       expect(rows[3]).toHaveTextContent('Clinical Notes'); // Jan 13 — oldest last
     });
 
@@ -877,17 +883,17 @@ describe('DocumentsTable', () => {
       };
       (useQuery as jest.Mock).mockReturnValue(
         mockQueryData([
-          noDateDoc,          // no date — should go to bottom
-          mockImageDocument,  // 2024-01-14
-          mockPdfDocument,    // 2024-01-15
+          noDateDoc, // no date — should go to bottom
+          mockImageDocument, // 2024-01-14
+          mockPdfDocument, // 2024-01-15
         ]),
       );
       renderComponent({ config: defaultConfig });
 
       const rows = screen.getAllByRole('row');
-      expect(rows[1]).toHaveTextContent('Test Document');  // Jan 15 first
-      expect(rows[2]).toHaveTextContent('X-Ray Image');    // Jan 14 second
-      expect(rows[3]).toHaveTextContent('No Date Doc');    // no date last
+      expect(rows[1]).toHaveTextContent('Test Document'); // Jan 15 first
+      expect(rows[2]).toHaveTextContent('X-Ray Image'); // Jan 14 second
+      expect(rows[3]).toHaveTextContent('No Date Doc'); // no date last
     });
 
     it('maintains date desc sort order when navigating to page 2', async () => {
@@ -900,13 +906,13 @@ describe('DocumentsTable', () => {
         uploadedBy: 'Dr. Test',
         contentType: 'application/pdf',
         documentUrl: `100/doc-${i}.pdf`,
-        attachments: [{ url: `100/doc-${i}.pdf`, contentType: 'application/pdf' }],
+        attachments: [
+          { url: `100/doc-${i}.pdf`, contentType: 'application/pdf' },
+        ],
       }));
 
       // Pass in ascending order — component must sort descending before paginating
-      (useQuery as jest.Mock).mockReturnValue(
-        mockQueryData(pagedDocs),
-      );
+      (useQuery as jest.Mock).mockReturnValue(mockQueryData(pagedDocs));
       renderComponent({ config: { ...defaultConfig, pageSize: 5 } });
 
       // Page 1: should show 5 newest (Doc 12 → Doc 08)

--- a/packages/bahmni-widgets/src/forms/__tests__/__snapshots__/FormsTable.test.tsx.snap
+++ b/packages/bahmni-widgets/src/forms/__tests__/__snapshots__/FormsTable.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`FormsTable Snapshots should match snapshot in empty state 1`] = `
     data-testid="forms-table"
   >
     <p
-      class="_sortableDataTableBodyEmpty_1xyik_26"
+      class="_sortableDataTableBodyEmpty_1w499_26"
       data-testid="forms-table-empty"
     >
       No forms available
@@ -28,7 +28,7 @@ exports[`FormsTable Snapshots should match snapshot in loading state 1`] = `
         class="cds--skeleton cds--data-table-container"
       >
         <table
-          class="_sortableDataTableSkeleton_1xyik_21 cds--skeleton cds--data-table cds--data-table--compact"
+          class="_sortableDataTableSkeleton_1w499_21 cds--skeleton cds--data-table cds--data-table--compact"
         >
           <thead>
             <tr>
@@ -137,7 +137,7 @@ exports[`FormsTable Snapshots should match snapshot with form data 1`] = `
             id="accordion-item-_r_3c_"
           >
             <div
-              class="formsTableBody _sortableDataTableBody_1xyik_1"
+              class="formsTableBody _sortableDataTableBody_1w499_1"
               data-testid="forms-table-History Form"
             >
               <div
@@ -341,7 +341,7 @@ exports[`FormsTable Snapshots should match snapshot with form data 1`] = `
             id="accordion-item-_r_3f_"
           >
             <div
-              class="formsTableBody _sortableDataTableBody_1xyik_1"
+              class="formsTableBody _sortableDataTableBody_1w499_1"
               data-testid="forms-table-Vitals Form"
             >
               <div

--- a/packages/bahmni-widgets/src/patientPrograms/__tests__/__snapshots__/PatientProgramsTable.test.tsx.snap
+++ b/packages/bahmni-widgets/src/patientPrograms/__tests__/__snapshots__/PatientProgramsTable.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`PatientProgramsTable should match snapshot with program data 1`] = `
     id="patient-programs-table"
   >
     <div
-      class="table _sortableDataTableBody_1xyik_1"
+      class="table _sortableDataTableBody_1w499_1"
       data-testid="patient-programs-table"
     >
       <div


### PR DESCRIPTION
## Description

As a developer, I need pagination support in SortableDataTable so that widgets can implement pagination consistently.As part of this card apply the pagination for DocumentsTable alone.

Note: pageSize: controlled by “standard_config” parameter