### PR TITLE
BAH-4605 | Apply pagination for all display controls which have SortableDataTable (no Accordions) - DiagnosesTable, ConditionsTable, PatientProgramsTable

### DIFF
--- a/apps/clinical/src/components/dashboardSection/styles/DashboardSection.module.scss
+++ b/apps/clinical/src/components/dashboardSection/styles/DashboardSection.module.scss
@@ -16,8 +16,7 @@
 }
 
 .divider {
-  height: $spacing-07;
-  background-color: $layer-01;
+  height: 0;
 }
 
 .widgetLoading {

--- a/apps/clinical/src/components/dashboardSection/styles/DashboardSection.module.scss
+++ b/apps/clinical/src/components/dashboardSection/styles/DashboardSection.module.scss
@@ -16,7 +16,7 @@
 }
 
 .divider {
-  height: 0;
+  display: none;
 }
 
 .widgetLoading {

--- a/apps/clinical/src/components/forms/conditionsAndDiagnoses/ConditionsAndDiagnoses.tsx
+++ b/apps/clinical/src/components/forms/conditionsAndDiagnoses/ConditionsAndDiagnoses.tsx
@@ -152,7 +152,7 @@ const ConditionsAndDiagnoses: React.FC = React.memo(() => {
 
   const isConditionDuplicate = (diagnosisId: string): boolean => {
     const isExistingCondition = existingConditions!.some(
-      (d) => d.code === diagnosisId,
+      (d) => d.code?.coding?.[0]?.code === diagnosisId,
     );
     const isSelectedConditions =
       selectedConditions?.some((condition) => condition.id === diagnosisId) ||

--- a/packages/bahmni-services/src/conditionService/__tests__/conditionService.test.ts
+++ b/packages/bahmni-services/src/conditionService/__tests__/conditionService.test.ts
@@ -128,13 +128,13 @@ describe('conditionService', () => {
       expect(result.total).toBe(42);
     });
 
-    it('should fall back to conditions length when bundle total is undefined', async () => {
+    it('should return undefined total when bundle total is missing', async () => {
       const bundleWithoutTotal = { ...mockConditionBundle, total: undefined };
       (get as jest.Mock).mockResolvedValueOnce(bundleWithoutTotal);
 
       const result = await getConditionPage(patientUUID, 10, 1);
 
-      expect(result.total).toBe(result.conditions.length);
+      expect(result.total).toBeUndefined();
     });
 
     it('should return empty conditions for empty bundle', async () => {

--- a/packages/bahmni-services/src/conditionService/__tests__/conditionService.test.ts
+++ b/packages/bahmni-services/src/conditionService/__tests__/conditionService.test.ts
@@ -27,7 +27,7 @@ describe('conditionService', () => {
       const result = await getConditionsBundle(patientUUID);
 
       expect(get).toHaveBeenCalledWith(
-        `/openmrs/ws/fhir2/R4/Condition?category=problem-list-item&patient=${patientUUID}&_count=10&_getpagesoffset=0&_sort=-_lastUpdated`,
+        `/openmrs/ws/fhir2/R4/Condition?category=problem-list-item&patient=${patientUUID}&_count=100&_sort=-_lastUpdated`,
       );
       expect(result).toEqual(mockConditionBundle);
     });
@@ -51,7 +51,7 @@ describe('conditionService', () => {
       const result = await getConditions(patientUUID);
 
       expect(get).toHaveBeenCalledWith(
-        `/openmrs/ws/fhir2/R4/Condition?category=problem-list-item&patient=${patientUUID}&_count=10&_getpagesoffset=0&_sort=-_lastUpdated`,
+        `/openmrs/ws/fhir2/R4/Condition?category=problem-list-item&patient=${patientUUID}&_count=100&_sort=-_lastUpdated`,
       );
       expect(result).toEqual([mockCondition]);
     });

--- a/packages/bahmni-services/src/conditionService/__tests__/conditionService.test.ts
+++ b/packages/bahmni-services/src/conditionService/__tests__/conditionService.test.ts
@@ -5,7 +5,11 @@ import {
   mockEmptyConditionBundle,
   mockMalformedBundle,
 } from '../__mocks__/mocks';
-import { getConditions, getConditionsBundle } from '../conditionService';
+import {
+  getConditions,
+  getConditionsBundle,
+  getConditionPage,
+} from '../conditionService';
 
 jest.mock('../../api');
 
@@ -23,7 +27,7 @@ describe('conditionService', () => {
       const result = await getConditionsBundle(patientUUID);
 
       expect(get).toHaveBeenCalledWith(
-        `/openmrs/ws/fhir2/R4/Condition?category=problem-list-item&patient=${patientUUID}&_count=100&_sort=-_lastUpdated`,
+        `/openmrs/ws/fhir2/R4/Condition?category=problem-list-item&patient=${patientUUID}&_count=10&_getpagesoffset=0&_sort=-_lastUpdated`,
       );
       expect(result).toEqual(mockConditionBundle);
     });
@@ -47,7 +51,7 @@ describe('conditionService', () => {
       const result = await getConditions(patientUUID);
 
       expect(get).toHaveBeenCalledWith(
-        `/openmrs/ws/fhir2/R4/Condition?category=problem-list-item&patient=${patientUUID}&_count=100&_sort=-_lastUpdated`,
+        `/openmrs/ws/fhir2/R4/Condition?category=problem-list-item&patient=${patientUUID}&_count=10&_getpagesoffset=0&_sort=-_lastUpdated`,
       );
       expect(result).toEqual([mockCondition]);
     });
@@ -77,6 +81,78 @@ describe('conditionService', () => {
 
       const result = await getConditions(patientUUID);
       expect(result).toEqual([]);
+    });
+  });
+
+  describe('getConditionPage', () => {
+    const patientUUID = '02f47490-d657-48ee-98e7-4c9133ea168b';
+
+    it('should fetch page 1 with default count', async () => {
+      (get as jest.Mock).mockResolvedValueOnce(mockConditionBundle);
+
+      const result = await getConditionPage(patientUUID);
+
+      expect(get).toHaveBeenCalledWith(
+        `/openmrs/ws/fhir2/R4/Condition?category=problem-list-item&patient=${patientUUID}&_count=10&_getpagesoffset=0&_sort=-_lastUpdated`,
+      );
+      expect(result.conditions).toEqual([mockCondition]);
+      expect(result.total).toBe(1);
+    });
+
+    it('should calculate correct offset for page 2', async () => {
+      (get as jest.Mock).mockResolvedValueOnce(mockConditionBundle);
+
+      await getConditionPage(patientUUID, 5, 2);
+
+      expect(get).toHaveBeenCalledWith(
+        `/openmrs/ws/fhir2/R4/Condition?category=problem-list-item&patient=${patientUUID}&_count=5&_getpagesoffset=5&_sort=-_lastUpdated`,
+      );
+    });
+
+    it('should calculate correct offset for page 3 with count 10', async () => {
+      (get as jest.Mock).mockResolvedValueOnce(mockConditionBundle);
+
+      await getConditionPage(patientUUID, 10, 3);
+
+      expect(get).toHaveBeenCalledWith(
+        `/openmrs/ws/fhir2/R4/Condition?category=problem-list-item&patient=${patientUUID}&_count=10&_getpagesoffset=20&_sort=-_lastUpdated`,
+      );
+    });
+
+    it('should return total from bundle', async () => {
+      const bundleWithTotal = { ...mockConditionBundle, total: 42 };
+      (get as jest.Mock).mockResolvedValueOnce(bundleWithTotal);
+
+      const result = await getConditionPage(patientUUID, 10, 1);
+
+      expect(result.total).toBe(42);
+    });
+
+    it('should fall back to conditions length when bundle total is undefined', async () => {
+      const bundleWithoutTotal = { ...mockConditionBundle, total: undefined };
+      (get as jest.Mock).mockResolvedValueOnce(bundleWithoutTotal);
+
+      const result = await getConditionPage(patientUUID, 10, 1);
+
+      expect(result.total).toBe(result.conditions.length);
+    });
+
+    it('should return empty conditions for empty bundle', async () => {
+      (get as jest.Mock).mockResolvedValueOnce(mockEmptyConditionBundle);
+
+      const result = await getConditionPage(patientUUID, 10, 1);
+
+      expect(result.conditions).toEqual([]);
+      expect(result.total).toBe(0);
+    });
+
+    it('should propagate errors from the API', async () => {
+      const error = new Error('Network error');
+      (get as jest.Mock).mockRejectedValueOnce(error);
+
+      await expect(getConditionPage(patientUUID)).rejects.toThrow(
+        'Network error',
+      );
     });
   });
 });

--- a/packages/bahmni-services/src/conditionService/conditionService.ts
+++ b/packages/bahmni-services/src/conditionService/conditionService.ts
@@ -2,7 +2,6 @@ import { Condition, Bundle } from 'fhir/r4';
 import { get } from '../api';
 import { PATIENT_CONDITION_RESOURCE_URL } from './constants';
 
-// TODO: Add Optional parameters for pagination and filtering
 /**
  * Fetches conditions for a given patient UUID from the FHIR R4 endpoint
  * @param patientUUID - The UUID of the patient
@@ -27,4 +26,36 @@ export async function getConditions(patientUUID: string): Promise<Condition[]> {
       .map((entry) => entry.resource as Condition) ?? [];
 
   return conditions;
+}
+
+export interface ConditionPage {
+  conditions: Condition[];
+  total: number;
+}
+
+/**
+ * Fetches a single page of conditions using offset-based pagination.
+ * Uses _getpagesoffset = (page - 1) * count to jump directly to any page.
+ * @param patientUUID - The UUID of the patient
+ * @param count - Number of items per page (default 10)
+ * @param page - 1-based page number (default 1)
+ * @returns Promise resolving to a ConditionPage with conditions and total count
+ */
+export async function getConditionPage(
+  patientUUID: string,
+  count: number = 10,
+  page: number = 1,
+): Promise<ConditionPage> {
+  const offset = (page - 1) * count;
+  const bundle = await get<Bundle>(
+    PATIENT_CONDITION_RESOURCE_URL(patientUUID, count, offset),
+  );
+  const conditions =
+    bundle.entry
+      ?.filter((entry) => entry.resource?.resourceType === 'Condition')
+      .map((entry) => entry.resource as Condition) ?? [];
+  return {
+    conditions,
+    total: bundle.total ?? conditions.length,
+  };
 }

--- a/packages/bahmni-services/src/conditionService/conditionService.ts
+++ b/packages/bahmni-services/src/conditionService/conditionService.ts
@@ -33,7 +33,7 @@ export async function getConditions(patientUUID: string): Promise<Condition[]> {
 
 export interface ConditionPage {
   conditions: Condition[];
-  total: number;
+  total: number | undefined;
 }
 
 /**
@@ -59,6 +59,6 @@ export async function getConditionPage(
       .map((entry) => entry.resource as Condition) ?? [];
   return {
     conditions,
-    total: bundle.total ?? conditions.length,
+    total: bundle.total,
   };
 }

--- a/packages/bahmni-services/src/conditionService/conditionService.ts
+++ b/packages/bahmni-services/src/conditionService/conditionService.ts
@@ -1,6 +1,9 @@
 import { Condition, Bundle } from 'fhir/r4';
 import { get } from '../api';
-import { PATIENT_CONDITION_RESOURCE_URL } from './constants';
+import {
+  PATIENT_CONDITION_RESOURCE_URL,
+  PATIENT_CONDITION_PAGE_URL,
+} from './constants';
 
 /**
  * Fetches conditions for a given patient UUID from the FHIR R4 endpoint
@@ -48,7 +51,7 @@ export async function getConditionPage(
 ): Promise<ConditionPage> {
   const offset = (page - 1) * count;
   const bundle = await get<Bundle>(
-    PATIENT_CONDITION_RESOURCE_URL(patientUUID, count, offset),
+    PATIENT_CONDITION_PAGE_URL(patientUUID, count, offset),
   );
   const conditions =
     bundle.entry

--- a/packages/bahmni-services/src/conditionService/constants.ts
+++ b/packages/bahmni-services/src/conditionService/constants.ts
@@ -1,6 +1,10 @@
 import { OPENMRS_FHIR_R4 } from '../constants/app';
 import { HL7_CONDITION_CATEGORY_CONDITION_CODE } from '../constants/fhir';
 
-export const PATIENT_CONDITION_RESOURCE_URL = (patientUUID: string) =>
+export const PATIENT_CONDITION_RESOURCE_URL = (
+  patientUUID: string,
+  count: number = 10,
+  offset: number = 0,
+) =>
   OPENMRS_FHIR_R4 +
-  `/Condition?category=${HL7_CONDITION_CATEGORY_CONDITION_CODE}&patient=${patientUUID}&_count=100&_sort=-_lastUpdated`;
+  `/Condition?category=${HL7_CONDITION_CATEGORY_CONDITION_CODE}&patient=${patientUUID}&_count=${count}&_getpagesoffset=${offset}&_sort=-_lastUpdated`;

--- a/packages/bahmni-services/src/conditionService/constants.ts
+++ b/packages/bahmni-services/src/conditionService/constants.ts
@@ -1,7 +1,13 @@
 import { OPENMRS_FHIR_R4 } from '../constants/app';
 import { HL7_CONDITION_CATEGORY_CONDITION_CODE } from '../constants/fhir';
 
-export const PATIENT_CONDITION_RESOURCE_URL = (
+// Used by getConditions() — fetches all records for consultation forms
+export const PATIENT_CONDITION_RESOURCE_URL = (patientUUID: string) =>
+  OPENMRS_FHIR_R4 +
+  `/Condition?category=${HL7_CONDITION_CATEGORY_CONDITION_CODE}&patient=${patientUUID}&_count=100&_sort=-_lastUpdated`;
+
+// Used by getConditionPage() — fetches one page for the paginated widget
+export const PATIENT_CONDITION_PAGE_URL = (
   patientUUID: string,
   count: number = 10,
   offset: number = 0,

--- a/packages/bahmni-services/src/conditionService/index.ts
+++ b/packages/bahmni-services/src/conditionService/index.ts
@@ -1,2 +1,6 @@
-export { getConditions } from './conditionService';
+export {
+  getConditions,
+  getConditionPage,
+  type ConditionPage,
+} from './conditionService';
 export { type ConditionInputEntry } from './models';

--- a/packages/bahmni-services/src/diagnosesService/__tests__/diagnosesService.test.ts
+++ b/packages/bahmni-services/src/diagnosesService/__tests__/diagnosesService.test.ts
@@ -83,7 +83,7 @@ describe('diagnosesService', () => {
         const result = await getPatientDiagnoses(patientUUID);
 
         expect(get).toHaveBeenCalledWith(
-          `/openmrs/ws/fhir2/R4/Condition?category=encounter-diagnosis&patient=${patientUUID}&_count=10&_getpagesoffset=0&_sort=-_lastUpdated`,
+          `/openmrs/ws/fhir2/R4/Condition?category=encounter-diagnosis&patient=${patientUUID}&_count=100&_sort=-_lastUpdated`,
         );
         expect(result).toHaveLength(2);
         expect(result[0].id).toBe('diagnosis-1');
@@ -344,7 +344,7 @@ describe('diagnosesService', () => {
         const result = await getPatientDiagnoses(emptyUUID);
 
         expect(get).toHaveBeenCalledWith(
-          `/openmrs/ws/fhir2/R4/Condition?category=encounter-diagnosis&patient=${emptyUUID}&_count=10&_getpagesoffset=0&_sort=-_lastUpdated`,
+          `/openmrs/ws/fhir2/R4/Condition?category=encounter-diagnosis&patient=${emptyUUID}&_count=100&_sort=-_lastUpdated`,
         );
         expect(result).toEqual([]);
       });
@@ -357,7 +357,7 @@ describe('diagnosesService', () => {
         const result = await getPatientDiagnoses(specialUUID);
 
         expect(get).toHaveBeenCalledWith(
-          `/openmrs/ws/fhir2/R4/Condition?category=encounter-diagnosis&patient=${specialUUID}&_count=10&_getpagesoffset=0&_sort=-_lastUpdated`,
+          `/openmrs/ws/fhir2/R4/Condition?category=encounter-diagnosis&patient=${specialUUID}&_count=100&_sort=-_lastUpdated`,
         );
         expect(result).toEqual([]);
       });

--- a/packages/bahmni-services/src/diagnosesService/__tests__/diagnosesService.test.ts
+++ b/packages/bahmni-services/src/diagnosesService/__tests__/diagnosesService.test.ts
@@ -746,7 +746,7 @@ describe('diagnosesService', () => {
       expect(result.total).toBe(42);
     });
 
-    it('should fall back to diagnoses length when bundle total is undefined', async () => {
+    it('should return undefined total when bundle total is missing', async () => {
       const bundle = {
         ...createMockBundle([createMockDiagnosis()]),
         total: undefined,
@@ -755,7 +755,7 @@ describe('diagnosesService', () => {
 
       const result = await getDiagnosesPage(patientUUID, 10, 1);
 
-      expect(result.total).toBe(result.diagnoses.length);
+      expect(result.total).toBeUndefined();
     });
 
     it('should return empty diagnoses for empty bundle', async () => {

--- a/packages/bahmni-services/src/diagnosesService/__tests__/diagnosesService.test.ts
+++ b/packages/bahmni-services/src/diagnosesService/__tests__/diagnosesService.test.ts
@@ -1,7 +1,7 @@
 import { Condition, Bundle } from 'fhir/r4';
 import { get } from '../../api';
 import { CERTAINITY_CONCEPTS } from '../constants';
-import { getPatientDiagnoses } from '../diagnosesService';
+import { getPatientDiagnoses, getDiagnosesPage } from '../diagnosesService';
 
 jest.mock('../../api');
 
@@ -83,7 +83,7 @@ describe('diagnosesService', () => {
         const result = await getPatientDiagnoses(patientUUID);
 
         expect(get).toHaveBeenCalledWith(
-          `/openmrs/ws/fhir2/R4/Condition?category=encounter-diagnosis&patient=${patientUUID}&_count=100&_sort=-_lastUpdated`,
+          `/openmrs/ws/fhir2/R4/Condition?category=encounter-diagnosis&patient=${patientUUID}&_count=10&_getpagesoffset=0&_sort=-_lastUpdated`,
         );
         expect(result).toHaveLength(2);
         expect(result[0].id).toBe('diagnosis-1');
@@ -344,7 +344,7 @@ describe('diagnosesService', () => {
         const result = await getPatientDiagnoses(emptyUUID);
 
         expect(get).toHaveBeenCalledWith(
-          `/openmrs/ws/fhir2/R4/Condition?category=encounter-diagnosis&patient=${emptyUUID}&_count=100&_sort=-_lastUpdated`,
+          `/openmrs/ws/fhir2/R4/Condition?category=encounter-diagnosis&patient=${emptyUUID}&_count=10&_getpagesoffset=0&_sort=-_lastUpdated`,
         );
         expect(result).toEqual([]);
       });
@@ -357,7 +357,7 @@ describe('diagnosesService', () => {
         const result = await getPatientDiagnoses(specialUUID);
 
         expect(get).toHaveBeenCalledWith(
-          `/openmrs/ws/fhir2/R4/Condition?category=encounter-diagnosis&patient=${specialUUID}&_count=100&_sort=-_lastUpdated`,
+          `/openmrs/ws/fhir2/R4/Condition?category=encounter-diagnosis&patient=${specialUUID}&_count=10&_getpagesoffset=0&_sort=-_lastUpdated`,
         );
         expect(result).toEqual([]);
       });
@@ -660,6 +660,118 @@ describe('diagnosesService', () => {
         expect(resultMap.get('Asthma')?.id).toBe('unique-1'); // Only one
         expect(resultMap.get('Hypertension')?.id).toBe('hypertension-2'); // Most recent
       });
+    });
+  });
+
+  describe('getDiagnosesPage', () => {
+    const patientUUID = '02f47490-d657-48ee-98e7-4c9133ea168b';
+
+    const createMockDiagnosis = (
+      overrides: Partial<Condition> = {},
+    ): Condition => ({
+      resourceType: 'Condition',
+      id: 'diagnosis-1',
+      subject: { reference: 'Patient/test-patient', display: 'Test Patient' },
+      code: { text: 'Test Diagnosis' },
+      verificationStatus: {
+        coding: [
+          {
+            system:
+              'http://terminology.hl7.org/CodeSystem/condition-ver-status',
+            code: 'confirmed',
+            display: 'Confirmed',
+          },
+        ],
+      },
+      recordedDate: '2025-03-25T06:48:32+00:00',
+      recorder: { reference: 'Practitioner/p-1', display: 'Dr. Smith' },
+      ...overrides,
+    });
+
+    const createMockBundle = (
+      conditions: Condition[] = [],
+      total?: number,
+    ): Bundle => ({
+      resourceType: 'Bundle',
+      id: 'bundle-id',
+      type: 'searchset',
+      total: total ?? conditions.length,
+      entry: conditions.map((c) => ({
+        resource: c,
+        fullUrl: `http://example.com/Condition/${c.id}`,
+      })),
+    });
+
+    it('should fetch page 1 with default count', async () => {
+      const bundle = createMockBundle([createMockDiagnosis()], 10);
+      (get as jest.Mock).mockResolvedValueOnce(bundle);
+
+      const result = await getDiagnosesPage(patientUUID);
+
+      expect(get).toHaveBeenCalledWith(
+        `/openmrs/ws/fhir2/R4/Condition?category=encounter-diagnosis&patient=${patientUUID}&_count=10&_getpagesoffset=0&_sort=-_lastUpdated`,
+      );
+      expect(result.diagnoses).toHaveLength(1);
+      expect(result.total).toBe(10);
+    });
+
+    it('should calculate correct offset for page 2', async () => {
+      const bundle = createMockBundle([], 20);
+      (get as jest.Mock).mockResolvedValueOnce(bundle);
+
+      await getDiagnosesPage(patientUUID, 5, 2);
+
+      expect(get).toHaveBeenCalledWith(
+        `/openmrs/ws/fhir2/R4/Condition?category=encounter-diagnosis&patient=${patientUUID}&_count=5&_getpagesoffset=5&_sort=-_lastUpdated`,
+      );
+    });
+
+    it('should calculate correct offset for page 3 with count 10', async () => {
+      const bundle = createMockBundle([], 30);
+      (get as jest.Mock).mockResolvedValueOnce(bundle);
+
+      await getDiagnosesPage(patientUUID, 10, 3);
+
+      expect(get).toHaveBeenCalledWith(
+        `/openmrs/ws/fhir2/R4/Condition?category=encounter-diagnosis&patient=${patientUUID}&_count=10&_getpagesoffset=20&_sort=-_lastUpdated`,
+      );
+    });
+
+    it('should return total from bundle', async () => {
+      const bundle = createMockBundle([createMockDiagnosis()], 42);
+      (get as jest.Mock).mockResolvedValueOnce(bundle);
+
+      const result = await getDiagnosesPage(patientUUID, 10, 1);
+
+      expect(result.total).toBe(42);
+    });
+
+    it('should fall back to diagnoses length when bundle total is undefined', async () => {
+      const bundle = {
+        ...createMockBundle([createMockDiagnosis()]),
+        total: undefined,
+      };
+      (get as jest.Mock).mockResolvedValueOnce(bundle);
+
+      const result = await getDiagnosesPage(patientUUID, 10, 1);
+
+      expect(result.total).toBe(result.diagnoses.length);
+    });
+
+    it('should return empty diagnoses for empty bundle', async () => {
+      const bundle = createMockBundle([], 0);
+      (get as jest.Mock).mockResolvedValueOnce(bundle);
+
+      const result = await getDiagnosesPage(patientUUID, 10, 1);
+
+      expect(result.diagnoses).toEqual([]);
+      expect(result.total).toBe(0);
+    });
+
+    it('should propagate errors from the API', async () => {
+      (get as jest.Mock).mockRejectedValueOnce(new Error('API Error'));
+
+      await expect(getDiagnosesPage(patientUUID)).rejects.toThrow('API Error');
     });
   });
 });

--- a/packages/bahmni-services/src/diagnosesService/constants.ts
+++ b/packages/bahmni-services/src/diagnosesService/constants.ts
@@ -2,9 +2,13 @@ import { Coding } from 'fhir/r4';
 import { OPENMRS_FHIR_R4 } from '../constants/app';
 import { HL7_CONDITION_CATEGORY_DIAGNOSIS_CODE } from '../constants/fhir';
 
-export const PATIENT_DIAGNOSIS_RESOURCE_URL = (patientUUID: string) =>
+export const PATIENT_DIAGNOSIS_RESOURCE_URL = (
+  patientUUID: string,
+  count: number = 10,
+  offset: number = 0,
+) =>
   OPENMRS_FHIR_R4 +
-  `/Condition?category=${HL7_CONDITION_CATEGORY_DIAGNOSIS_CODE}&patient=${patientUUID}&_count=100&_sort=-_lastUpdated`;
+  `/Condition?category=${HL7_CONDITION_CATEGORY_DIAGNOSIS_CODE}&patient=${patientUUID}&_count=${count}&_getpagesoffset=${offset}&_sort=-_lastUpdated`;
 
 export const CERTAINITY_CONCEPTS: Coding[] = [
   {

--- a/packages/bahmni-services/src/diagnosesService/constants.ts
+++ b/packages/bahmni-services/src/diagnosesService/constants.ts
@@ -2,7 +2,13 @@ import { Coding } from 'fhir/r4';
 import { OPENMRS_FHIR_R4 } from '../constants/app';
 import { HL7_CONDITION_CATEGORY_DIAGNOSIS_CODE } from '../constants/fhir';
 
-export const PATIENT_DIAGNOSIS_RESOURCE_URL = (
+// Used by getPatientDiagnoses() — fetches all records for consultation forms
+export const PATIENT_DIAGNOSIS_RESOURCE_URL = (patientUUID: string) =>
+  OPENMRS_FHIR_R4 +
+  `/Condition?category=${HL7_CONDITION_CATEGORY_DIAGNOSIS_CODE}&patient=${patientUUID}&_count=100&_sort=-_lastUpdated`;
+
+// Used by getDiagnosesPage() — fetches one page for the paginated widget
+export const PATIENT_DIAGNOSIS_PAGE_URL = (
   patientUUID: string,
   count: number = 10,
   offset: number = 0,

--- a/packages/bahmni-services/src/diagnosesService/diagnosesService.ts
+++ b/packages/bahmni-services/src/diagnosesService/diagnosesService.ts
@@ -11,13 +11,6 @@ import { Diagnosis } from './models';
 const CONFIRMED_STATUS = 'confirmed';
 const PROVISIONAL_STATUS = 'provisional';
 
-/**
- * Fetches diagnoses for a given patient UUID from the FHIR R4 endpoint
- * @param patientUUID - The UUID of the patient
- * @param count - Number of items per page (default 10)
- * @param offset - Zero-based offset for pagination (default 0)
- * @returns Promise resolving to a Bundle containing diagnoses
- */
 // Fetches all diagnoses (for consultation forms — no pagination)
 async function getPatientDiagnosesBundle(patientUUID: string): Promise<Bundle> {
   return await get<Bundle>(PATIENT_DIAGNOSIS_RESOURCE_URL(patientUUID));
@@ -145,7 +138,7 @@ export interface DiagnosisPage {
 /**
  * Fetches a single page of diagnoses using offset-based pagination.
  * Uses _getpagesoffset = (page - 1) * count to jump directly to any page.
- * Deduplication is applied per-page.
+ * No per-page deduplication — cross-page dedup is not possible with server-side pagination.
  * @param patientUUID - The UUID of the patient
  * @param count - Number of items per page (default 10)
  * @param page - 1-based page number (default 1)

--- a/packages/bahmni-services/src/diagnosesService/diagnosesService.ts
+++ b/packages/bahmni-services/src/diagnosesService/diagnosesService.ts
@@ -3,6 +3,7 @@ import { get } from '../api';
 import {
   CERTAINITY_CONCEPTS,
   PATIENT_DIAGNOSIS_RESOURCE_URL,
+  PATIENT_DIAGNOSIS_PAGE_URL,
 } from './constants';
 import { Diagnosis } from './models';
 
@@ -17,13 +18,20 @@ const PROVISIONAL_STATUS = 'provisional';
  * @param offset - Zero-based offset for pagination (default 0)
  * @returns Promise resolving to a Bundle containing diagnoses
  */
-async function getPatientDiagnosesBundle(
+// Fetches all diagnoses (for consultation forms — no pagination)
+async function getPatientDiagnosesBundle(patientUUID: string): Promise<Bundle> {
+  return await get<Bundle>(PATIENT_DIAGNOSIS_RESOURCE_URL(patientUUID));
+}
+
+// Fetches a single page of diagnoses (for the paginated widget)
+async function getPatientDiagnosesBundlePage(
   patientUUID: string,
-  count: number = 10,
-  offset: number = 0,
+  count: number,
+  offset: number,
 ): Promise<Bundle> {
-  const url = PATIENT_DIAGNOSIS_RESOURCE_URL(patientUUID, count, offset);
-  return await get<Bundle>(url);
+  return await get<Bundle>(
+    PATIENT_DIAGNOSIS_PAGE_URL(patientUUID, count, offset),
+  );
 }
 
 /**
@@ -149,7 +157,11 @@ export async function getDiagnosesPage(
   page: number = 1,
 ): Promise<DiagnosisPage> {
   const offset = (page - 1) * count;
-  const bundle = await getPatientDiagnosesBundle(patientUUID, count, offset);
+  const bundle = await getPatientDiagnosesBundlePage(
+    patientUUID,
+    count,
+    offset,
+  );
   // No per-page deduplication — with server-side pagination each page only has
   // a subset of records, so cross-page deduplication is not possible.
   const diagnoses = formatDiagnoses(bundle);

--- a/packages/bahmni-services/src/diagnosesService/diagnosesService.ts
+++ b/packages/bahmni-services/src/diagnosesService/diagnosesService.ts
@@ -13,10 +13,16 @@ const PROVISIONAL_STATUS = 'provisional';
 /**
  * Fetches diagnoses for a given patient UUID from the FHIR R4 endpoint
  * @param patientUUID - The UUID of the patient
+ * @param count - Number of items per page (default 10)
+ * @param offset - Zero-based offset for pagination (default 0)
  * @returns Promise resolving to a Bundle containing diagnoses
  */
-async function getPatientDiagnosesBundle(patientUUID: string): Promise<Bundle> {
-  const url = PATIENT_DIAGNOSIS_RESOURCE_URL(patientUUID);
+async function getPatientDiagnosesBundle(
+  patientUUID: string,
+  count: number = 10,
+  offset: number = 0,
+): Promise<Bundle> {
+  const url = PATIENT_DIAGNOSIS_RESOURCE_URL(patientUUID, count, offset);
   return await get<Bundle>(url);
 }
 
@@ -121,4 +127,34 @@ export async function getPatientDiagnoses(
   const bundle = await getPatientDiagnosesBundle(patientUUID);
   const formattedDiagnoses = formatDiagnoses(bundle);
   return deduplicateDiagnoses(formattedDiagnoses);
+}
+
+export interface DiagnosisPage {
+  diagnoses: Diagnosis[];
+  total: number;
+}
+
+/**
+ * Fetches a single page of diagnoses using offset-based pagination.
+ * Uses _getpagesoffset = (page - 1) * count to jump directly to any page.
+ * Deduplication is applied per-page.
+ * @param patientUUID - The UUID of the patient
+ * @param count - Number of items per page (default 10)
+ * @param page - 1-based page number (default 1)
+ * @returns Promise resolving to a DiagnosisPage with diagnoses and total count
+ */
+export async function getDiagnosesPage(
+  patientUUID: string,
+  count: number = 10,
+  page: number = 1,
+): Promise<DiagnosisPage> {
+  const offset = (page - 1) * count;
+  const bundle = await getPatientDiagnosesBundle(patientUUID, count, offset);
+  // No per-page deduplication — with server-side pagination each page only has
+  // a subset of records, so cross-page deduplication is not possible.
+  const diagnoses = formatDiagnoses(bundle);
+  return {
+    diagnoses,
+    total: bundle.total ?? diagnoses.length,
+  };
 }

--- a/packages/bahmni-services/src/diagnosesService/diagnosesService.ts
+++ b/packages/bahmni-services/src/diagnosesService/diagnosesService.ts
@@ -132,7 +132,7 @@ export async function getPatientDiagnoses(
 
 export interface DiagnosisPage {
   diagnoses: Diagnosis[];
-  total: number;
+  total: number | undefined;
 }
 
 /**
@@ -160,6 +160,6 @@ export async function getDiagnosesPage(
   const diagnoses = formatDiagnoses(bundle);
   return {
     diagnoses,
-    total: bundle.total ?? diagnoses.length,
+    total: bundle.total,
   };
 }

--- a/packages/bahmni-services/src/diagnosesService/index.ts
+++ b/packages/bahmni-services/src/diagnosesService/index.ts
@@ -1,4 +1,8 @@
-export { getPatientDiagnoses } from './diagnosesService';
+export {
+  getPatientDiagnoses,
+  getDiagnosesPage,
+  type DiagnosisPage,
+} from './diagnosesService';
 export {
   type Diagnosis,
   type DiagnosisInputEntry,

--- a/packages/bahmni-services/src/index.ts
+++ b/packages/bahmni-services/src/index.ts
@@ -125,9 +125,16 @@ export {
   fetchAndFormatAllergenConcepts,
   fetchReactionConcepts,
 } from './allergyService';
-export { getConditions, type ConditionInputEntry } from './conditionService';
+export {
+  getConditions,
+  getConditionPage,
+  type ConditionPage,
+  type ConditionInputEntry,
+} from './conditionService';
 export {
   getPatientDiagnoses,
+  getDiagnosesPage,
+  type DiagnosisPage,
   type Diagnosis,
   type DiagnosisInputEntry,
   type DiagnosesByDate,
@@ -285,10 +292,12 @@ export {
 export { getServiceRequests } from './orderRequestService';
 export {
   getPatientPrograms,
+  getPatientProgramsPage,
   getProgramByUUID,
   getCurrentStateName,
   extractAttributes,
   updateProgramState,
+  type ProgramPage,
   type ProgramEnrollment,
   type PatientProgramsResponse,
 } from './programService';

--- a/packages/bahmni-services/src/programService/__tests__/programService.test.ts
+++ b/packages/bahmni-services/src/programService/__tests__/programService.test.ts
@@ -1,11 +1,16 @@
 import { get, post } from '../../api';
 import { mockEnrollments, patientUUID } from '../__mocks__/mocks';
-import { PROGRAM_DETAILS_URL, PATIENT_PROGRAMS_URL } from '../constants';
+import {
+  PROGRAM_DETAILS_URL,
+  PATIENT_PROGRAMS_URL,
+  PATIENT_PROGRAMS_PAGE_URL,
+} from '../constants';
 import { ProgramEnrollment, PatientProgramsResponse } from '../model';
 import {
   extractAttributes,
   getCurrentStateName,
   getPatientPrograms,
+  getPatientProgramsPage,
   getProgramByUUID,
   updateProgramState,
 } from '../programService';
@@ -199,6 +204,96 @@ describe('programService', () => {
       await expect(
         updateProgramState(programEnrollmentUUID, stateConceptUUID),
       ).rejects.toThrow('Failed to update program state');
+    });
+  });
+
+  describe('getPatientProgramsPage', () => {
+    it('should fetch page 1 with default count', async () => {
+      const mockResponse: PatientProgramsResponse = {
+        results: mockEnrollments.slice(0, 1),
+        totalCount: 10,
+      };
+      (get as jest.Mock).mockResolvedValue(mockResponse);
+
+      const result = await getPatientProgramsPage(patientUUID);
+
+      expect(get).toHaveBeenCalledWith(
+        PATIENT_PROGRAMS_PAGE_URL(patientUUID, 15, 0),
+      );
+      expect(result.programs).toEqual(mockEnrollments.slice(0, 1));
+      expect(result.total).toBe(10);
+    });
+
+    it('should calculate correct startIndex for page 2', async () => {
+      const mockResponse: PatientProgramsResponse = {
+        results: [],
+        totalCount: 20,
+      };
+      (get as jest.Mock).mockResolvedValue(mockResponse);
+
+      await getPatientProgramsPage(patientUUID, 5, 2);
+
+      expect(get).toHaveBeenCalledWith(
+        PATIENT_PROGRAMS_PAGE_URL(patientUUID, 5, 5),
+      );
+    });
+
+    it('should calculate correct startIndex for page 3 with count 10', async () => {
+      const mockResponse: PatientProgramsResponse = {
+        results: [],
+        totalCount: 30,
+      };
+      (get as jest.Mock).mockResolvedValue(mockResponse);
+
+      await getPatientProgramsPage(patientUUID, 10, 3);
+
+      expect(get).toHaveBeenCalledWith(
+        PATIENT_PROGRAMS_PAGE_URL(patientUUID, 10, 20),
+      );
+    });
+
+    it('should return totalCount from response when available', async () => {
+      const mockResponse: PatientProgramsResponse = {
+        results: mockEnrollments.slice(0, 2),
+        totalCount: 42,
+      };
+      (get as jest.Mock).mockResolvedValue(mockResponse);
+
+      const result = await getPatientProgramsPage(patientUUID, 15, 1);
+
+      expect(result.total).toBe(42);
+    });
+
+    it('should fall back to results length when totalCount is absent', async () => {
+      const mockResponse: PatientProgramsResponse = {
+        results: mockEnrollments.slice(0, 2),
+      };
+      (get as jest.Mock).mockResolvedValue(mockResponse);
+
+      const result = await getPatientProgramsPage(patientUUID, 15, 1);
+
+      expect(result.total).toBe(2);
+    });
+
+    it('should return empty programs when no enrollments exist', async () => {
+      const mockResponse: PatientProgramsResponse = {
+        results: [],
+        totalCount: 0,
+      };
+      (get as jest.Mock).mockResolvedValue(mockResponse);
+
+      const result = await getPatientProgramsPage(patientUUID);
+
+      expect(result.programs).toEqual([]);
+      expect(result.total).toBe(0);
+    });
+
+    it('should propagate API errors', async () => {
+      (get as jest.Mock).mockRejectedValue(new Error('Network error'));
+
+      await expect(getPatientProgramsPage(patientUUID)).rejects.toThrow(
+        'Network error',
+      );
     });
   });
 });

--- a/packages/bahmni-services/src/programService/__tests__/programService.test.ts
+++ b/packages/bahmni-services/src/programService/__tests__/programService.test.ts
@@ -264,7 +264,7 @@ describe('programService', () => {
       expect(result.total).toBe(42);
     });
 
-    it('should fall back to results length when totalCount is absent', async () => {
+    it('should return undefined total when totalCount is absent', async () => {
       const mockResponse: PatientProgramsResponse = {
         results: mockEnrollments.slice(0, 2),
       };
@@ -272,7 +272,7 @@ describe('programService', () => {
 
       const result = await getPatientProgramsPage(patientUUID, 15, 1);
 
-      expect(result.total).toBe(2);
+      expect(result.total).toBeUndefined();
     });
 
     it('should return empty programs when no enrollments exist', async () => {

--- a/packages/bahmni-services/src/programService/constants.ts
+++ b/packages/bahmni-services/src/programService/constants.ts
@@ -5,6 +5,12 @@ const PROGRAM_ENROLLMENT_CUSTOM_REP =
 
 export const PATIENT_PROGRAMS_URL = (patientUUID: string) =>
   `${OPENMRS_REST_V1}/bahmniprogramenrollment?patient=${patientUUID}&v=${PROGRAM_ENROLLMENT_CUSTOM_REP}`;
+export const PATIENT_PROGRAMS_PAGE_URL = (
+  patientUUID: string,
+  limit: number = 15,
+  startIndex: number = 0,
+) =>
+  `${OPENMRS_REST_V1}/bahmniprogramenrollment?patient=${patientUUID}&v=${PROGRAM_ENROLLMENT_CUSTOM_REP}&limit=${limit}&startIndex=${startIndex}&totalCount=true`;
 export const PROGRAMS_URL = (programUUID: string) =>
   `${OPENMRS_REST_V1}/bahmniprogramenrollment/${programUUID}`;
 export const PROGRAM_DETAILS_URL = (programUUID: string) =>

--- a/packages/bahmni-services/src/programService/index.ts
+++ b/packages/bahmni-services/src/programService/index.ts
@@ -1,8 +1,10 @@
 export {
   getPatientPrograms,
+  getPatientProgramsPage,
   getProgramByUUID,
   getCurrentStateName,
   extractAttributes,
   updateProgramState,
+  type ProgramPage,
 } from './programService';
 export { type ProgramEnrollment, type PatientProgramsResponse } from './model';

--- a/packages/bahmni-services/src/programService/model.ts
+++ b/packages/bahmni-services/src/programService/model.ts
@@ -189,4 +189,5 @@ export interface ProgramEnrollment extends BaseResource {
 
 export interface PatientProgramsResponse {
   results: ProgramEnrollment[];
+  totalCount?: number;
 }

--- a/packages/bahmni-services/src/programService/programService.ts
+++ b/packages/bahmni-services/src/programService/programService.ts
@@ -21,7 +21,7 @@ export const getPatientPrograms = async (
 
 export interface ProgramPage {
   programs: ProgramEnrollment[];
-  total: number;
+  total: number | undefined;
 }
 
 /**
@@ -43,7 +43,7 @@ export const getPatientProgramsPage = async (
   );
   return {
     programs: response.results,
-    total: response.totalCount ?? response.results.length,
+    total: response.totalCount,
   };
 };
 

--- a/packages/bahmni-services/src/programService/programService.ts
+++ b/packages/bahmni-services/src/programService/programService.ts
@@ -2,12 +2,12 @@ import { get, post } from '../api';
 import { getDisplayNameForConcept } from '../conceptService';
 import {
   PATIENT_PROGRAMS_URL,
+  PATIENT_PROGRAMS_PAGE_URL,
   PROGRAM_DETAILS_URL,
   PROGRAMS_URL,
 } from './constants';
 import { PatientProgramsResponse, ProgramEnrollment } from './model';
 
-// TODO: Add Optional parameters for pagination and filtering
 /**
  * Fetches programs for a given patient UUID
  * @param patientUUID - The UUID of the patient
@@ -17,6 +17,34 @@ export const getPatientPrograms = async (
   patientUUID: string,
 ): Promise<PatientProgramsResponse> => {
   return await get<PatientProgramsResponse>(PATIENT_PROGRAMS_URL(patientUUID));
+};
+
+export interface ProgramPage {
+  programs: ProgramEnrollment[];
+  total: number;
+}
+
+/**
+ * Fetches a single page of patient programs using offset-based pagination.
+ * Uses startIndex = (page - 1) * count to jump directly to any page.
+ * @param patientUUID - The UUID of the patient
+ * @param count - Number of items per page (default 15)
+ * @param page - 1-based page number (default 1)
+ * @returns Promise resolving to a ProgramPage with programs and total count
+ */
+export const getPatientProgramsPage = async (
+  patientUUID: string,
+  count: number = 15,
+  page: number = 1,
+): Promise<ProgramPage> => {
+  const startIndex = (page - 1) * count;
+  const response = await get<PatientProgramsResponse>(
+    PATIENT_PROGRAMS_PAGE_URL(patientUUID, count, startIndex),
+  );
+  return {
+    programs: response.results,
+    total: response.totalCount ?? response.results.length,
+  };
 };
 
 /**

--- a/packages/bahmni-widgets/src/conditions/ConditionsTable.tsx
+++ b/packages/bahmni-widgets/src/conditions/ConditionsTable.tsx
@@ -1,39 +1,49 @@
 import { SortableDataTable, StatusTag, Tile } from '@bahmni/design-system';
 import {
-  getConditions,
+  getConditionPage,
   useTranslation,
   FormatDateResult,
   formatDateDistance,
   useSubscribeConsultationSaved,
 } from '@bahmni/services';
 import { useQuery } from '@tanstack/react-query';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { usePatientUUID } from '../hooks/usePatientUUID';
 import { useNotification } from '../notification';
+import { WidgetProps } from '../registry/model';
 import { ConditionViewModel, ConditionStatus } from './models';
 import styles from './styles/ConditionsTable.module.scss';
 import { createConditionViewModels } from './utils';
-
-const fetchConditions = async (
-  patientUUID: string,
-): Promise<ConditionViewModel[]> => {
-  const response = await getConditions(patientUUID!);
-  return createConditionViewModels(response);
-};
 
 // TODO: Take UUID As A Prop
 /**
  * Component to display patient conditions using SortableDataTable
  */
-const ConditionsTable: React.FC = () => {
-  const [conditions, setConditions] = useState<ConditionViewModel[]>([]);
+const ConditionsTable: React.FC<WidgetProps> = ({ config }) => {
+  // Number() safely handles non-numeric config values (NaN → falsy → fallback 10)
+  const configPageSize = Number(config?.pageSize) || 10;
   const patientUUID = usePatientUUID();
   const { t } = useTranslation();
   const { addNotification } = useNotification();
+
+  const [currentPage, setCurrentPage] = useState(1);
+  const [selectedPageSize, setSelectedPageSize] = useState(configPageSize);
+  const [serverTotal, setServerTotal] = useState<number | undefined>(undefined);
+
   const { data, isLoading, isError, error, refetch } = useQuery({
-    queryKey: ['conditions', patientUUID!],
+    queryKey: ['conditions', patientUUID!, currentPage, selectedPageSize],
     enabled: !!patientUUID,
-    queryFn: () => fetchConditions(patientUUID!),
+    queryFn: async () => {
+      const page = await getConditionPage(
+        patientUUID!,
+        selectedPageSize,
+        currentPage,
+      );
+      return {
+        conditions: createConditionViewModels(page.conditions),
+        total: page.total,
+      };
+    },
   });
 
   // Listen to consultation saved events and refetch if conditions were updated
@@ -52,6 +62,19 @@ const ConditionsTable: React.FC = () => {
     [patientUUID, refetch],
   );
 
+  // Update server total when data arrives
+  useEffect(() => {
+    if (data) {
+      setServerTotal(data.total);
+    }
+  }, [data]);
+
+  // Reset pagination when patient changes
+  useEffect(() => {
+    setCurrentPage(1);
+    setServerTotal(undefined);
+  }, [patientUUID]);
+
   useEffect(() => {
     if (isError)
       addNotification({
@@ -59,8 +82,23 @@ const ConditionsTable: React.FC = () => {
         message: error.message,
         type: 'error',
       });
-    if (data) setConditions(data);
-  }, [data, isLoading, isError, error, addNotification, t]);
+  }, [isError, error, addNotification, t]);
+
+  const handlePageChange = useCallback(
+    (newPage: number, newPageSize: number) => {
+      if (newPageSize !== selectedPageSize) {
+        // Page size changed: reset to page 1, re-fetch with new _count
+        setSelectedPageSize(newPageSize);
+        setCurrentPage(1);
+        setServerTotal(undefined);
+      } else {
+        // Offset-based pagination: any page can be fetched directly via
+        // _getpagesoffset = (page - 1) * _count — no cursor cache needed
+        setCurrentPage(newPage);
+      }
+    },
+    [selectedPageSize],
+  );
 
   const headers = useMemo(
     () => [
@@ -125,13 +163,17 @@ const ConditionsTable: React.FC = () => {
         <SortableDataTable
           headers={headers}
           ariaLabel={t('CONDITION_LIST_DISPLAY_CONTROL_TITLE')}
-          rows={conditions}
+          rows={data?.conditions ?? []}
           loading={isLoading}
           errorStateMessage={isError ? error.message : null}
           emptyStateMessage={t('CONDITION_LIST_NO_CONDITIONS')}
           renderCell={renderCell}
           className={styles.conditionsTableBody}
           dataTestId="conditions-table"
+          pageSize={selectedPageSize}
+          totalItems={serverTotal}
+          page={currentPage}
+          onPageChange={handlePageChange}
         />
       </div>
     </>

--- a/packages/bahmni-widgets/src/conditions/ConditionsTable.tsx
+++ b/packages/bahmni-widgets/src/conditions/ConditionsTable.tsx
@@ -28,11 +28,11 @@ const ConditionsTable: React.FC<WidgetProps> = ({ config }) => {
 
   const [currentPage, setCurrentPage] = useState(1);
   const [selectedPageSize, setSelectedPageSize] = useState(configPageSize);
-  const [serverTotal, setServerTotal] = useState<number | undefined>(undefined);
 
   const { data, isLoading, isError, error, refetch } = useQuery({
     queryKey: ['conditions', patientUUID!, currentPage, selectedPageSize],
     enabled: !!patientUUID,
+    placeholderData: (prev) => prev,
     queryFn: async () => {
       const page = await getConditionPage(
         patientUUID!,
@@ -62,17 +62,9 @@ const ConditionsTable: React.FC<WidgetProps> = ({ config }) => {
     [patientUUID, refetch],
   );
 
-  // Update server total when data arrives
-  useEffect(() => {
-    if (data) {
-      setServerTotal(data.total);
-    }
-  }, [data]);
-
   // Reset pagination when patient changes
   useEffect(() => {
     setCurrentPage(1);
-    setServerTotal(undefined);
   }, [patientUUID]);
 
   useEffect(() => {
@@ -90,7 +82,6 @@ const ConditionsTable: React.FC<WidgetProps> = ({ config }) => {
         // Page size changed: reset to page 1, re-fetch with new _count
         setSelectedPageSize(newPageSize);
         setCurrentPage(1);
-        setServerTotal(undefined);
       } else {
         // Offset-based pagination: any page can be fetched directly via
         // _getpagesoffset = (page - 1) * _count — no cursor cache needed
@@ -171,7 +162,7 @@ const ConditionsTable: React.FC<WidgetProps> = ({ config }) => {
           className={styles.conditionsTableBody}
           dataTestId="conditions-table"
           pageSize={selectedPageSize}
-          totalItems={serverTotal}
+          totalItems={data?.total}
           page={currentPage}
           onPageChange={handlePageChange}
         />

--- a/packages/bahmni-widgets/src/conditions/__tests__/ConditionsTable.integration.test.tsx
+++ b/packages/bahmni-widgets/src/conditions/__tests__/ConditionsTable.integration.test.tsx
@@ -1,108 +1,136 @@
-import { getConditions } from '@bahmni/services';
+import {
+  getConditionPage,
+  useSubscribeConsultationSaved,
+} from '@bahmni/services';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { Condition } from 'fhir/r4';
+import { usePatientUUID } from '../../hooks/usePatientUUID';
 import { useNotification } from '../../notification';
 import ConditionsTable from '../ConditionsTable';
 
 jest.mock('../../notification');
-jest.mock('@bahmni/services', () => ({
-  ...jest.requireActual('@bahmni/services'),
-  getConditions: jest.fn(),
-}));
 jest.mock('../../hooks/usePatientUUID', () => ({
   usePatientUUID: jest.fn(() => 'test-patient-uuid'),
 }));
+jest.mock('@bahmni/services', () => ({
+  ...jest.requireActual('@bahmni/services'),
+  useTranslation: () => ({ t: (key: string) => key }),
+  getConditionPage: jest.fn(),
+  useSubscribeConsultationSaved: jest.fn(),
+}));
+
+const mockedGetConditionPage = getConditionPage as jest.MockedFunction<
+  typeof getConditionPage
+>;
+
 const mockAddNotification = jest.fn();
 
-const mockValidConditions: Condition[] = [
-  {
-    resourceType: 'Condition',
-    id: 'condition-active-diabetes',
-    meta: {
-      versionId: '1',
-      lastUpdated: '2025-03-25T06:48:32.000+00:00',
-    },
-    clinicalStatus: {
-      coding: [
-        {
-          system: 'http://terminology.hl7.org/CodeSystem/condition-clinical',
-          code: 'active',
-          display: 'Active',
-        },
-      ],
-    },
-    code: {
-      coding: [
-        {
-          system: 'http://snomed.info/sct',
-          code: '73211009',
-          display: 'Diabetes mellitus',
-        },
-      ],
-    },
-    subject: {
-      reference: 'Patient/test-patient',
-      type: 'Patient',
-      display: 'John Doe',
-    },
-    onsetDateTime: '2023-01-15T10:30:00.000+00:00',
-    recordedDate: '2023-01-15T10:30:00.000+00:00',
-    recorder: {
-      reference: 'Practitioner/dr-smith',
-      display: 'Dr. Smith',
-    },
-    note: [
+const wrapPage = (conditions: Condition[], total?: number) => ({
+  conditions,
+  total: total ?? conditions.length,
+});
+
+const activeCondition: Condition = {
+  resourceType: 'Condition',
+  id: 'condition-active-diabetes',
+  clinicalStatus: {
+    coding: [
       {
-        text: 'Patient diagnosed with Type 2 diabetes',
-      },
-      {
-        text: 'Requires regular blood sugar monitoring',
+        system: 'http://terminology.hl7.org/CodeSystem/condition-clinical',
+        code: 'active',
+        display: 'Active',
       },
     ],
   },
-];
-
-describe('ConditionsTable', () => {
-  const queryClient: QueryClient = new QueryClient({
-    defaultOptions: {
-      queries: {
-        retry: false,
-        staleTime: 0,
+  code: {
+    coding: [
+      {
+        system: 'http://snomed.info/sct',
+        code: '73211009',
+        display: 'Diabetes mellitus',
       },
-    },
-  });
+    ],
+    text: 'Diabetes mellitus',
+  },
+  subject: { reference: 'Patient/test-patient', type: 'Patient' },
+  onsetDateTime: '2023-01-15T10:30:00.000+00:00',
+  recordedDate: '2023-01-15T10:30:00.000+00:00',
+  recorder: { reference: 'Practitioner/dr-smith', display: 'Dr. Smith' },
+};
+
+const inactiveCondition: Condition = {
+  resourceType: 'Condition',
+  id: 'condition-inactive-hypertension',
+  clinicalStatus: {
+    coding: [
+      {
+        system: 'http://terminology.hl7.org/CodeSystem/condition-clinical',
+        code: 'inactive',
+        display: 'Inactive',
+      },
+    ],
+  },
+  code: {
+    coding: [
+      {
+        system: 'http://snomed.info/sct',
+        code: '73211008',
+        display: 'High blood pressure',
+      },
+    ],
+    text: 'High blood pressure',
+  },
+  subject: { reference: 'Patient/test-patient', type: 'Patient' },
+  recordedDate: '2022-06-10T08:15:00.000+00:00',
+  recorder: { reference: 'Practitioner/dr-johnson', display: 'Dr. Johnson' },
+};
+
+describe('ConditionsTable Integration', () => {
+  let queryClient: QueryClient;
+
+  const renderComponent = (props = {}) =>
+    render(
+      <QueryClientProvider client={queryClient}>
+        <ConditionsTable {...props} />
+      </QueryClientProvider>,
+    );
+
   beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+          staleTime: 0,
+        },
+      },
+    });
     jest.clearAllMocks();
     (useNotification as jest.Mock).mockReturnValue({
       addNotification: mockAddNotification,
     });
   });
+
   afterEach(() => {
     queryClient.clear();
   });
 
-  const wrapper = (
-    <QueryClientProvider client={queryClient}>
-      <ConditionsTable />
-    </QueryClientProvider>
-  );
-  it('should show conditions table when an there patient has conditions marked', async () => {
-    (getConditions as jest.Mock).mockReturnValue(mockValidConditions);
-    render(wrapper);
+  it('should show conditions table when patient has conditions marked', async () => {
+    mockedGetConditionPage.mockResolvedValueOnce(wrapPage([activeCondition]));
+    renderComponent();
     expect(screen.getByTestId('condition-table')).toBeInTheDocument();
     await waitFor(() => {
       expect(screen.getByText('Diabetes mellitus')).toBeInTheDocument();
     });
-    expect(screen.getByText('Diabetes mellitus')).toBeInTheDocument();
     expect(screen.getByText('Dr. Smith')).toBeInTheDocument();
-    expect(getConditions).toHaveBeenCalledTimes(1);
+    expect(mockedGetConditionPage).toHaveBeenCalledTimes(1);
   });
 
   it('should show error state when an error occurs', async () => {
     const errorMessage = 'Failed to fetch conditions from server';
-    (getConditions as jest.Mock).mockRejectedValue(new Error(errorMessage));
-    render(wrapper);
+    mockedGetConditionPage.mockRejectedValueOnce(new Error(errorMessage));
+    renderComponent();
     expect(screen.getByTestId('condition-table')).toBeInTheDocument();
     await waitFor(() => {
       expect(screen.getByTestId('conditions-table-error')).toBeInTheDocument();
@@ -112,5 +140,164 @@ describe('ConditionsTable', () => {
         message: 'Failed to fetch conditions from server',
       });
     });
+  });
+
+  it('shows empty state when patient has no conditions', async () => {
+    mockedGetConditionPage.mockResolvedValueOnce(wrapPage([]));
+    renderComponent();
+    await waitFor(() => {
+      expect(screen.getByTestId('conditions-table-empty')).toBeInTheDocument();
+    });
+  });
+
+  it('calls service with page=1 on initial load', async () => {
+    mockedGetConditionPage.mockResolvedValueOnce(wrapPage([activeCondition]));
+    renderComponent();
+    await waitFor(() => {
+      expect(mockedGetConditionPage).toHaveBeenCalledWith(
+        'test-patient-uuid',
+        10,
+        1,
+      );
+    });
+  });
+
+  it('navigates to page 2 via offset-based fetch', async () => {
+    const user = userEvent.setup();
+
+    mockedGetConditionPage.mockResolvedValueOnce(
+      wrapPage([activeCondition], 4),
+    );
+    mockedGetConditionPage.mockResolvedValueOnce(
+      wrapPage([inactiveCondition], 4),
+    );
+
+    renderComponent({ config: { pageSize: 2 } });
+
+    await waitFor(() => {
+      expect(screen.getByText('Diabetes mellitus')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: /next page/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('High blood pressure')).toBeInTheDocument();
+    });
+
+    expect(mockedGetConditionPage).toHaveBeenLastCalledWith(
+      'test-patient-uuid',
+      2,
+      2,
+    );
+    expect(screen.queryByText('Diabetes mellitus')).not.toBeInTheDocument();
+  });
+
+  it('navigates back to page 1 when previous button is clicked', async () => {
+    const user = userEvent.setup();
+
+    mockedGetConditionPage.mockResolvedValueOnce(
+      wrapPage([activeCondition], 4),
+    );
+    mockedGetConditionPage.mockResolvedValueOnce(
+      wrapPage([inactiveCondition], 4),
+    );
+    mockedGetConditionPage.mockResolvedValueOnce(
+      wrapPage([activeCondition], 4),
+    );
+
+    renderComponent({ config: { pageSize: 2 } });
+
+    await waitFor(() => {
+      expect(screen.getByText('Diabetes mellitus')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: /next page/i }));
+    await waitFor(() => {
+      expect(screen.getByText('High blood pressure')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: /previous page/i }));
+    await waitFor(() => {
+      expect(screen.getByText('Diabetes mellitus')).toBeInTheDocument();
+    });
+
+    expect(mockedGetConditionPage).toHaveBeenLastCalledWith(
+      'test-patient-uuid',
+      2,
+      1,
+    );
+  });
+
+  it('re-fetches from page 1 when page size is changed', async () => {
+    const user = userEvent.setup();
+
+    mockedGetConditionPage.mockResolvedValueOnce(
+      wrapPage([activeCondition], 4),
+    );
+    mockedGetConditionPage.mockResolvedValueOnce(
+      wrapPage([activeCondition, inactiveCondition], 4),
+    );
+
+    renderComponent({ config: { pageSize: 2 } });
+
+    await waitFor(() => {
+      expect(screen.getByText('Diabetes mellitus')).toBeInTheDocument();
+    });
+
+    const select = screen.getByRole('combobox', { name: /items per page/i });
+    await user.selectOptions(select, '5');
+
+    await waitFor(() => {
+      expect(mockedGetConditionPage).toHaveBeenCalledTimes(2);
+    });
+
+    expect(mockedGetConditionPage).toHaveBeenLastCalledWith(
+      'test-patient-uuid',
+      5,
+      1,
+    );
+  });
+
+  it('hides pagination when server total is fewer than or equal to pageSize', async () => {
+    mockedGetConditionPage.mockResolvedValueOnce(
+      wrapPage([activeCondition, inactiveCondition], 2),
+    );
+
+    renderComponent({ config: { pageSize: 10 } });
+
+    await waitFor(() => {
+      expect(screen.getByText('Diabetes mellitus')).toBeInTheDocument();
+    });
+
+    expect(
+      screen.queryByRole('button', { name: /next page/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows pagination when server total exceeds pageSize', async () => {
+    mockedGetConditionPage.mockResolvedValueOnce(
+      wrapPage([activeCondition], 5),
+    );
+
+    renderComponent({ config: { pageSize: 2 } });
+
+    await waitFor(() => {
+      expect(screen.getByText('Diabetes mellitus')).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByRole('button', { name: /next page/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('does not call the API when patientUUID is null', async () => {
+    (usePatientUUID as jest.Mock).mockReturnValue(null);
+    mockedGetConditionPage.mockResolvedValueOnce(wrapPage([]));
+
+    renderComponent();
+
+    await act(async () => {});
+
+    expect(mockedGetConditionPage).not.toHaveBeenCalled();
   });
 });

--- a/packages/bahmni-widgets/src/conditions/__tests__/ConditionsTable.test.tsx
+++ b/packages/bahmni-widgets/src/conditions/__tests__/ConditionsTable.test.tsx
@@ -47,6 +47,18 @@ describe('ConditionsTable', () => {
       <ConditionsTable />
     </QueryClientProvider>
   );
+
+  const buildCondition = (index: number) => ({
+    code: `code-${index}`,
+    codeDisplay: `Condition ${index}`,
+    display: `Condition ${index}`,
+    id: `condition-${index}`,
+    note: undefined,
+    onsetDate: '2023-01-15T10:30:00.000+00:00',
+    recordedDate: '2023-01-15T10:30:00.000+00:00',
+    recorder: 'Dr. Smith',
+    status: 'active',
+  });
   it('should show loading state when data is loading', () => {
     (useQuery as jest.Mock).mockReturnValue({
       data: null,
@@ -78,7 +90,7 @@ describe('ConditionsTable', () => {
 
   it('should show empty state when an there is no data', () => {
     (useQuery as jest.Mock).mockReturnValue({
-      data: [],
+      data: { conditions: [], total: 0 },
       error: null,
       isError: false,
       isLoading: false,
@@ -90,56 +102,8 @@ describe('ConditionsTable', () => {
 
   it('should show conditions table when an there patient has conditions marked', () => {
     (useQuery as jest.Mock).mockReturnValue({
-      data: [
-        {
-          code: '73211009',
-          codeDisplay: 'Diabetes mellitus',
-          display: 'Diabetes mellitus',
-          id: 'condition-active-diabetes',
-          note: [
-            'Patient diagnosed with Type 2 diabetes',
-            'Requires regular blood sugar monitoring',
-          ],
-          onsetDate: '2023-01-15T10:30:00.000+00:00',
-          recordedDate: '2023-01-15T10:30:00.000+00:00',
-          recorder: 'Dr. Smith',
-          status: 'active',
-        },
-        {
-          code: '73211008',
-          codeDisplay: 'High blood pressure',
-          display: 'High blood pressure',
-          id: 'condition-inactive-hypertension',
-          note: undefined,
-          recordedDate: '2022-06-10T08:15:00.000+00:00',
-          recorder: 'Dr. Johnson',
-          status: 'inactive',
-        },
-      ],
-      error: null,
-      isError: false,
-      isLoading: false,
-    });
-    render(wrapper);
-    expect(screen.getByTestId('condition-table')).toBeInTheDocument();
-    expect(screen.getByText('Diabetes mellitus')).toBeInTheDocument();
-    const activeStatusTag = screen.getByTestId('condition-status-73211009');
-    expect(activeStatusTag).toHaveTextContent('CONDITION_LIST_ACTIVE');
-    expect(
-      screen.getByText('CONDITION_ONSET_SINCE_FORMAT'),
-    ).toBeInTheDocument();
-    expect(screen.getByText('High blood pressure')).toBeInTheDocument();
-    const inactiveStatusTag = screen.getByTestId('condition-status-73211008');
-    expect(inactiveStatusTag).toHaveTextContent('CONDITION_LIST_INACTIVE');
-    expect(
-      screen.getByText('CONDITION_TABLE_NOT_AVAILABLE'),
-    ).toBeInTheDocument();
-  });
-
-  describe('Accessibility', () => {
-    it('passes accessibility tests with data', async () => {
-      (useQuery as jest.Mock).mockReturnValue({
-        data: [
+      data: {
+        conditions: [
           {
             code: '73211009',
             codeDisplay: 'Diabetes mellitus',
@@ -165,6 +129,117 @@ describe('ConditionsTable', () => {
             status: 'inactive',
           },
         ],
+        total: 2,
+      },
+      error: null,
+      isError: false,
+      isLoading: false,
+    });
+    render(wrapper);
+    expect(screen.getByTestId('condition-table')).toBeInTheDocument();
+    expect(screen.getByText('Diabetes mellitus')).toBeInTheDocument();
+    const activeStatusTag = screen.getByTestId('condition-status-73211009');
+    expect(activeStatusTag).toHaveTextContent('CONDITION_LIST_ACTIVE');
+    expect(
+      screen.getByText('CONDITION_ONSET_SINCE_FORMAT'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('High blood pressure')).toBeInTheDocument();
+    const inactiveStatusTag = screen.getByTestId('condition-status-73211008');
+    expect(inactiveStatusTag).toHaveTextContent('CONDITION_LIST_INACTIVE');
+    expect(
+      screen.getByText('CONDITION_TABLE_NOT_AVAILABLE'),
+    ).toBeInTheDocument();
+  });
+
+  describe('Pagination', () => {
+    const manyConditions = Array.from({ length: 3 }, (_, i) =>
+      buildCondition(i + 1),
+    );
+
+    it('renders pagination when server total exceeds pageSize', () => {
+      (useQuery as jest.Mock).mockReturnValue({
+        data: { conditions: manyConditions, total: 5 },
+        error: null,
+        isError: false,
+        isLoading: false,
+      });
+      render(
+        <QueryClientProvider client={queryClient}>
+          <ConditionsTable config={{ pageSize: 1 }} />
+        </QueryClientProvider>,
+      );
+      expect(
+        screen.getByRole('button', { name: /next page/i }),
+      ).toBeInTheDocument();
+    });
+
+    it('hides pagination when server total is fewer than or equal to pageSize', () => {
+      (useQuery as jest.Mock).mockReturnValue({
+        data: { conditions: manyConditions, total: 3 },
+        error: null,
+        isError: false,
+        isLoading: false,
+      });
+      render(
+        <QueryClientProvider client={queryClient}>
+          <ConditionsTable config={{ pageSize: 10 }} />
+        </QueryClientProvider>,
+      );
+      expect(
+        screen.queryByRole('button', { name: /next page/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('displays the current page of conditions returned by the server', () => {
+      (useQuery as jest.Mock).mockReturnValue({
+        data: { conditions: manyConditions.slice(0, 2), total: 3 },
+        error: null,
+        isError: false,
+        isLoading: false,
+      });
+      render(
+        <QueryClientProvider client={queryClient}>
+          <ConditionsTable config={{ pageSize: 2 }} />
+        </QueryClientProvider>,
+      );
+      expect(screen.getByText('Condition 1')).toBeInTheDocument();
+      expect(screen.getByText('Condition 2')).toBeInTheDocument();
+      expect(screen.queryByText('Condition 3')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('passes accessibility tests with data', async () => {
+      (useQuery as jest.Mock).mockReturnValue({
+        data: {
+          conditions: [
+            {
+              code: '73211009',
+              codeDisplay: 'Diabetes mellitus',
+              display: 'Diabetes mellitus',
+              id: 'condition-active-diabetes',
+              note: [
+                'Patient diagnosed with Type 2 diabetes',
+                'Requires regular blood sugar monitoring',
+              ],
+              onsetDate: '2023-01-15T10:30:00.000+00:00',
+              recordedDate: '2023-01-15T10:30:00.000+00:00',
+              recorder: 'Dr. Smith',
+              status: 'active',
+            },
+            {
+              code: '73211008',
+              codeDisplay: 'High blood pressure',
+              display: 'High blood pressure',
+              id: 'condition-inactive-hypertension',
+              note: undefined,
+              recordedDate: '2022-06-10T08:15:00.000+00:00',
+              recorder: 'Dr. Johnson',
+              status: 'inactive',
+            },
+          ],
+          total: 2,
+        },
         error: null,
         isError: false,
         isLoading: false,

--- a/packages/bahmni-widgets/src/diagnoses/DiagnosesTable.tsx
+++ b/packages/bahmni-widgets/src/diagnoses/DiagnosesTable.tsx
@@ -25,12 +25,12 @@ const DiagnosesTable: React.FC<WidgetProps> = ({ config }) => {
 
   const [currentPage, setCurrentPage] = useState(1);
   const [selectedPageSize, setSelectedPageSize] = useState(configPageSize);
-  const [serverTotal, setServerTotal] = useState<number | undefined>(undefined);
 
   // Use TanStack Query for data fetching and caching
   const { data, isLoading, isError, error, refetch } = useQuery({
     queryKey: ['diagnoses', patientUUID!, currentPage, selectedPageSize],
     enabled: !!patientUUID,
+    placeholderData: (prev) => prev,
     queryFn: () =>
       getDiagnosesPage(patientUUID!, selectedPageSize, currentPage),
   });
@@ -51,17 +51,9 @@ const DiagnosesTable: React.FC<WidgetProps> = ({ config }) => {
     [patientUUID, refetch],
   );
 
-  // Update server total when data arrives
-  useEffect(() => {
-    if (data) {
-      setServerTotal(data.total);
-    }
-  }, [data]);
-
   // Reset pagination when patient changes
   useEffect(() => {
     setCurrentPage(1);
-    setServerTotal(undefined);
   }, [patientUUID]);
 
   // Handle errors with notifications
@@ -81,7 +73,6 @@ const DiagnosesTable: React.FC<WidgetProps> = ({ config }) => {
         // Page size changed: reset to page 1, re-fetch with new _count
         setSelectedPageSize(newPageSize);
         setCurrentPage(1);
-        setServerTotal(undefined);
       } else {
         // Offset-based pagination: any page can be fetched directly via
         // _getpagesoffset = (page - 1) * _count — no cursor cache needed
@@ -158,7 +149,7 @@ const DiagnosesTable: React.FC<WidgetProps> = ({ config }) => {
           className={styles.diagnosesTableBody}
           dataTestId="diagnoses-table"
           pageSize={selectedPageSize}
-          totalItems={serverTotal}
+          totalItems={data?.total}
           page={currentPage}
           onPageChange={handlePageChange}
         />

--- a/packages/bahmni-widgets/src/diagnoses/DiagnosesTable.tsx
+++ b/packages/bahmni-widgets/src/diagnoses/DiagnosesTable.tsx
@@ -1,31 +1,38 @@
 import { SortableDataTable, Tag, Tile } from '@bahmni/design-system';
 import {
   formatDateTime,
-  sortByDate,
   Diagnosis,
   useTranslation,
-  getPatientDiagnoses,
+  getDiagnosesPage,
   useSubscribeConsultationSaved,
 } from '@bahmni/services';
 import { useQuery } from '@tanstack/react-query';
-import React, { useMemo, useCallback, useEffect } from 'react';
+import React, { useMemo, useCallback, useEffect, useState } from 'react';
 import { usePatientUUID } from '../hooks/usePatientUUID';
 import { useNotification } from '../notification';
+import { WidgetProps } from '../registry/model';
 import styles from './styles/DiagnosesTable.module.scss';
 
 /**
  * Component to display patient diagnoses using SortableDataTable
  */
-const DiagnosesTable: React.FC = () => {
+const DiagnosesTable: React.FC<WidgetProps> = ({ config }) => {
+  // Number() safely handles non-numeric config values (NaN → falsy → fallback 10)
+  const configPageSize = Number(config?.pageSize) || 10;
   const { t } = useTranslation();
   const patientUUID = usePatientUUID();
   const { addNotification } = useNotification();
 
+  const [currentPage, setCurrentPage] = useState(1);
+  const [selectedPageSize, setSelectedPageSize] = useState(configPageSize);
+  const [serverTotal, setServerTotal] = useState<number | undefined>(undefined);
+
   // Use TanStack Query for data fetching and caching
   const { data, isLoading, isError, error, refetch } = useQuery({
-    queryKey: ['diagnoses', patientUUID!],
+    queryKey: ['diagnoses', patientUUID!, currentPage, selectedPageSize],
     enabled: !!patientUUID,
-    queryFn: () => getPatientDiagnoses(patientUUID!),
+    queryFn: () =>
+      getDiagnosesPage(patientUUID!, selectedPageSize, currentPage),
   });
 
   // Listen to consultation saved events and refetch if diagnoses were updated
@@ -44,6 +51,19 @@ const DiagnosesTable: React.FC = () => {
     [patientUUID, refetch],
   );
 
+  // Update server total when data arrives
+  useEffect(() => {
+    if (data) {
+      setServerTotal(data.total);
+    }
+  }, [data]);
+
+  // Reset pagination when patient changes
+  useEffect(() => {
+    setCurrentPage(1);
+    setServerTotal(undefined);
+  }, [patientUUID]);
+
   // Handle errors with notifications
   useEffect(() => {
     if (isError) {
@@ -55,6 +75,22 @@ const DiagnosesTable: React.FC = () => {
     }
   }, [isError, error, addNotification, t]);
 
+  const handlePageChange = useCallback(
+    (newPage: number, newPageSize: number) => {
+      if (newPageSize !== selectedPageSize) {
+        // Page size changed: reset to page 1, re-fetch with new _count
+        setSelectedPageSize(newPageSize);
+        setCurrentPage(1);
+        setServerTotal(undefined);
+      } else {
+        // Offset-based pagination: any page can be fetched directly via
+        // _getpagesoffset = (page - 1) * _count — no cursor cache needed
+        setCurrentPage(newPage);
+      }
+    },
+    [selectedPageSize],
+  );
+
   // Define table headers
   const headers = useMemo(
     () => [
@@ -65,9 +101,9 @@ const DiagnosesTable: React.FC = () => {
     [t],
   );
 
-  const processedDiagnoses = useMemo(() => {
-    return sortByDate(data ?? [], 'recordedDate');
-  }, [data]);
+  // Server sorts by _sort=-_lastUpdated (latest first); no per-page client sort needed.
+  // Per-page sortByDate would only sort within a page, producing inconsistent cross-page order.
+  const processedDiagnoses = data?.diagnoses ?? [];
 
   const renderCell = useCallback(
     (diagnosis: Diagnosis, cellId: string) => {
@@ -121,6 +157,10 @@ const DiagnosesTable: React.FC = () => {
           renderCell={renderCell}
           className={styles.diagnosesTableBody}
           dataTestId="diagnoses-table"
+          pageSize={selectedPageSize}
+          totalItems={serverTotal}
+          page={currentPage}
+          onPageChange={handlePageChange}
         />
       </div>
     </>

--- a/packages/bahmni-widgets/src/diagnoses/__tests__/DiagnosesTable.integration.test.tsx
+++ b/packages/bahmni-widgets/src/diagnoses/__tests__/DiagnosesTable.integration.test.tsx
@@ -322,6 +322,86 @@ describe('DiagnosesTable Integration', () => {
       expect(screen.queryByText('Hypertension')).not.toBeInTheDocument();
     });
 
+    it('navigates back to page 1 when previous button is clicked', async () => {
+      const user = userEvent.setup();
+      const queryClient = createTestQueryClient();
+
+      const page2Diagnoses: Diagnosis[] = [
+        {
+          id: '3',
+          display: 'Asthma',
+          certainty: {
+            code: 'confirmed',
+            display: 'CERTAINITY_CONFIRMED',
+            system: '',
+          },
+          recordedDate: '2024-02-01T10:30:00+00:00',
+          recorder: 'Dr. Wilson',
+        },
+      ];
+
+      mockGetDiagnosesPage.mockResolvedValueOnce(wrapPage(mockDiagnoses, 4));
+      mockGetDiagnosesPage.mockResolvedValueOnce(wrapPage(page2Diagnoses, 4));
+      mockGetDiagnosesPage.mockResolvedValueOnce(wrapPage(mockDiagnoses, 4));
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <DiagnosesTable config={{ pageSize: 2 }} />
+        </QueryClientProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Hypertension')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /next page/i }));
+      await waitFor(() => {
+        expect(screen.getByText('Asthma')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /previous page/i }));
+      await waitFor(() => {
+        expect(screen.getByText('Hypertension')).toBeInTheDocument();
+      });
+
+      expect(mockGetDiagnosesPage).toHaveBeenLastCalledWith(
+        'patient-123',
+        2,
+        1,
+      );
+    });
+
+    it('re-fetches from page 1 when page size is changed', async () => {
+      const user = userEvent.setup();
+      const queryClient = createTestQueryClient();
+
+      mockGetDiagnosesPage.mockResolvedValueOnce(wrapPage(mockDiagnoses, 4));
+      mockGetDiagnosesPage.mockResolvedValueOnce(wrapPage(mockDiagnoses, 4));
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <DiagnosesTable config={{ pageSize: 2 }} />
+        </QueryClientProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Hypertension')).toBeInTheDocument();
+      });
+
+      const select = screen.getByRole('combobox', { name: /items per page/i });
+      await user.selectOptions(select, '5');
+
+      await waitFor(() => {
+        expect(mockGetDiagnosesPage).toHaveBeenCalledTimes(2);
+      });
+
+      expect(mockGetDiagnosesPage).toHaveBeenLastCalledWith(
+        'patient-123',
+        5,
+        1,
+      );
+    });
+
     it('hides pagination when server total is fewer than or equal to pageSize', async () => {
       mockGetDiagnosesPage.mockResolvedValue(wrapPage(mockDiagnoses, 2));
 

--- a/packages/bahmni-widgets/src/diagnoses/__tests__/DiagnosesTable.integration.test.tsx
+++ b/packages/bahmni-widgets/src/diagnoses/__tests__/DiagnosesTable.integration.test.tsx
@@ -1,5 +1,5 @@
 import {
-  getPatientDiagnoses,
+  getDiagnosesPage,
   getFormattedError,
   useTranslation,
   useSubscribeConsultationSaved,
@@ -7,13 +7,14 @@ import {
 } from '@bahmni/services';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { usePatientUUID } from '../../hooks/usePatientUUID';
 import { useNotification } from '../../notification';
 import DiagnosesTable from '../DiagnosesTable';
 
 jest.mock('@bahmni/services', () => ({
   ...jest.requireActual('@bahmni/services'),
-  getPatientDiagnoses: jest.fn(),
+  getDiagnosesPage: jest.fn(),
   getFormattedError: jest.fn(),
   useTranslation: jest.fn(),
   useSubscribeConsultationSaved: jest.fn(),
@@ -22,8 +23,8 @@ jest.mock('@bahmni/services', () => ({
 jest.mock('../../hooks/usePatientUUID');
 jest.mock('../../notification');
 
-const mockGetPatientDiagnoses = getPatientDiagnoses as jest.MockedFunction<
-  typeof getPatientDiagnoses
+const mockGetDiagnosesPage = getDiagnosesPage as jest.MockedFunction<
+  typeof getDiagnosesPage
 >;
 const mockGetFormattedError = getFormattedError as jest.MockedFunction<
   typeof getFormattedError
@@ -41,6 +42,11 @@ const mockuseSubscribeConsultationSaved =
 const mockUseNotification = useNotification as jest.MockedFunction<
   typeof useNotification
 >;
+
+const wrapPage = (diagnoses: Diagnosis[], total?: number) => ({
+  diagnoses,
+  total: total ?? diagnoses.length,
+});
 
 const mockDiagnoses: Diagnosis[] = [
   {
@@ -122,7 +128,7 @@ describe('DiagnosesTable Integration', () => {
   });
 
   it('renders diagnoses from service through complete data flow', async () => {
-    mockGetPatientDiagnoses.mockResolvedValue(mockDiagnoses);
+    mockGetDiagnosesPage.mockResolvedValue(wrapPage(mockDiagnoses));
 
     renderWithQueryClient(<DiagnosesTable />);
 
@@ -135,12 +141,12 @@ describe('DiagnosesTable Integration', () => {
       expect(screen.getByText('Provisional')).toBeInTheDocument();
     });
 
-    expect(mockGetPatientDiagnoses).toHaveBeenCalledWith('patient-123');
+    expect(mockGetDiagnosesPage).toHaveBeenCalledWith('patient-123', 10, 1);
   });
 
   it('propagates service errors through hook to component UI', async () => {
     const serviceError = new Error('Network timeout');
-    mockGetPatientDiagnoses.mockRejectedValue(serviceError);
+    mockGetDiagnosesPage.mockRejectedValue(serviceError);
 
     renderWithQueryClient(<DiagnosesTable />);
 
@@ -157,7 +163,7 @@ describe('DiagnosesTable Integration', () => {
   });
 
   it('handles empty service response through complete flow', async () => {
-    mockGetPatientDiagnoses.mockResolvedValue([]);
+    mockGetDiagnosesPage.mockResolvedValue(wrapPage([]));
 
     renderWithQueryClient(<DiagnosesTable />);
 
@@ -176,28 +182,34 @@ describe('DiagnosesTable Integration', () => {
       expect(screen.getByTestId('diagnoses-table-empty')).toBeInTheDocument();
     });
 
-    expect(mockGetPatientDiagnoses).not.toHaveBeenCalled();
+    expect(mockGetDiagnosesPage).not.toHaveBeenCalled();
   });
 
   it('shows loading state during service call', async () => {
-    let resolvePromise: (value: Diagnosis[]) => void;
-    const servicePromise = new Promise<Diagnosis[]>((resolve) => {
+    let resolvePromise: (value: {
+      diagnoses: Diagnosis[];
+      total: number;
+    }) => void;
+    const servicePromise = new Promise<{
+      diagnoses: Diagnosis[];
+      total: number;
+    }>((resolve) => {
       resolvePromise = resolve;
     });
-    mockGetPatientDiagnoses.mockReturnValue(servicePromise);
+    mockGetDiagnosesPage.mockReturnValue(servicePromise);
 
     renderWithQueryClient(<DiagnosesTable />);
 
     expect(screen.getByTestId('diagnoses-table-skeleton')).toBeInTheDocument();
 
-    resolvePromise!(mockDiagnoses);
+    resolvePromise!(wrapPage(mockDiagnoses));
     await waitFor(() => {
       expect(screen.getByText('Hypertension')).toBeInTheDocument();
     });
   });
 
   it('registers consultation saved event listener', async () => {
-    mockGetPatientDiagnoses.mockResolvedValue(mockDiagnoses);
+    mockGetDiagnosesPage.mockResolvedValue(wrapPage(mockDiagnoses));
 
     renderWithQueryClient(<DiagnosesTable />);
 
@@ -214,7 +226,7 @@ describe('DiagnosesTable Integration', () => {
       eventCallback = callback;
     });
 
-    mockGetPatientDiagnoses.mockResolvedValue(mockDiagnoses);
+    mockGetDiagnosesPage.mockResolvedValue(wrapPage(mockDiagnoses));
 
     renderWithQueryClient(<DiagnosesTable />);
 
@@ -223,7 +235,7 @@ describe('DiagnosesTable Integration', () => {
     });
 
     // Initially called once
-    expect(mockGetPatientDiagnoses).toHaveBeenCalledTimes(1);
+    expect(mockGetDiagnosesPage).toHaveBeenCalledTimes(1);
 
     // Trigger consultation saved event
     const updatedDiagnoses: Diagnosis[] = [
@@ -240,7 +252,7 @@ describe('DiagnosesTable Integration', () => {
         recorder: 'Dr. Wilson',
       },
     ];
-    mockGetPatientDiagnoses.mockResolvedValue(updatedDiagnoses);
+    mockGetDiagnosesPage.mockResolvedValue(wrapPage(updatedDiagnoses));
 
     eventCallback({
       patientUUID: 'patient-123',
@@ -249,8 +261,93 @@ describe('DiagnosesTable Integration', () => {
 
     // Should refetch and display new diagnosis
     await waitFor(() => {
-      expect(mockGetPatientDiagnoses).toHaveBeenCalledTimes(2);
+      expect(mockGetDiagnosesPage).toHaveBeenCalledTimes(2);
       expect(screen.getByText('Asthma')).toBeInTheDocument();
+    });
+  });
+
+  describe('Pagination', () => {
+    it('calls service with page=1 on initial load', async () => {
+      mockGetDiagnosesPage.mockResolvedValue(wrapPage(mockDiagnoses));
+
+      renderWithQueryClient(<DiagnosesTable />);
+
+      await waitFor(() => {
+        expect(mockGetDiagnosesPage).toHaveBeenCalledWith('patient-123', 10, 1);
+      });
+    });
+
+    it('navigates to page 2 via offset-based fetch', async () => {
+      const user = userEvent.setup();
+      const queryClient = createTestQueryClient();
+
+      const page2Diagnoses: Diagnosis[] = [
+        {
+          id: '3',
+          display: 'Asthma',
+          certainty: {
+            code: 'confirmed',
+            display: 'CERTAINITY_CONFIRMED',
+            system: '',
+          },
+          recordedDate: '2024-02-01T10:30:00+00:00',
+          recorder: 'Dr. Wilson',
+        },
+      ];
+
+      mockGetDiagnosesPage.mockResolvedValueOnce(wrapPage(mockDiagnoses, 4));
+      mockGetDiagnosesPage.mockResolvedValueOnce(wrapPage(page2Diagnoses, 4));
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <DiagnosesTable config={{ pageSize: 2 }} />
+        </QueryClientProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Hypertension')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /next page/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Asthma')).toBeInTheDocument();
+      });
+
+      expect(mockGetDiagnosesPage).toHaveBeenLastCalledWith(
+        'patient-123',
+        2,
+        2,
+      );
+      expect(screen.queryByText('Hypertension')).not.toBeInTheDocument();
+    });
+
+    it('hides pagination when server total is fewer than or equal to pageSize', async () => {
+      mockGetDiagnosesPage.mockResolvedValue(wrapPage(mockDiagnoses, 2));
+
+      renderWithQueryClient(<DiagnosesTable config={{ pageSize: 10 }} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Hypertension')).toBeInTheDocument();
+      });
+
+      expect(
+        screen.queryByRole('button', { name: /next page/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('shows pagination when server total exceeds pageSize', async () => {
+      mockGetDiagnosesPage.mockResolvedValue(wrapPage(mockDiagnoses, 5));
+
+      renderWithQueryClient(<DiagnosesTable config={{ pageSize: 2 }} />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Hypertension')).toBeInTheDocument();
+      });
+
+      expect(
+        screen.getByRole('button', { name: /next page/i }),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/packages/bahmni-widgets/src/diagnoses/__tests__/DiagnosesTable.test.tsx
+++ b/packages/bahmni-widgets/src/diagnoses/__tests__/DiagnosesTable.test.tsx
@@ -139,7 +139,7 @@ describe('DiagnosesTable', () => {
 
   it('renders empty state', () => {
     mockUseQuery.mockReturnValue({
-      data: [],
+      data: { diagnoses: [], total: 0 },
       isLoading: false,
       isError: false,
       error: null,
@@ -150,9 +150,10 @@ describe('DiagnosesTable', () => {
     expect(screen.getByText('No diagnoses recorded')).toBeInTheDocument();
   });
 
-  it('sorts diagnoses by date', () => {
+  it('renders diagnoses in the order returned by the server (sorted by _lastUpdated desc)', () => {
+    // Server sorts via _sort=-_lastUpdated; component renders rows as-is without client-side re-sort
     mockUseQuery.mockReturnValue({
-      data: mockDiagnoses,
+      data: { diagnoses: mockDiagnoses, total: mockDiagnoses.length },
       isLoading: false,
       isError: false,
       error: null,
@@ -160,12 +161,15 @@ describe('DiagnosesTable', () => {
     } as any);
 
     render(<DiagnosesTable />);
-    expect(mockSortByDate).toHaveBeenCalledWith(mockDiagnoses, 'recordedDate');
+    // sortByDate is no longer called — sorting is delegated to the server
+    expect(mockSortByDate).not.toHaveBeenCalled();
+    // All diagnoses are still rendered
+    expect(screen.getByText('Hypertension')).toBeInTheDocument();
   });
 
   it('renders diagnosis display cell with confirmed certainty', () => {
     mockUseQuery.mockReturnValue({
-      data: [mockDiagnoses[0]],
+      data: { diagnoses: [mockDiagnoses[0]], total: 1 },
       isLoading: false,
       isError: false,
       error: null,
@@ -179,7 +183,7 @@ describe('DiagnosesTable', () => {
 
   it('renders diagnosis display cell with provisional certainty', () => {
     mockUseQuery.mockReturnValue({
-      data: [mockDiagnoses[1]],
+      data: { diagnoses: [mockDiagnoses[1]], total: 1 },
       isLoading: false,
       isError: false,
       error: null,
@@ -193,7 +197,7 @@ describe('DiagnosesTable', () => {
 
   it('renders formatted recorded date', () => {
     mockUseQuery.mockReturnValue({
-      data: [mockDiagnoses[0]],
+      data: { diagnoses: [mockDiagnoses[0]], total: 1 },
       isLoading: false,
       isError: false,
       error: null,
@@ -210,7 +214,7 @@ describe('DiagnosesTable', () => {
 
   it('renders recorder name when available', () => {
     mockUseQuery.mockReturnValue({
-      data: [mockDiagnoses[0]],
+      data: { diagnoses: [mockDiagnoses[0]], total: 1 },
       isLoading: false,
       isError: false,
       error: null,
@@ -223,7 +227,7 @@ describe('DiagnosesTable', () => {
 
   it('renders "Not available" when recorder is empty', () => {
     mockUseQuery.mockReturnValue({
-      data: [mockDiagnoses[2]],
+      data: { diagnoses: [mockDiagnoses[2]], total: 1 },
       isLoading: false,
       isError: false,
       error: null,
@@ -236,7 +240,7 @@ describe('DiagnosesTable', () => {
 
   it('registers consultation saved event listener', () => {
     mockUseQuery.mockReturnValue({
-      data: mockDiagnoses,
+      data: { diagnoses: mockDiagnoses, total: mockDiagnoses.length },
       isLoading: false,
       isError: false,
       error: null,
@@ -254,7 +258,7 @@ describe('DiagnosesTable', () => {
     });
 
     mockUseQuery.mockReturnValue({
-      data: mockDiagnoses,
+      data: { diagnoses: mockDiagnoses, total: mockDiagnoses.length },
       isLoading: false,
       isError: false,
       error: null,
@@ -279,7 +283,7 @@ describe('DiagnosesTable', () => {
     });
 
     mockUseQuery.mockReturnValue({
-      data: mockDiagnoses,
+      data: { diagnoses: mockDiagnoses, total: mockDiagnoses.length },
       isLoading: false,
       isError: false,
       error: null,
@@ -304,7 +308,7 @@ describe('DiagnosesTable', () => {
     });
 
     mockUseQuery.mockReturnValue({
-      data: mockDiagnoses,
+      data: { diagnoses: mockDiagnoses, total: mockDiagnoses.length },
       isLoading: false,
       isError: false,
       error: null,
@@ -322,9 +326,64 @@ describe('DiagnosesTable', () => {
     expect(mockRefetch).not.toHaveBeenCalled();
   });
 
+  describe('Pagination', () => {
+    const manyDiagnoses: Diagnosis[] = Array.from({ length: 3 }, (_, i) => ({
+      id: `${i + 1}`,
+      display: `Diagnosis ${i + 1}`,
+      certainty: { code: 'confirmed' },
+      recordedDate: '2024-01-15T10:30:00Z',
+      recorder: 'Dr. Smith',
+    }));
+
+    it('renders pagination when server total exceeds pageSize', () => {
+      mockUseQuery.mockReturnValue({
+        data: { diagnoses: manyDiagnoses, total: 5 },
+        isLoading: false,
+        isError: false,
+        error: null,
+        refetch: jest.fn(),
+      } as any);
+
+      render(<DiagnosesTable config={{ pageSize: 1 }} />);
+      expect(
+        screen.getByRole('button', { name: /next page/i }),
+      ).toBeInTheDocument();
+    });
+
+    it('hides pagination when server total is fewer than or equal to pageSize', () => {
+      mockUseQuery.mockReturnValue({
+        data: { diagnoses: manyDiagnoses, total: 3 },
+        isLoading: false,
+        isError: false,
+        error: null,
+        refetch: jest.fn(),
+      } as any);
+
+      render(<DiagnosesTable config={{ pageSize: 10 }} />);
+      expect(
+        screen.queryByRole('button', { name: /next page/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('displays the current page of diagnoses returned by the server', () => {
+      mockUseQuery.mockReturnValue({
+        data: { diagnoses: manyDiagnoses.slice(0, 2), total: 3 },
+        isLoading: false,
+        isError: false,
+        error: null,
+        refetch: jest.fn(),
+      } as any);
+
+      render(<DiagnosesTable config={{ pageSize: 2 }} />);
+      expect(screen.getByText('Diagnosis 1')).toBeInTheDocument();
+      expect(screen.getByText('Diagnosis 2')).toBeInTheDocument();
+      expect(screen.queryByText('Diagnosis 3')).not.toBeInTheDocument();
+    });
+  });
+
   it('has no accessibility violations', async () => {
     mockUseQuery.mockReturnValue({
-      data: mockDiagnoses,
+      data: { diagnoses: mockDiagnoses, total: mockDiagnoses.length },
       isLoading: false,
       isError: false,
       error: null,

--- a/packages/bahmni-widgets/src/patientPrograms/PatientProgramsTable.tsx
+++ b/packages/bahmni-widgets/src/patientPrograms/PatientProgramsTable.tsx
@@ -27,7 +27,6 @@ const PatientProgramsTable: React.FC<WidgetProps> = ({ config }) => {
 
   const [currentPage, setCurrentPage] = useState(1);
   const [selectedPageSize, setSelectedPageSize] = useState(configPageSize);
-  const [serverTotal, setServerTotal] = useState<number | undefined>(undefined);
 
   const programAttributes = useMemo(
     () => extractProgramAttributeNames((config?.fields as string[]) ?? []),
@@ -43,6 +42,7 @@ const PatientProgramsTable: React.FC<WidgetProps> = ({ config }) => {
       selectedPageSize,
     ],
     enabled: !!patientUUID,
+    placeholderData: (prev) => prev,
     queryFn: async () => {
       const page = await getPatientProgramsPage(
         patientUUID!,
@@ -59,17 +59,9 @@ const PatientProgramsTable: React.FC<WidgetProps> = ({ config }) => {
     },
   });
 
-  // Update server total when data arrives
-  useEffect(() => {
-    if (data) {
-      setServerTotal(data.total);
-    }
-  }, [data]);
-
   // Reset pagination when patient changes
   useEffect(() => {
     setCurrentPage(1);
-    setServerTotal(undefined);
   }, [patientUUID]);
 
   const handlePageChange = useCallback(
@@ -78,7 +70,6 @@ const PatientProgramsTable: React.FC<WidgetProps> = ({ config }) => {
         // Page size changed: reset to page 1, re-fetch with new limit
         setSelectedPageSize(newPageSize);
         setCurrentPage(1);
-        setServerTotal(undefined);
       } else {
         // Offset-based pagination: any page can be fetched directly via
         // startIndex = (page - 1) * limit — no cursor cache needed
@@ -200,7 +191,7 @@ const PatientProgramsTable: React.FC<WidgetProps> = ({ config }) => {
         className={styles.table}
         dataTestId="patient-programs-table"
         pageSize={selectedPageSize}
-        totalItems={serverTotal}
+        totalItems={data?.total}
         page={currentPage}
         onPageChange={handlePageChange}
       />

--- a/packages/bahmni-widgets/src/patientPrograms/PatientProgramsTable.tsx
+++ b/packages/bahmni-widgets/src/patientPrograms/PatientProgramsTable.tsx
@@ -2,11 +2,12 @@ import { SortableDataTable, Tag } from '@bahmni/design-system';
 import {
   useTranslation,
   formatDateTime,
-  getPatientPrograms,
+  getPatientProgramsPage,
 } from '@bahmni/services';
 import { useQuery } from '@tanstack/react-query';
-import React, { useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { usePatientUUID } from '../hooks/usePatientUUID';
+import { WidgetProps } from '../registry/model';
 import { PatientProgramViewModel } from './model';
 import styles from './styles/PatientProgramsTable.module.scss';
 import {
@@ -15,49 +16,96 @@ import {
   extractProgramAttributeNames,
 } from './utils';
 
-export const programsQueryKeys = (
-  patientUUID: string,
-  programAttributes: string[],
-) => ['programs', patientUUID, programAttributes] as const;
-
-const fetchPatientPrograms = async (
-  patientUUID: string,
-  programAttributes: string[],
-): Promise<PatientProgramViewModel[]> => {
-  const response = await getPatientPrograms(patientUUID!);
-  return createPatientProgramViewModal(response, programAttributes);
-};
-
-interface PatientProgramsTableProps {
-  config: {
-    fields: string[];
-  };
-}
-
 /**
  * Component to display patient programs using SortableDataTable
  */
-const PatientProgramsTable: React.FC<PatientProgramsTableProps> = ({
-  config,
-}) => {
+const PatientProgramsTable: React.FC<WidgetProps> = ({ config }) => {
   const { t } = useTranslation();
   const patientUUID = usePatientUUID();
+  // Number() safely handles non-numeric config values (NaN → falsy → fallback 15)
+  const configPageSize = Number(config?.pageSize) || 15;
+
+  const [currentPage, setCurrentPage] = useState(1);
+  const [selectedPageSize, setSelectedPageSize] = useState(configPageSize);
+  const [serverTotal, setServerTotal] = useState<number | undefined>(undefined);
 
   const programAttributes = useMemo(
-    () => extractProgramAttributeNames(config?.fields),
+    () => extractProgramAttributeNames((config?.fields as string[]) ?? []),
     [config?.fields],
   );
 
   const { data, isLoading, isError } = useQuery({
-    queryKey: programsQueryKeys(patientUUID!, programAttributes),
+    queryKey: [
+      'programs',
+      patientUUID!,
+      programAttributes,
+      currentPage,
+      selectedPageSize,
+    ],
     enabled: !!patientUUID,
-    queryFn: () => fetchPatientPrograms(patientUUID!, programAttributes),
+    queryFn: async () => {
+      const page = await getPatientProgramsPage(
+        patientUUID!,
+        selectedPageSize,
+        currentPage,
+      );
+      return {
+        programs: createPatientProgramViewModal(
+          { results: page.programs },
+          programAttributes,
+        ),
+        total: page.total,
+      };
+    },
   });
 
+  // Update server total when data arrives
+  useEffect(() => {
+    if (data) {
+      setServerTotal(data.total);
+    }
+  }, [data]);
+
+  // Reset pagination when patient changes
+  useEffect(() => {
+    setCurrentPage(1);
+    setServerTotal(undefined);
+  }, [patientUUID]);
+
+  const handlePageChange = useCallback(
+    (newPage: number, newPageSize: number) => {
+      if (newPageSize !== selectedPageSize) {
+        // Page size changed: reset to page 1, re-fetch with new limit
+        setSelectedPageSize(newPageSize);
+        setCurrentPage(1);
+        setServerTotal(undefined);
+      } else {
+        // Offset-based pagination: any page can be fetched directly via
+        // startIndex = (page - 1) * limit — no cursor cache needed
+        setCurrentPage(newPage);
+      }
+    },
+    [selectedPageSize],
+  );
+
   const headers = useMemo(
-    () => createProgramHeaders(config.fields, t),
+    () => createProgramHeaders((config?.fields as string[]) ?? [], t),
     [config?.fields],
   );
+
+  // Server-side sort is not supported by bahmniprogramenrollment endpoint.
+  // Apply client-side sort by dateEnrolled descending (most recent first).
+  const sortedPrograms = useMemo(() => {
+    const programs = data?.programs ?? [];
+    return [...programs].sort((a, b) => {
+      if (!a.dateEnrolled && !b.dateEnrolled) return 0;
+      if (!a.dateEnrolled) return 1;
+      if (!b.dateEnrolled) return -1;
+      return (
+        new Date(b.dateEnrolled).getTime() - new Date(a.dateEnrolled).getTime()
+      );
+    });
+  }, [data?.programs]);
 
   const renderCell = (program: PatientProgramViewModel, cellId: string) => {
     switch (cellId) {
@@ -144,13 +192,17 @@ const PatientProgramsTable: React.FC<PatientProgramsTableProps> = ({
       <SortableDataTable
         headers={headers}
         ariaLabel={t('PROGRAMS_TABLE_ARIA_LABEL')}
-        rows={data ?? []}
+        rows={sortedPrograms}
         loading={isLoading}
         errorStateMessage={isError ? t('ERROR_DEFAULT_TITLE') : null}
         emptyStateMessage={t('PROGRAMS_TABLE_MESSAGE_NO_DATA')}
         renderCell={renderCell}
         className={styles.table}
         dataTestId="patient-programs-table"
+        pageSize={selectedPageSize}
+        totalItems={serverTotal}
+        page={currentPage}
+        onPageChange={handlePageChange}
       />
     </div>
   );

--- a/packages/bahmni-widgets/src/patientPrograms/PatientProgramsTable.tsx
+++ b/packages/bahmni-widgets/src/patientPrograms/PatientProgramsTable.tsx
@@ -90,7 +90,7 @@ const PatientProgramsTable: React.FC<WidgetProps> = ({ config }) => {
 
   const headers = useMemo(
     () => createProgramHeaders((config?.fields as string[]) ?? [], t),
-    [config?.fields],
+    [config?.fields, t],
   );
 
   // Server-side sort is not supported by bahmniprogramenrollment endpoint.

--- a/packages/bahmni-widgets/src/patientPrograms/__tests__/PatientProgramsTable.integration.test.tsx
+++ b/packages/bahmni-widgets/src/patientPrograms/__tests__/PatientProgramsTable.integration.test.tsx
@@ -1,17 +1,31 @@
-import { getPatientPrograms, PatientProgramsResponse } from '@bahmni/services';
+import {
+  getPatientProgramsPage,
+  ProgramEnrollment,
+  PatientProgramsResponse,
+} from '@bahmni/services';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { usePatientUUID } from '../../hooks/usePatientUUID';
 import { useNotification } from '../../notification';
 import PatientProgramsTable from '../PatientProgramsTable';
 
 jest.mock('../../notification');
 jest.mock('@bahmni/services', () => ({
   ...jest.requireActual('@bahmni/services'),
-  getPatientPrograms: jest.fn(),
+  getPatientProgramsPage: jest.fn(),
 }));
 jest.mock('../../hooks/usePatientUUID', () => ({
   usePatientUUID: jest.fn(() => 'test-patient-uuid'),
 }));
+
+const mockedGetPatientProgramsPage =
+  getPatientProgramsPage as jest.MockedFunction<typeof getPatientProgramsPage>;
+
+const wrapPage = (programs: ProgramEnrollment[], total?: number) => ({
+  programs,
+  total: total ?? programs.length,
+});
 
 const mockAddNotification = jest.fn();
 
@@ -433,8 +447,8 @@ describe('PatientProgramsTable Integration', () => {
   });
 
   it('should fetch and display patient programs correctly', async () => {
-    (getPatientPrograms as jest.Mock).mockResolvedValue(
-      mockPatientProgramsResponse,
+    mockedGetPatientProgramsPage.mockResolvedValue(
+      wrapPage(mockPatientProgramsResponse.results),
     );
 
     render(
@@ -476,15 +490,17 @@ describe('PatientProgramsTable Integration', () => {
       screen.getByText('Patient completed treatment successfully'),
     ).toBeInTheDocument();
 
-    expect(getPatientPrograms).toHaveBeenCalledTimes(1);
-    expect(getPatientPrograms).toHaveBeenCalledWith('test-patient-uuid');
+    expect(mockedGetPatientProgramsPage).toHaveBeenCalledTimes(1);
+    expect(mockedGetPatientProgramsPage).toHaveBeenCalledWith(
+      'test-patient-uuid',
+      15,
+      1,
+    );
   });
 
   it('should show error state when an error occurs', async () => {
     const errorMessage = 'Failed to fetch patient programs from server';
-    (getPatientPrograms as jest.Mock).mockRejectedValue(
-      new Error(errorMessage),
-    );
+    mockedGetPatientProgramsPage.mockRejectedValue(new Error(errorMessage));
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -508,8 +524,8 @@ describe('PatientProgramsTable Integration', () => {
   });
 
   it('should fetch and display custom program attributes', async () => {
-    (getPatientPrograms as jest.Mock).mockResolvedValue(
-      mockPatientProgramsWithAttributes,
+    mockedGetPatientProgramsPage.mockResolvedValue(
+      wrapPage(mockPatientProgramsWithAttributes.results),
     );
 
     render(
@@ -539,12 +555,11 @@ describe('PatientProgramsTable Integration', () => {
     expect(screen.getByText('REG123456')).toBeInTheDocument();
     expect(screen.getByText('Category I')).toBeInTheDocument();
 
-    expect(getPatientPrograms).toHaveBeenCalledTimes(1);
-    expect(getPatientPrograms).toHaveBeenCalledWith('test-patient-uuid');
+    expect(mockedGetPatientProgramsPage).toHaveBeenCalledTimes(1);
   });
 
   it('should display empty state when no programs exist', async () => {
-    (getPatientPrograms as jest.Mock).mockResolvedValue({ results: [] });
+    mockedGetPatientProgramsPage.mockResolvedValue(wrapPage([]));
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -566,6 +581,116 @@ describe('PatientProgramsTable Integration', () => {
       ).toBeInTheDocument();
     });
 
-    expect(getPatientPrograms).toHaveBeenCalledTimes(1);
+    expect(mockedGetPatientProgramsPage).toHaveBeenCalledTimes(1);
+  });
+
+  describe('Pagination', () => {
+    it('calls service with page=1 on initial load', async () => {
+      mockedGetPatientProgramsPage.mockResolvedValue(
+        wrapPage(mockPatientProgramsResponse.results),
+      );
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <PatientProgramsTable
+            config={{ fields: ['programName', 'startDate', 'state'] }}
+          />
+        </QueryClientProvider>,
+      );
+
+      await waitFor(() => {
+        expect(mockedGetPatientProgramsPage).toHaveBeenCalledWith(
+          'test-patient-uuid',
+          15,
+          1,
+        );
+      });
+    });
+
+    it('navigates to page 2 via offset-based fetch', async () => {
+      const user = userEvent.setup();
+
+      mockedGetPatientProgramsPage.mockResolvedValueOnce(
+        wrapPage(mockPatientProgramsResponse.results, 4),
+      );
+      mockedGetPatientProgramsPage.mockResolvedValueOnce(
+        wrapPage(mockPatientProgramsWithAttributes.results, 4),
+      );
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <PatientProgramsTable
+            config={{
+              fields: ['programName', 'startDate', 'state'],
+              pageSize: 2,
+            }}
+          />
+        </QueryClientProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('HIV Program')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /next page/i }));
+
+      await waitFor(() => {
+        expect(mockedGetPatientProgramsPage).toHaveBeenLastCalledWith(
+          'test-patient-uuid',
+          2,
+          2,
+        );
+      });
+    });
+
+    it('hides pagination when server total is fewer than or equal to pageSize', async () => {
+      mockedGetPatientProgramsPage.mockResolvedValue(
+        wrapPage(mockPatientProgramsResponse.results, 2),
+      );
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <PatientProgramsTable
+            config={{
+              fields: ['programName', 'startDate', 'state'],
+              pageSize: 10,
+            }}
+          />
+        </QueryClientProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('HIV Program')).toBeInTheDocument();
+      });
+
+      expect(
+        screen.queryByRole('button', { name: /next page/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('shows pagination when server total exceeds pageSize', async () => {
+      mockedGetPatientProgramsPage.mockResolvedValue(
+        wrapPage(mockPatientProgramsResponse.results, 5),
+      );
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <PatientProgramsTable
+            config={{
+              fields: ['programName', 'startDate', 'state'],
+              pageSize: 2,
+            }}
+          />
+        </QueryClientProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('HIV Program')).toBeInTheDocument();
+      });
+
+      expect(
+        screen.getByRole('button', { name: /next page/i }),
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/packages/bahmni-widgets/src/patientPrograms/__tests__/PatientProgramsTable.integration.test.tsx
+++ b/packages/bahmni-widgets/src/patientPrograms/__tests__/PatientProgramsTable.integration.test.tsx
@@ -692,5 +692,122 @@ describe('PatientProgramsTable Integration', () => {
         screen.getByRole('button', { name: /next page/i }),
       ).toBeInTheDocument();
     });
+
+    it('navigates back to page 1 when previous button is clicked', async () => {
+      const user = userEvent.setup();
+
+      mockedGetPatientProgramsPage.mockResolvedValueOnce(
+        wrapPage(mockPatientProgramsResponse.results, 4),
+      );
+      mockedGetPatientProgramsPage.mockResolvedValueOnce(
+        wrapPage(mockPatientProgramsWithAttributes.results, 4),
+      );
+      mockedGetPatientProgramsPage.mockResolvedValueOnce(
+        wrapPage(mockPatientProgramsResponse.results, 4),
+      );
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <PatientProgramsTable
+            config={{
+              fields: ['programName', 'startDate', 'state'],
+              pageSize: 2,
+            }}
+          />
+        </QueryClientProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('HIV Program')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /next page/i }));
+      await waitFor(() => {
+        expect(mockedGetPatientProgramsPage).toHaveBeenCalledWith(
+          'test-patient-uuid',
+          2,
+          2,
+        );
+      });
+
+      await user.click(screen.getByRole('button', { name: /previous page/i }));
+      await waitFor(() => {
+        expect(mockedGetPatientProgramsPage).toHaveBeenLastCalledWith(
+          'test-patient-uuid',
+          2,
+          1,
+        );
+      });
+    });
+
+    it('re-fetches from page 1 when page size is changed', async () => {
+      const user = userEvent.setup();
+
+      mockedGetPatientProgramsPage.mockResolvedValueOnce(
+        wrapPage(mockPatientProgramsResponse.results, 4),
+      );
+      mockedGetPatientProgramsPage.mockResolvedValueOnce(
+        wrapPage(mockPatientProgramsResponse.results, 4),
+      );
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <PatientProgramsTable
+            config={{
+              fields: ['programName', 'startDate', 'state'],
+              pageSize: 2,
+            }}
+          />
+        </QueryClientProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('HIV Program')).toBeInTheDocument();
+      });
+
+      const select = screen.getByRole('combobox', { name: /items per page/i });
+      await user.selectOptions(select, '5');
+
+      await waitFor(() => {
+        expect(mockedGetPatientProgramsPage).toHaveBeenCalledTimes(2);
+      });
+
+      expect(mockedGetPatientProgramsPage).toHaveBeenLastCalledWith(
+        'test-patient-uuid',
+        5,
+        1,
+      );
+    });
+
+    it('renders programs sorted by dateEnrolled descending (most recent first)', async () => {
+      // Supply programs in ascending order — component must sort descending
+      const ascendingPrograms = {
+        results: [
+          mockPatientProgramsResponse.results[1], // TB: 2022-06-10 (older)
+          mockPatientProgramsResponse.results[0], // HIV: 2023-01-15 (newer)
+        ],
+      };
+
+      mockedGetPatientProgramsPage.mockResolvedValueOnce(
+        wrapPage(ascendingPrograms.results, 2),
+      );
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <PatientProgramsTable
+            config={{ fields: ['programName', 'startDate', 'state'] }}
+          />
+        </QueryClientProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('HIV Program')).toBeInTheDocument();
+      });
+
+      const rows = screen.getAllByRole('row');
+      // rows[0] is header; HIV (2023) must appear before TB (2022)
+      expect(rows[1]).toHaveTextContent('HIV Program');
+      expect(rows[2]).toHaveTextContent('TB Program');
+    });
   });
 });

--- a/packages/bahmni-widgets/src/patientPrograms/__tests__/PatientProgramsTable.test.tsx
+++ b/packages/bahmni-widgets/src/patientPrograms/__tests__/PatientProgramsTable.test.tsx
@@ -82,7 +82,7 @@ describe('PatientProgramsTable', () => {
 
   it('should show empty state when there is no data', () => {
     (useQuery as jest.Mock).mockReturnValue({
-      data: [],
+      data: { programs: [], total: 0 },
       error: null,
       isError: false,
       isLoading: false,
@@ -98,30 +98,33 @@ describe('PatientProgramsTable', () => {
 
   it('should show programs table when patient has programs', () => {
     (useQuery as jest.Mock).mockReturnValue({
-      data: [
-        {
-          id: 'program-1',
-          uuid: 'program-uuid-1',
-          programName: 'HIV Program',
-          dateEnrolled: '2023-01-15T10:30:00.000+00:00',
-          dateCompleted: null,
-          outcomeName: null,
-          outcomeDetails: null,
-          currentStateName: 'On ART',
-          attributes: {},
-        },
-        {
-          id: 'program-2',
-          uuid: 'program-uuid-2',
-          programName: 'TB Program',
-          dateEnrolled: '2022-06-10T08:15:00.000+00:00',
-          dateCompleted: '2023-01-10T08:15:00.000+00:00',
-          outcomeName: 'Cured',
-          outcomeDetails: 'Patient completed treatment successfully',
-          currentStateName: 'Treatment Complete',
-          attributes: {},
-        },
-      ],
+      data: {
+        programs: [
+          {
+            id: 'program-1',
+            uuid: 'program-uuid-1',
+            programName: 'HIV Program',
+            dateEnrolled: '2023-01-15T10:30:00.000+00:00',
+            dateCompleted: null,
+            outcomeName: null,
+            outcomeDetails: null,
+            currentStateName: 'On ART',
+            attributes: {},
+          },
+          {
+            id: 'program-2',
+            uuid: 'program-uuid-2',
+            programName: 'TB Program',
+            dateEnrolled: '2022-06-10T08:15:00.000+00:00',
+            dateCompleted: '2023-01-10T08:15:00.000+00:00',
+            outcomeName: 'Cured',
+            outcomeDetails: 'Patient completed treatment successfully',
+            currentStateName: 'Treatment Complete',
+            attributes: {},
+          },
+        ],
+        total: 2,
+      },
       error: null,
       isError: false,
       isLoading: false,
@@ -159,36 +162,39 @@ describe('PatientProgramsTable', () => {
     );
 
     (useQuery as jest.Mock).mockReturnValue({
-      data: [
-        {
-          id: 'program-1',
-          uuid: 'program-uuid-1',
-          programName: 'HIV Program',
-          dateEnrolled: '2023-01-15T10:30:00.000+00:00',
-          dateCompleted: null,
-          outcomeName: null,
-          outcomeDetails: null,
-          currentStateName: null,
-          attributes: {
-            'Registration Number': 'REG123456',
-            'Treatment Category': 'Category I',
+      data: {
+        programs: [
+          {
+            id: 'program-1',
+            uuid: 'program-uuid-1',
+            programName: 'HIV Program',
+            dateEnrolled: '2023-01-15T10:30:00.000+00:00',
+            dateCompleted: null,
+            outcomeName: null,
+            outcomeDetails: null,
+            currentStateName: null,
+            attributes: {
+              'Registration Number': 'REG123456',
+              'Treatment Category': 'Category I',
+            },
           },
-        },
-        {
-          id: 'program-2',
-          uuid: 'program-uuid-2',
-          programName: 'TB Program',
-          dateEnrolled: '2022-06-10T08:15:00.000+00:00',
-          dateCompleted: '2023-01-10T08:15:00.000+00:00',
-          outcomeName: 'Cured',
-          outcomeDetails: 'Patient completed treatment successfully',
-          currentStateName: 'Treatment Complete',
-          attributes: {
-            'Registration Number': 'REG789012',
-            'Treatment Category': null,
+          {
+            id: 'program-2',
+            uuid: 'program-uuid-2',
+            programName: 'TB Program',
+            dateEnrolled: '2022-06-10T08:15:00.000+00:00',
+            dateCompleted: '2023-01-10T08:15:00.000+00:00',
+            outcomeName: 'Cured',
+            outcomeDetails: 'Patient completed treatment successfully',
+            currentStateName: 'Treatment Complete',
+            attributes: {
+              'Registration Number': 'REG789012',
+              'Treatment Category': null,
+            },
           },
-        },
-      ],
+        ],
+        total: 2,
+      },
       error: null,
       isError: false,
       isLoading: false,
@@ -207,44 +213,81 @@ describe('PatientProgramsTable', () => {
     expect(nullAttributeCell).toHaveTextContent('-');
   });
 
-  it('should match snapshot with program data', () => {
-    (useQuery as jest.Mock).mockReturnValue({
-      data: [
-        {
-          id: 'program-1',
-          uuid: 'program-uuid-1',
-          programName: 'HIV Program',
-          dateEnrolled: '2023-01-15T10:30:00.000+00:00',
-          dateCompleted: null,
-          outcomeName: null,
-          outcomeDetails: null,
-          currentStateName: 'On ART',
-          attributes: {},
-        },
-        {
-          id: 'program-2',
-          uuid: 'program-uuid-2',
-          programName: 'TB Program',
-          dateEnrolled: '2022-06-10T08:15:00.000+00:00',
-          dateCompleted: '2023-01-10T08:15:00.000+00:00',
-          outcomeName: 'Cured',
-          outcomeDetails: 'Patient completed treatment successfully',
-          currentStateName: 'Treatment Complete',
-          attributes: {},
-        },
-      ],
-      error: null,
-      isError: false,
-      isLoading: false,
+  describe('Pagination', () => {
+    const manyPrograms = Array.from({ length: 3 }, (_, i) => ({
+      id: `program-${i + 1}`,
+      uuid: `program-uuid-${i + 1}`,
+      programName: `Program ${i + 1}`,
+      dateEnrolled: '2023-01-15T10:30:00.000+00:00',
+      dateCompleted: null,
+      outcomeName: null,
+      outcomeDetails: null,
+      currentStateName: null,
+      attributes: {},
+    }));
+
+    it('renders pagination when server total exceeds pageSize', () => {
+      (useQuery as jest.Mock).mockReturnValue({
+        data: { programs: manyPrograms, total: 5 },
+        error: null,
+        isError: false,
+        isLoading: false,
+      });
+      render(
+        <QueryClientProvider client={queryClient}>
+          <PatientProgramsTable
+            config={{ fields: ['programName', 'startDate'], pageSize: 1 }}
+          />
+        </QueryClientProvider>,
+      );
+      expect(
+        screen.getByRole('button', { name: /next page/i }),
+      ).toBeInTheDocument();
     });
-    const { container } = render(wrapper);
-    expect(container).toMatchSnapshot();
+
+    it('hides pagination when server total is fewer than or equal to pageSize', () => {
+      (useQuery as jest.Mock).mockReturnValue({
+        data: { programs: manyPrograms, total: 3 },
+        error: null,
+        isError: false,
+        isLoading: false,
+      });
+      render(
+        <QueryClientProvider client={queryClient}>
+          <PatientProgramsTable
+            config={{ fields: ['programName', 'startDate'], pageSize: 10 }}
+          />
+        </QueryClientProvider>,
+      );
+      expect(
+        screen.queryByRole('button', { name: /next page/i }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('displays the current page of programs returned by the server', () => {
+      (useQuery as jest.Mock).mockReturnValue({
+        data: { programs: manyPrograms.slice(0, 2), total: 3 },
+        error: null,
+        isError: false,
+        isLoading: false,
+      });
+      render(
+        <QueryClientProvider client={queryClient}>
+          <PatientProgramsTable
+            config={{ fields: ['programName', 'startDate'], pageSize: 2 }}
+          />
+        </QueryClientProvider>,
+      );
+      expect(screen.getByText('Program 1')).toBeInTheDocument();
+      expect(screen.getByText('Program 2')).toBeInTheDocument();
+      expect(screen.queryByText('Program 3')).not.toBeInTheDocument();
+    });
   });
 
-  describe('Accessibility', () => {
-    it('passes accessibility tests with data', async () => {
-      (useQuery as jest.Mock).mockReturnValue({
-        data: [
+  it('should match snapshot with program data', () => {
+    (useQuery as jest.Mock).mockReturnValue({
+      data: {
+        programs: [
           {
             id: 'program-1',
             uuid: 'program-uuid-1',
@@ -268,6 +311,46 @@ describe('PatientProgramsTable', () => {
             attributes: {},
           },
         ],
+        total: 2,
+      },
+      error: null,
+      isError: false,
+      isLoading: false,
+    });
+    const { container } = render(wrapper);
+    expect(container).toMatchSnapshot();
+  });
+
+  describe('Accessibility', () => {
+    it('passes accessibility tests with data', async () => {
+      (useQuery as jest.Mock).mockReturnValue({
+        data: {
+          programs: [
+            {
+              id: 'program-1',
+              uuid: 'program-uuid-1',
+              programName: 'HIV Program',
+              dateEnrolled: '2023-01-15T10:30:00.000+00:00',
+              dateCompleted: null,
+              outcomeName: null,
+              outcomeDetails: null,
+              currentStateName: 'On ART',
+              attributes: {},
+            },
+            {
+              id: 'program-2',
+              uuid: 'program-uuid-2',
+              programName: 'TB Program',
+              dateEnrolled: '2022-06-10T08:15:00.000+00:00',
+              dateCompleted: '2023-01-10T08:15:00.000+00:00',
+              outcomeName: 'Cured',
+              outcomeDetails: 'Patient completed treatment successfully',
+              currentStateName: 'Treatment Complete',
+              attributes: {},
+            },
+          ],
+          total: 2,
+        },
         error: null,
         isError: false,
         isLoading: false,

--- a/packages/bahmni-widgets/src/patientPrograms/__tests__/__snapshots__/PatientProgramsTable.test.tsx.snap
+++ b/packages/bahmni-widgets/src/patientPrograms/__tests__/__snapshots__/PatientProgramsTable.test.tsx.snap
@@ -27,12 +27,12 @@ exports[`PatientProgramsTable should match snapshot with program data 1`] = `
               >
                 <div
                   class="cds--table-sort__description"
-                  id="table-sort-_r_r_"
+                  id="table-sort-_r_16_"
                 >
                   Click to sort rows by PROGRAMS_TABLE_HEADER_PROGRAM_NAME header in ascending order
                 </div>
                 <button
-                  aria-describedby="table-sort-_r_r_"
+                  aria-describedby="table-sort-_r_16_"
                   class="cds--table-sort"
                   data-testid="table-header-programName"
                   type="button"
@@ -88,12 +88,12 @@ exports[`PatientProgramsTable should match snapshot with program data 1`] = `
               >
                 <div
                   class="cds--table-sort__description"
-                  id="table-sort-_r_s_"
+                  id="table-sort-_r_17_"
                 >
                   Click to sort rows by PROGRAMS_TABLE_HEADER_START_DATE header in ascending order
                 </div>
                 <button
-                  aria-describedby="table-sort-_r_s_"
+                  aria-describedby="table-sort-_r_17_"
                   class="cds--table-sort"
                   data-testid="table-header-startDate"
                   type="button"
@@ -149,12 +149,12 @@ exports[`PatientProgramsTable should match snapshot with program data 1`] = `
               >
                 <div
                   class="cds--table-sort__description"
-                  id="table-sort-_r_t_"
+                  id="table-sort-_r_18_"
                 >
                   Click to sort rows by PROGRAMS_TABLE_HEADER_END_DATE header in ascending order
                 </div>
                 <button
-                  aria-describedby="table-sort-_r_t_"
+                  aria-describedby="table-sort-_r_18_"
                   class="cds--table-sort"
                   data-testid="table-header-endDate"
                   type="button"
@@ -210,12 +210,12 @@ exports[`PatientProgramsTable should match snapshot with program data 1`] = `
               >
                 <div
                   class="cds--table-sort__description"
-                  id="table-sort-_r_u_"
+                  id="table-sort-_r_19_"
                 >
                   Click to sort rows by PROGRAMS_TABLE_HEADER_STATE header in ascending order
                 </div>
                 <button
-                  aria-describedby="table-sort-_r_u_"
+                  aria-describedby="table-sort-_r_19_"
                   class="cds--table-sort"
                   data-testid="table-header-state"
                   type="button"
@@ -271,12 +271,12 @@ exports[`PatientProgramsTable should match snapshot with program data 1`] = `
               >
                 <div
                   class="cds--table-sort__description"
-                  id="table-sort-_r_v_"
+                  id="table-sort-_r_1a_"
                 >
                   Click to sort rows by PROGRAMS_TABLE_HEADER_OUTCOME header in ascending order
                 </div>
                 <button
-                  aria-describedby="table-sort-_r_v_"
+                  aria-describedby="table-sort-_r_1a_"
                   class="cds--table-sort"
                   data-testid="table-header-outcome"
                   type="button"

--- a/packages/bahmni-widgets/src/patientPrograms/__tests__/__snapshots__/PatientProgramsTable.test.tsx.snap
+++ b/packages/bahmni-widgets/src/patientPrograms/__tests__/__snapshots__/PatientProgramsTable.test.tsx.snap
@@ -27,12 +27,12 @@ exports[`PatientProgramsTable should match snapshot with program data 1`] = `
               >
                 <div
                   class="cds--table-sort__description"
-                  id="table-sort-_r_a_"
+                  id="table-sort-_r_r_"
                 >
                   Click to sort rows by PROGRAMS_TABLE_HEADER_PROGRAM_NAME header in ascending order
                 </div>
                 <button
-                  aria-describedby="table-sort-_r_a_"
+                  aria-describedby="table-sort-_r_r_"
                   class="cds--table-sort"
                   data-testid="table-header-programName"
                   type="button"
@@ -88,12 +88,12 @@ exports[`PatientProgramsTable should match snapshot with program data 1`] = `
               >
                 <div
                   class="cds--table-sort__description"
-                  id="table-sort-_r_b_"
+                  id="table-sort-_r_s_"
                 >
                   Click to sort rows by PROGRAMS_TABLE_HEADER_START_DATE header in ascending order
                 </div>
                 <button
-                  aria-describedby="table-sort-_r_b_"
+                  aria-describedby="table-sort-_r_s_"
                   class="cds--table-sort"
                   data-testid="table-header-startDate"
                   type="button"
@@ -149,12 +149,12 @@ exports[`PatientProgramsTable should match snapshot with program data 1`] = `
               >
                 <div
                   class="cds--table-sort__description"
-                  id="table-sort-_r_c_"
+                  id="table-sort-_r_t_"
                 >
                   Click to sort rows by PROGRAMS_TABLE_HEADER_END_DATE header in ascending order
                 </div>
                 <button
-                  aria-describedby="table-sort-_r_c_"
+                  aria-describedby="table-sort-_r_t_"
                   class="cds--table-sort"
                   data-testid="table-header-endDate"
                   type="button"
@@ -210,12 +210,12 @@ exports[`PatientProgramsTable should match snapshot with program data 1`] = `
               >
                 <div
                   class="cds--table-sort__description"
-                  id="table-sort-_r_d_"
+                  id="table-sort-_r_u_"
                 >
                   Click to sort rows by PROGRAMS_TABLE_HEADER_STATE header in ascending order
                 </div>
                 <button
-                  aria-describedby="table-sort-_r_d_"
+                  aria-describedby="table-sort-_r_u_"
                   class="cds--table-sort"
                   data-testid="table-header-state"
                   type="button"
@@ -271,12 +271,12 @@ exports[`PatientProgramsTable should match snapshot with program data 1`] = `
               >
                 <div
                   class="cds--table-sort__description"
-                  id="table-sort-_r_e_"
+                  id="table-sort-_r_v_"
                 >
                   Click to sort rows by PROGRAMS_TABLE_HEADER_OUTCOME header in ascending order
                 </div>
                 <button
-                  aria-describedby="table-sort-_r_e_"
+                  aria-describedby="table-sort-_r_v_"
                   class="cds--table-sort"
                   data-testid="table-header-outcome"
                   type="button"

--- a/packages/bahmni-widgets/src/patientPrograms/index.ts
+++ b/packages/bahmni-widgets/src/patientPrograms/index.ts
@@ -1,4 +1,1 @@
-export {
-  default as PatientProgramsTable,
-  programsQueryKeys,
-} from './PatientProgramsTable';
+export { default as PatientProgramsTable } from './PatientProgramsTable';


### PR DESCRIPTION
## Description

As a developer, I need pagination support in SortableDataTable so that widgets can implement pagination consistently.

Identified widgets include PatientProgramsTable, DiagnosesTable, ConditionsTable

Note: pageSize: controlled by “standard_config” parameter, default is 10
