### PR TITLE
[BAH-4450] Make individual controls responsive

### DIFF
--- a/apps/clinical/src/components/dashboardSection/styles/DashboardSection.module.scss
+++ b/apps/clinical/src/components/dashboardSection/styles/DashboardSection.module.scss
@@ -5,21 +5,23 @@
 
 .sectionWrapper {
   box-shadow: 0px 2px 6px 0px $shadow;
-  :global(.cds--data-table:has(td:nth-child(5))) td,
-  :global(.cds--data-table:has(td:nth-child(5))) th {
-    min-width: 110px;
-  }
-  :global(div[id^="accordion-item"]) {
-    padding-block-end: $spacing-05;
+  :global(html:has([data-separator])) & {
+    overflow-x: auto;
   }
 }
 
 :global(html:has([data-separator]) div[id^="accordion-item"]) {
   overflow-x: auto;
+  padding-block-end: $spacing-05;
 }
 
-:global(html:has([data-separator]) .cds--data-table:has(td:nth-child(5))) {
+:global(html:has([data-separator]) #main-display-area .cds--data-table:has(td:nth-child(5))) {
   min-width: 1000px;
+}
+
+:global(html:has([data-separator]) #main-display-area .cds--data-table:has(td:nth-child(5))) td,
+:global(html:has([data-separator]) #main-display-area .cds--data-table:has(td:nth-child(5))) th {
+  min-width: 110px;
 }
 
 .sectionName {

--- a/apps/clinical/src/components/dashboardSection/styles/DashboardSection.module.scss
+++ b/apps/clinical/src/components/dashboardSection/styles/DashboardSection.module.scss
@@ -3,6 +3,9 @@
 @use "@carbon/react/scss/theme" as *;
 @use "@carbon/react/scss/type" as *;
 
+$table-min-width: 62.5rem;
+$table-cell-min-width: 6.875rem;
+
 .sectionWrapper {
   box-shadow: 0px 2px 6px 0px $shadow;
   :global(html:has([data-separator])) & {
@@ -10,18 +13,17 @@
   }
 }
 
-:global(html:has([data-separator]) div[id^="accordion-item"]) {
+:global(html:has([data-separator]) #main-display-area div[id^="accordion-item"]) {
   overflow-x: auto;
   padding-block-end: $spacing-05;
 }
 
 :global(html:has([data-separator]) #main-display-area .cds--data-table:has(td:nth-child(5))) {
-  min-width: 1000px;
-}
+  min-width: $table-min-width;
 
-:global(html:has([data-separator]) #main-display-area .cds--data-table:has(td:nth-child(5))) td,
-:global(html:has([data-separator]) #main-display-area .cds--data-table:has(td:nth-child(5))) th {
-  min-width: 110px;
+  td, th {
+    min-width: $table-cell-min-width;
+  }
 }
 
 .sectionName {

--- a/apps/clinical/src/components/dashboardSection/styles/DashboardSection.module.scss
+++ b/apps/clinical/src/components/dashboardSection/styles/DashboardSection.module.scss
@@ -15,6 +15,9 @@ $table-cell-min-width: 6.875rem;
 
 :global(html:has([data-separator]) #main-display-area div[id^="accordion-item"]) {
   overflow-x: auto;
+}
+
+:global(html:has([data-separator]) #main-display-area div[id^="accordion-item"]:has(.cds--data-table td:nth-child(5))) {
   padding-block-end: $spacing-05;
 }
 

--- a/apps/clinical/src/components/dashboardSection/styles/DashboardSection.module.scss
+++ b/apps/clinical/src/components/dashboardSection/styles/DashboardSection.module.scss
@@ -5,6 +5,21 @@
 
 .sectionWrapper {
   box-shadow: 0px 2px 6px 0px $shadow;
+  :global(.cds--data-table:has(td:nth-child(5))) td,
+  :global(.cds--data-table:has(td:nth-child(5))) th {
+    min-width: 110px;
+  }
+  :global(div[id^="accordion-item"]) {
+    padding-block-end: $spacing-05;
+  }
+}
+
+:global(html:has([data-separator]) div[id^="accordion-item"]) {
+  overflow-x: auto;
+}
+
+:global(html:has([data-separator]) .cds--data-table:has(td:nth-child(5))) {
+  min-width: 1000px;
 }
 
 .sectionName {


### PR DESCRIPTION
**JIRA** → [BAH-#4450](https://bahmni.atlassian.net/browse/BAH-4450?atlOrigin=eyJpIjoiY2YyMTJkNDQ2M2RjNDZlMGJlNmI2NmYxMzEwYmE5NGQiLCJwIjoiaiJ9)

### **Description**
## Summary                                                                                                                                                                
  - Added responsive CSS for dashboard section tables with 5+ columns
  - Tables with 5+ columns scroll horizontally on smaller screens with a min-width of 1000px                                                                                
  - Set minimum column width of 110px to prevent content overflow                                                                                                           
                                                                                                                                                                            
  ## Test plan                                                                                                                                                              
  - [x] Verify dashboard tables with 5+ columns are horizontally scrollable on small screens                                                                                
  - [x] Verify tables with fewer than 5 columns are unaffected
  - [x] Verify scrollbar in Basic details control in the 40-60 split view
 
Authored by: sivavithyaashree.m@thoughtworks.com
Co-authored by: Komal.sharma@thoughtworks.com

---