### PR TITLE
[BAH-4450] Fix observations horizontal scroll in split view

### DIFF
--- a/apps/clinical/src/components/dashboardSection/styles/DashboardSection.module.scss
+++ b/apps/clinical/src/components/dashboardSection/styles/DashboardSection.module.scss
@@ -5,21 +5,23 @@
 
 .sectionWrapper {
   box-shadow: 0px 2px 6px 0px $shadow;
-  :global(.cds--data-table:has(td:nth-child(5))) td,
-  :global(.cds--data-table:has(td:nth-child(5))) th {
-    min-width: 110px;
-  }
-  :global(div[id^="accordion-item"]) {
-    padding-block-end: $spacing-05;
+  :global(html:has([data-separator])) & {
+    overflow-x: auto;
   }
 }
 
 :global(html:has([data-separator]) div[id^="accordion-item"]) {
   overflow-x: auto;
+  padding-block-end: $spacing-05;
 }
 
-:global(html:has([data-separator]) .cds--data-table:has(td:nth-child(5))) {
+:global(html:has([data-separator]) #main-display-area .cds--data-table:has(td:nth-child(5))) {
   min-width: 1000px;
+}
+
+:global(html:has([data-separator]) #main-display-area .cds--data-table:has(td:nth-child(5))) td,
+:global(html:has([data-separator]) #main-display-area .cds--data-table:has(td:nth-child(5))) th {
+  min-width: 110px;
 }
 
 .sectionName {

--- a/apps/clinical/src/components/dashboardSection/styles/DashboardSection.module.scss
+++ b/apps/clinical/src/components/dashboardSection/styles/DashboardSection.module.scss
@@ -3,6 +3,9 @@
 @use "@carbon/react/scss/theme" as *;
 @use "@carbon/react/scss/type" as *;
 
+$table-min-width: 62.5rem;
+$table-cell-min-width: 6.875rem;
+
 .sectionWrapper {
   box-shadow: 0px 2px 6px 0px $shadow;
   :global(html:has([data-separator])) & {
@@ -10,18 +13,17 @@
   }
 }
 
-:global(html:has([data-separator]) div[id^="accordion-item"]) {
+:global(html:has([data-separator]) #main-display-area div[id^="accordion-item"]) {
   overflow-x: auto;
   padding-block-end: $spacing-05;
 }
 
 :global(html:has([data-separator]) #main-display-area .cds--data-table:has(td:nth-child(5))) {
-  min-width: 1000px;
-}
+  min-width: $table-min-width;
 
-:global(html:has([data-separator]) #main-display-area .cds--data-table:has(td:nth-child(5))) td,
-:global(html:has([data-separator]) #main-display-area .cds--data-table:has(td:nth-child(5))) th {
-  min-width: 110px;
+  td, th {
+    min-width: $table-cell-min-width;
+  }
 }
 
 .sectionName {

--- a/apps/clinical/src/components/dashboardSection/styles/DashboardSection.module.scss
+++ b/apps/clinical/src/components/dashboardSection/styles/DashboardSection.module.scss
@@ -15,6 +15,9 @@ $table-cell-min-width: 6.875rem;
 
 :global(html:has([data-separator]) #main-display-area div[id^="accordion-item"]) {
   overflow-x: auto;
+}
+
+:global(html:has([data-separator]) #main-display-area div[id^="accordion-item"]:has(.cds--data-table td:nth-child(5))) {
   padding-block-end: $spacing-05;
 }
 

--- a/apps/clinical/src/components/dashboardSection/styles/DashboardSection.module.scss
+++ b/apps/clinical/src/components/dashboardSection/styles/DashboardSection.module.scss
@@ -5,6 +5,21 @@
 
 .sectionWrapper {
   box-shadow: 0px 2px 6px 0px $shadow;
+  :global(.cds--data-table:has(td:nth-child(5))) td,
+  :global(.cds--data-table:has(td:nth-child(5))) th {
+    min-width: 110px;
+  }
+  :global(div[id^="accordion-item"]) {
+    padding-block-end: $spacing-05;
+  }
+}
+
+:global(html:has([data-separator]) div[id^="accordion-item"]) {
+  overflow-x: auto;
+}
+
+:global(html:has([data-separator]) .cds--data-table:has(td:nth-child(5))) {
+  min-width: 1000px;
 }
 
 .sectionName {

--- a/packages/bahmni-design-system/src/molecules/collapsibleRowGroup/styles/CollapsibleRowGroup.module.scss
+++ b/packages/bahmni-design-system/src/molecules/collapsibleRowGroup/styles/CollapsibleRowGroup.module.scss
@@ -14,6 +14,9 @@
   width: 100%;
   max-width: 100%;
   overflow-x: hidden;
+  :global(html:has([data-separator]) #main-display-area) & {
+    overflow-x: auto;
+  }
   div:last-child {
     padding-block: 0;
   }
@@ -38,6 +41,9 @@
   width: 100%;
   max-width: 100%;
   box-sizing: border-box;
+  :global(html:has([data-separator]) #main-display-area) & {
+    min-width: 62.5rem;
+  }
 }
 
 .accordion:last-child {

--- a/packages/bahmni-widgets/src/observations/__tests__/__snapshots__/ObsByEncounter.test.tsx.snap
+++ b/packages/bahmni-widgets/src/observations/__tests__/__snapshots__/ObsByEncounter.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`ObsByEncounter Snapshot should match snapshot for ObsByEncounter 1`] = 
   >
     <div
       aria-label="encounter-enc-1-aria-label"
-      class="_container_1ml42_1"
+      class="_container_7xzxd_1"
       data-testid="encounter-enc-1-test-id"
       id="encounter-enc-1"
     >
@@ -17,7 +17,7 @@ exports[`ObsByEncounter Snapshot should match snapshot for ObsByEncounter 1`] = 
         class="cds--accordion cds--accordion--start cds--accordion--lg cds--layout--size-lg"
       >
         <li
-          class="cds--accordion__item cds--accordion__item--active _accordion_1ml42_5"
+          class="cds--accordion__item cds--accordion__item--active _accordion_7xzxd_5"
           data-testid="encounter-enc-1-test-id-accordion-item"
         >
           <button
@@ -57,7 +57,7 @@ exports[`ObsByEncounter Snapshot should match snapshot for ObsByEncounter 1`] = 
             >
               <div
                 aria-label="encounter-enc-1-rows-aria-label"
-                class="_rows_1ml42_35"
+                class="_rows_7xzxd_38"
                 data-testid="encounter-enc-1-rows-test-id"
                 id="encounter-enc-1-rows"
               >
@@ -94,7 +94,7 @@ exports[`ObsByEncounter Snapshot should match snapshot for ObsByEncounter 1`] = 
                 </div>
                 <div
                   aria-label="grouped-obs-Blood Pressure-0-aria-label"
-                  class="_container_1ml42_1"
+                  class="_container_7xzxd_1"
                   data-testid="grouped-obs-Blood Pressure-0-test-id"
                   id="grouped-obs-Blood Pressure-0"
                 >
@@ -102,7 +102,7 @@ exports[`ObsByEncounter Snapshot should match snapshot for ObsByEncounter 1`] = 
                     class="cds--accordion cds--accordion--start cds--accordion--lg cds--layout--size-lg"
                   >
                     <li
-                      class="cds--accordion__item cds--accordion__item--active _accordion_1ml42_5"
+                      class="cds--accordion__item cds--accordion__item--active _accordion_7xzxd_5"
                       data-testid="grouped-obs-Blood Pressure-0-test-id-accordion-item"
                     >
                       <button
@@ -142,7 +142,7 @@ exports[`ObsByEncounter Snapshot should match snapshot for ObsByEncounter 1`] = 
                         >
                           <div
                             aria-label="grouped-obs-Blood Pressure-0-rows-aria-label"
-                            class="_rows_1ml42_35"
+                            class="_rows_7xzxd_38"
                             data-testid="grouped-obs-Blood Pressure-0-rows-test-id"
                             id="grouped-obs-Blood Pressure-0-rows"
                           >


### PR DESCRIPTION
  Issue- In the 40-60 split view, RowCell-based display controls (Observations, History and   
  Examinations) were truncating content .                                                                          
                                                                                              
  Root Cause: Two CSS issues in CollapsibleRowGroup.module.scss:        
  1. .accordion had overflow-x: hidden — blocking the scrollbar from appearing                
  2. .rows had width: 100% / max-width: 100% — content always shrank to fit the narrow container

  Fix (in CollapsibleRowGroup.module.scss):                                                     
  - .accordion: Override overflow-x: hidden → overflow-x: auto in split mode to allow the
  scrollbar                                                                                     
  - .rows: Set min-width: 62.5rem in split mode to force content wider than the narrow panel, 
  triggering horizontal scroll                                                                  
                                                                                                                                      
                                                                                                
  Files Changed: packages/bahmni-design-system/src/molecules/collapsibleRowGroup/styles/Collapsi
  bleRowGroup.module.scss  
