### PR TITLE
BAH-4583 | <Kanchi/Kabita> | Add. Redirect options to patient dashboard for Bahmnni Lite

### DIFF
--- a/apps/registration/public/locales/locale_en.json
+++ b/apps/registration/public/locales/locale_en.json
@@ -152,6 +152,7 @@
   "NOTIFICATION_PATIENT_SAVE_FAILED": "Failed to save patient",
   "NOTIFICATION_PATIENT_UPDATE_FAILED": "Failed to update patient",
   "NOTIFICATION_VALIDATION_ERRORS": "Please fill the mandatory fields",
+  "PATIENT_DASHBOARD_REDIRECT": "Patient Dashboard",
   "NOTIFICATION_UNABLE_TO_GET_PATIENT_DATA": "Unable to get patient data",
   "NOTIFICATION_UNABLE_TO_GET_ADDRESS_DATA": "Unable to get patient address data",
   "NOTIFICATION_UNABLE_TO_GET_CONTACT_DATA": "Unable to get patient contact data",

--- a/apps/registration/public/locales/locale_es.json
+++ b/apps/registration/public/locales/locale_es.json
@@ -152,6 +152,7 @@
   "NOTIFICATION_PATIENT_SAVE_FAILED": "Error al guardar el paciente",
   "NOTIFICATION_PATIENT_UPDATE_FAILED": "Error al actualizar el paciente",
   "NOTIFICATION_VALIDATION_ERRORS": "Por favor complete los campos obligatorios",
+  "PATIENT_DASHBOARD_REDIRECT": "Panel del Paciente",
   "NOTIFICATION_UNABLE_TO_GET_PATIENT_DATA": "No se pueden obtener los datos del paciente",
   "NOTIFICATION_UNABLE_TO_GET_ADDRESS_DATA": "No se pueden obtener los datos de dirección del paciente",
   "NOTIFICATION_UNABLE_TO_GET_CONTACT_DATA": "No se pueden obtener los datos de contacto del paciente",

--- a/apps/registration/src/components/registrationActions/RegistrationActions.tsx
+++ b/apps/registration/src/components/registrationActions/RegistrationActions.tsx
@@ -46,17 +46,16 @@ export const RegistrationActions = ({
     return null;
   }
 
-  const handleVisitTypeSelect = async (
-    visitType: VisitType,
-    extension: AppExtensionConfig,
-  ) => {
+  const handleVisitTypeSelect = async (visitType: VisitType) => {
     if (!onBeforeNavigate) return;
 
     const patientUuid = await onBeforeNavigate();
     if (!patientUuid) return;
 
     await createVisit(patientUuid, visitType);
+  };
 
+  const handleActiveVisitClick = (extension: AppExtensionConfig) => {
     if (extension.url) {
       handleExtensionNavigation(extension.url, routeContext, navigate);
     }
@@ -81,8 +80,10 @@ export const RegistrationActions = ({
             <VisitTypeSelector
               key={extension.id}
               onVisitTypeSelect={(visitType) =>
-                handleVisitTypeSelect(visitType, extension)
+                handleVisitTypeSelect(visitType)
               }
+              activeVisitLabel={t(extension.translationKey)}
+              onActiveVisitClick={() => handleActiveVisitClick(extension)}
               data-testid="visit-type-selector"
             />
           );

--- a/apps/registration/src/components/registrationActions/__tests__/RegistrationActions.test.tsx
+++ b/apps/registration/src/components/registrationActions/__tests__/RegistrationActions.test.tsx
@@ -22,8 +22,12 @@ const mockUseCreateVisit = useCreateVisit as jest.MockedFunction<
 jest.mock('../../../pages/PatientRegister/visitTypeSelector', () => ({
   VisitTypeSelector: ({
     onVisitTypeSelect,
+    activeVisitLabel,
+    onActiveVisitClick,
   }: {
     onVisitTypeSelect: (visitType: VisitType) => void;
+    activeVisitLabel?: string;
+    onActiveVisitClick?: () => void;
   }) => (
     <div data-testid="visit-type-selector">
       <button
@@ -34,6 +38,11 @@ jest.mock('../../../pages/PatientRegister/visitTypeSelector', () => ({
       >
         Select Visit Type
       </button>
+      {onActiveVisitClick && (
+        <button data-testid="active-visit-button" onClick={onActiveVisitClick}>
+          {activeVisitLabel ?? 'Enter Visit Details'}
+        </button>
+      )}
     </div>
   ),
 }));
@@ -349,7 +358,7 @@ describe('RegistrationActions', () => {
       mockCreateVisit.mockClear();
     });
 
-    it('should call onBeforeNavigate, createVisit and navigate when visit type is selected', async () => {
+    it('should call onBeforeNavigate and createVisit when visit type is selected, but NOT navigate', async () => {
       const onBeforeNavigate = jest.fn().mockResolvedValue('patient-uuid-123');
       mockCreateVisit.mockResolvedValue(undefined);
 
@@ -374,6 +383,25 @@ describe('RegistrationActions', () => {
           name: 'OPD',
           uuid: 'opd-visit-type-uuid',
         });
+      });
+
+      expect(mockHandleExtensionNavigation).not.toHaveBeenCalled();
+    });
+
+    it('should navigate to extension URL when active visit button is clicked', async () => {
+      mockUseFilteredExtensions.mockReturnValue({
+        filteredExtensions: [startVisitExtension],
+        isLoading: false,
+      });
+
+      renderWithRouter(
+        <RegistrationActions extensionPointId="org.bahmni.registration.navigation" />,
+      );
+
+      const activeVisitButton = screen.getByTestId('active-visit-button');
+      fireEvent.click(activeVisitButton);
+
+      await waitFor(() => {
         expect(mockHandleExtensionNavigation).toHaveBeenCalledWith(
           '/clinical/patient/{{patientUuid}}/dashboard',
           {},

--- a/apps/registration/src/pages/PatientRegister/__tests__/visitTypeSelector.test.tsx
+++ b/apps/registration/src/pages/PatientRegister/__tests__/visitTypeSelector.test.tsx
@@ -26,6 +26,9 @@ jest.mock('@bahmni/services', () => ({
       if (key === 'ENTER_VISIT_DETAILS') {
         return 'Enter Visit Details';
       }
+      if (key === 'PATIENT_DASHBOARD_REDIRECT') {
+        return 'Patient Dashboard';
+      }
       return key;
     },
   }),
@@ -63,7 +66,13 @@ describe('VisitTypeSelector', () => {
     });
   });
 
-  const renderComponent = (patientUuid?: string) => {
+  const renderComponent = (
+    patientUuid?: string,
+    extraProps?: {
+      activeVisitLabel?: string;
+      onActiveVisitClick?: () => void;
+    },
+  ) => {
     const initialEntries = patientUuid
       ? [`/patient/${patientUuid}`]
       : ['/patient/new'];
@@ -79,6 +88,7 @@ describe('VisitTypeSelector', () => {
                   element={
                     <VisitTypeSelector
                       onVisitTypeSelect={mockOnVisitTypeSelect}
+                      {...extraProps}
                     />
                   }
                 />
@@ -103,7 +113,7 @@ describe('VisitTypeSelector', () => {
     expect(button).toHaveAttribute('id', 'visit-button');
   });
 
-  it('shows "Enter Visit Details" when patient has active visit', async () => {
+  it('shows "Enter Visit Details" when patient has active visit and no activeVisitLabel provided', async () => {
     const patientUuid = '9891a8b4-7404-4c05-a207-5ec9d34fc719';
     mockCheckIfActiveVisitExists.mockResolvedValue(true);
 
@@ -116,6 +126,82 @@ describe('VisitTypeSelector', () => {
 
     const button = screen.getByRole('button');
     expect(button).toHaveTextContent('Enter Visit Details');
+  });
+
+  it('shows activeVisitLabel when patient has active visit and activeVisitLabel is provided', async () => {
+    const patientUuid = '9891a8b4-7404-4c05-a207-5ec9d34fc719';
+    mockCheckIfActiveVisitExists.mockResolvedValue(true);
+
+    renderComponent(patientUuid, { activeVisitLabel: 'Patient Dashboard' });
+
+    await waitFor(() => expect(mockGetVisitTypes).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(mockCheckIfActiveVisitExists).toHaveBeenCalledWith(patientUuid),
+    );
+
+    const button = screen.getByRole('button');
+    expect(button).toHaveTextContent('Patient Dashboard');
+  });
+
+  it('calls onActiveVisitClick when provided and hasActiveVisit is true', async () => {
+    const patientUuid = '9891a8b4-7404-4c05-a207-5ec9d34fc719';
+    const mockOnActiveVisitClick = jest.fn();
+    mockCheckIfActiveVisitExists.mockResolvedValue(true);
+
+    renderComponent(patientUuid, {
+      onActiveVisitClick: mockOnActiveVisitClick,
+    });
+
+    await waitFor(() => expect(mockGetVisitTypes).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(mockCheckIfActiveVisitExists).toHaveBeenCalledWith(patientUuid),
+    );
+
+    const user = userEvent.setup();
+    const button = screen.getByRole('button');
+    await user.click(button);
+
+    expect(mockOnActiveVisitClick).toHaveBeenCalled();
+    expect(mockOnVisitTypeSelect).not.toHaveBeenCalled();
+  });
+
+  it('button kind is "primary" when hasActiveVisit is true', async () => {
+    const patientUuid = '9891a8b4-7404-4c05-a207-5ec9d34fc719';
+    mockCheckIfActiveVisitExists.mockResolvedValue(true);
+
+    renderComponent(patientUuid);
+
+    await waitFor(() => expect(mockGetVisitTypes).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(mockCheckIfActiveVisitExists).toHaveBeenCalledWith(patientUuid),
+    );
+
+    const button = screen.getByRole('button');
+    expect(button).toHaveClass('cds--btn--primary');
+  });
+
+  it('shows arrow icon when hasActiveVisit is true', async () => {
+    const patientUuid = '9891a8b4-7404-4c05-a207-5ec9d34fc719';
+    mockCheckIfActiveVisitExists.mockResolvedValue(true);
+
+    renderComponent(patientUuid);
+
+    await waitFor(() => expect(mockGetVisitTypes).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(mockCheckIfActiveVisitExists).toHaveBeenCalledWith(patientUuid),
+    );
+
+    expect(screen.getByTestId('patient-dashboard-arrow')).toBeInTheDocument();
+  });
+
+  it('does not show arrow icon when hasActiveVisit is false', async () => {
+    renderComponent();
+
+    await waitFor(() => expect(mockGetVisitTypes).toHaveBeenCalled());
+
+    expect(
+      screen.queryByTestId('patient-dashboard-arrow'),
+    ).not.toBeInTheDocument();
   });
 
   it('shows the dropdown with the correct list of items when no active visit', async () => {

--- a/apps/registration/src/pages/PatientRegister/styles/VisitTypeSelector.module.scss
+++ b/apps/registration/src/pages/PatientRegister/styles/VisitTypeSelector.module.scss
@@ -1,11 +1,19 @@
 @use '@carbon/styles/scss/spacing' as *;
 
+.buttonContent {
+  display: flex;
+  align-items: center;
+  gap: $spacing-02;
+}
+
 .opdVisitGroup {
   display: flex;
   align-items: center;
+  max-width: 100%;
 
   .visitButton {
     min-width: $spacing-13 + $spacing-12;
+    max-width: 100%;
   }
 
   .visitDropdown :global(.cds--list-box__menu) {

--- a/apps/registration/src/pages/PatientRegister/visitTypeSelector.tsx
+++ b/apps/registration/src/pages/PatientRegister/visitTypeSelector.tsx
@@ -1,4 +1,10 @@
-import { Button, Dropdown } from '@bahmni/design-system';
+import {
+  Button,
+  Dropdown,
+  Icon,
+  ICON_PADDING,
+  ICON_SIZE,
+} from '@bahmni/design-system';
 import { useTranslation } from '@bahmni/services';
 import { useParams } from 'react-router-dom';
 import { useActiveVisit, useVisitTypes } from '../../hooks/useVisit';
@@ -8,10 +14,14 @@ import styles from './styles/VisitTypeSelector.module.scss';
 
 interface VisitTypeSelectorProps {
   onVisitTypeSelect: (visitType: { name: string; uuid: string }) => void;
+  activeVisitLabel?: string;
+  onActiveVisitClick?: () => void;
 }
 
 export const VisitTypeSelector = ({
   onVisitTypeSelect,
+  activeVisitLabel,
+  onActiveVisitClick,
 }: VisitTypeSelectorProps) => {
   const { t } = useTranslation();
   const { patientUuid } = useParams<{ patientUuid: string }>();
@@ -32,15 +42,37 @@ export const VisitTypeSelector = ({
         id="visit-button"
         data-testid="start-visit-button"
         className={styles.visitButton}
-        kind="tertiary"
+        kind={hasActiveVisit ? 'primary' : 'tertiary'}
         disabled={isLoadingVisitTypes || visitTypesArray.length === 0}
-        onClick={() => defaultVisitType && onVisitTypeSelect(defaultVisitType)}
+        onClick={() => {
+          if (hasActiveVisit) {
+            if (onActiveVisitClick) {
+              onActiveVisitClick();
+            } else if (defaultVisitType) {
+              onVisitTypeSelect(defaultVisitType);
+            }
+          } else if (defaultVisitType) {
+            onVisitTypeSelect(defaultVisitType);
+          }
+        }}
       >
-        {!isLoadingVisitTypes && defaultVisitType
-          ? hasActiveVisit
-            ? t('ENTER_VISIT_DETAILS')
-            : t('START_VISIT_TYPE', { visitType: defaultVisitType.name })
-          : ''}
+        {!isLoadingVisitTypes && defaultVisitType ? (
+          hasActiveVisit ? (
+            <span className={styles.buttonContent}>
+              {activeVisitLabel ?? t('ENTER_VISIT_DETAILS')}
+              <Icon
+                id="patient-dashboard-arrow"
+                name="fa-arrow-right"
+                size={ICON_SIZE.SM}
+                padding={ICON_PADDING.NONE}
+              />
+            </span>
+          ) : (
+            t('START_VISIT_TYPE', { visitType: defaultVisitType.name })
+          )
+        ) : (
+          ''
+        )}
       </Button>
       {!hasActiveVisit && (
         <Dropdown

--- a/packages/bahmni-services/src/investigationService/__tests__/investigationService.test.ts
+++ b/packages/bahmni-services/src/investigationService/__tests__/investigationService.test.ts
@@ -685,14 +685,14 @@ describe('investigationService', () => {
       expect(result).toBe('lab-order-uuid');
     });
 
-    it('should return undefined when category name is not found', async () => {
+    it('should return null when category name is not found', async () => {
       const result = await getCategoryUuidFromOrderTypes('Non Existent Order');
-      expect(result).toBeUndefined();
+      expect(result).toBeNull();
     });
 
-    it('should return undefined when category name is undefined', async () => {
+    it('should return null when category name is undefined', async () => {
       const result = await getCategoryUuidFromOrderTypes(undefined);
-      expect(result).toBeUndefined();
+      expect(result).toBeNull();
     });
   });
 

--- a/packages/bahmni-services/src/investigationService/investigationService.ts
+++ b/packages/bahmni-services/src/investigationService/investigationService.ts
@@ -112,13 +112,13 @@ export const getFlattenedInvestigations = async (): Promise<
 
 export const getCategoryUuidFromOrderTypes = async (
   categoryName: string | undefined,
-): Promise<string | undefined> => {
-  if (!categoryName) return undefined;
+): Promise<string | null> => {
+  if (!categoryName) return null;
   const orderTypesData = await getOrderTypes();
   const orderType = orderTypesData.results.find(
     (ot) => ot.display.toLowerCase() === categoryName.toLowerCase(),
   );
-  return orderType?.uuid;
+  return orderType?.uuid ?? null;
 };
 
 export const getOrderTypeNames = async (): Promise<string[]> => {


### PR DESCRIPTION

Summary

This PR adds a "Patient Dashboard" redirect button in the Registration app for Bahmni Lite users. When a patient already has an active visit,
clicking the action button now takes the user directly to the Patient Dashboard instead of prompting them to start a new visit.

Description

What changed and why

In Bahmni Lite, after registering or updating a patient who already has an active visit, there was no easy way to navigate to their Patient
Dashboard. The button in the registration actions panel always showed "Enter Visit Details" which was confusing. This PR makes that button
smarter — if a patient has an active visit, it now redirects to the dashboard instead.

Changes made

VisitTypeSelector component (visitTypeSelector.tsx)

Added two optional props: activeVisitLabel (custom button text) and onActiveVisitClick (custom click handler for when patient has an active
visit)
When a patient has an active visit, the button style changes from tertiary to primary (highlighted in blue) to draw attention
An arrow icon (→) is now shown next to the label when active visit is detected
If onActiveVisitClick is provided, clicking the button triggers navigation (to dashboard). If not, it falls back to the previous behaviour
("Enter Visit Details")
RegistrationActions component (RegistrationActions.tsx)

Separated visit creation and navigation into two distinct steps:
handleVisitTypeSelect — only creates the visit, does not navigate
handleActiveVisitClick — only handles navigation to the extension URL (e.g. Patient Dashboard)
This means: selecting a visit type creates the visit; the active visit button redirects to the dashboard
Locale files (locale_en.json, locale_es.json)

Added translation key PATIENT_DASHBOARD_REDIRECT in English ("Patient Dashboard") and Spanish ("Panel del Paciente")
Styling (VisitTypeSelector.module.scss)

Added .buttonContent flex container to align the label and arrow icon side by side
Added max-width: 100% to prevent button overflow
Bug fix (investigationService.ts)

getCategoryUuidFromOrderTypes now returns null instead of undefined when a category is not found — aligns with consistent null-check
patterns
Tests

Updated and added unit tests for VisitTypeSelector covering: custom label display, onActiveVisitClick callback, button kind (primary vs
tertiary), and arrow icon visibility
Updated RegistrationActions tests to verify that visit creation and navigation are now separate actions
Updated investigationService tests for the null return value change
