### PR TITLE
BAH-4551 | Add. Expiry Date Before Administered On Validation In Immunization History Form

### DIFF
--- a/apps/clinical/public/locales/locale_en.json
+++ b/apps/clinical/public/locales/locale_en.json
@@ -193,6 +193,7 @@
   "IMMUNIZATION_HISTORY_BATCH_NUMBER_REQUIRED": "Please enter a batch number",
   "IMMUNIZATION_HISTORY_DRUG_CODE_REQUIRED": "Please select a drug name",
   "IMMUNIZATION_HISTORY_EXPIRY_DATE": "Expiry Date",
+  "IMMUNIZATION_HISTORY_EXPIRY_DATE_BEFORE_ADMINISTERED_ON": "Expiry date cannot be before the administered date",
   "IMMUNIZATION_HISTORY_EXPIRY_DATE_REQUIRED": "Please select an expiry date",
   "IMMUNIZATION_HISTORY_FORM_TITLE": "Immunization History",
   "IMMUNIZATION_HISTORY_MANUFACTURER": "Manufacturer",

--- a/apps/clinical/public/locales/locale_es.json
+++ b/apps/clinical/public/locales/locale_es.json
@@ -193,6 +193,7 @@
   "IMMUNIZATION_HISTORY_BATCH_NUMBER_REQUIRED": "Por favor ingrese el número de lote",
   "IMMUNIZATION_HISTORY_DRUG_CODE_REQUIRED": "Por favor seleccione un nombre de medicamento",
   "IMMUNIZATION_HISTORY_EXPIRY_DATE": "Fecha de Vencimiento",
+  "IMMUNIZATION_HISTORY_EXPIRY_DATE_BEFORE_ADMINISTERED_ON": "La fecha de vencimiento no puede ser anterior a la fecha de administración",
   "IMMUNIZATION_HISTORY_EXPIRY_DATE_REQUIRED": "Por favor seleccione la fecha de vencimiento",
   "IMMUNIZATION_HISTORY_FORM_TITLE": "Historial de Inmunización",
   "IMMUNIZATION_HISTORY_MANUFACTURER": "Fabricante",

--- a/apps/clinical/src/components/forms/immunizationHistory/ImmunizationHistoryForm.tsx
+++ b/apps/clinical/src/components/forms/immunizationHistory/ImmunizationHistoryForm.tsx
@@ -3,7 +3,6 @@ import {
   CodeSnippetSkeleton,
   ComboBox,
   SelectedItem,
-  Tile,
 } from '@bahmni/design-system';
 import {
   getLocationByTag,
@@ -198,10 +197,10 @@ const ImmunizationHistoryForm = () => {
     );
 
   return (
-    <Tile
+    <div
       id="immunization-history-form"
-      data-testid="immunization-history-form-tile-test-id"
-      className={styles.tile}
+      data-testid="immunization-history-form-test-id"
+      className={styles.form}
     >
       <div
         id="immunization-history-form-title"
@@ -274,7 +273,7 @@ const ImmunizationHistoryForm = () => {
           ))}
         </BoxWHeader>
       )}
-    </Tile>
+    </div>
   );
 };
 

--- a/apps/clinical/src/components/forms/immunizationHistory/__tests__/__snapshots__/ImmunizationHistoryForm.test.tsx.snap
+++ b/apps/clinical/src/components/forms/immunizationHistory/__tests__/__snapshots__/ImmunizationHistoryForm.test.tsx.snap
@@ -3,8 +3,8 @@
 exports[`ImmunizationHistoryForm Snapshots matches snapshot with no immunizations 1`] = `
 <div>
   <div
-    class="cds--tile tile"
-    data-testid="immunization-history-form-tile-test-id"
+    class="form"
+    data-testid="immunization-history-form-test-id"
     id="immunization-history-form"
   >
     <div
@@ -83,8 +83,8 @@ exports[`ImmunizationHistoryForm Snapshots matches snapshot with no immunization
 exports[`ImmunizationHistoryForm Snapshots matches snapshot with selected immunizations 1`] = `
 <div>
   <div
-    class="cds--tile tile"
-    data-testid="immunization-history-form-tile-test-id"
+    class="form"
+    data-testid="immunization-history-form-test-id"
     id="immunization-history-form"
   >
     <div

--- a/apps/clinical/src/components/forms/immunizationHistory/__tests__/stores.test.ts
+++ b/apps/clinical/src/components/forms/immunizationHistory/__tests__/stores.test.ts
@@ -398,6 +398,72 @@ describe('useImmunizationHistoryStore', () => {
       expect(result.current.selectedImmunizations[0].errors).toEqual({});
     });
 
+    it.each([
+      [
+        'before',
+        '2025-01-01',
+        '2024-06-01',
+        false,
+        'IMMUNIZATION_HISTORY_EXPIRY_DATE_BEFORE_ADMINISTERED_ON',
+      ],
+      ['same as', '2025-01-01', '2025-01-01', true, undefined],
+      ['after', '2025-01-01', '2026-01-01', true, undefined],
+    ])(
+      'returns %s result when expiryDate is %s administeredOn',
+      (
+        _label,
+        administeredOnStr,
+        expiryDateStr,
+        expectedValid,
+        expectedError,
+      ) => {
+        const { result } = renderHook(() => useImmunizationHistoryStore());
+
+        act(() => {
+          result.current.setAttributes([]);
+          result.current.addImmunization(mockVaccineCode);
+        });
+        const id = result.current.selectedImmunizations[0].id;
+        act(() => {
+          result.current.updateAdministeredOn(id, new Date(administeredOnStr));
+          result.current.updateExpiryDate(id, new Date(expiryDateStr));
+        });
+        let isValid: boolean;
+
+        act(() => {
+          isValid = result.current.validateAll();
+        });
+
+        expect(isValid).toBe(expectedValid);
+        expect(result.current.selectedImmunizations[0].errors.expiryDate).toBe(
+          expectedError,
+        );
+      },
+    );
+
+    it('does not set cross-field expiryDate error when administeredOn is absent', () => {
+      const { result } = renderHook(() => useImmunizationHistoryStore());
+
+      act(() => {
+        result.current.setAttributes([]);
+        result.current.addImmunization(mockVaccineCode);
+      });
+      const id = result.current.selectedImmunizations[0].id;
+      act(() => {
+        result.current.updateExpiryDate(id, new Date('2024-01-01'));
+      });
+      let isValid: boolean;
+
+      act(() => {
+        isValid = result.current.validateAll();
+      });
+
+      expect(isValid).toBe(true);
+      expect(
+        result.current.selectedImmunizations[0].errors.expiryDate,
+      ).toBeUndefined();
+    });
+
     it('returns false when at least one entry has a validation error', () => {
       const { result } = renderHook(() => useImmunizationHistoryStore());
 
@@ -425,6 +491,68 @@ describe('useImmunizationHistoryStore', () => {
         result.current.selectedImmunizations[1].errors.drug,
       ).toBeUndefined();
     });
+  });
+
+  describe('cross-field expiryDate validation (inline, post-validateAll)', () => {
+    it.each([
+      [
+        'before',
+        new Date('2025-01-01'),
+        'IMMUNIZATION_HISTORY_EXPIRY_DATE_BEFORE_ADMINISTERED_ON',
+      ],
+      ['on', new Date('2025-06-01'), undefined],
+      ['after', new Date('2026-01-01'), undefined],
+    ])(
+      'updateExpiryDate: sets expiryDate error when new value is %s administeredOn',
+      (_label, newExpiryDate, expectedError) => {
+        const { result } = renderHook(() => useImmunizationHistoryStore());
+
+        act(() => {
+          result.current.setAttributes([]);
+          result.current.addImmunization(mockVaccineCode);
+        });
+        const id = result.current.selectedImmunizations[0].id;
+        act(() => {
+          result.current.updateAdministeredOn(id, new Date('2025-06-01'));
+          result.current.validateAll();
+          result.current.updateExpiryDate(id, newExpiryDate);
+        });
+
+        expect(result.current.selectedImmunizations[0].errors.expiryDate).toBe(
+          expectedError,
+        );
+      },
+    );
+
+    it.each([
+      [
+        'after expiryDate',
+        new Date('2025-06-01'),
+        'IMMUNIZATION_HISTORY_EXPIRY_DATE_BEFORE_ADMINISTERED_ON',
+      ],
+      ['before expiryDate', new Date('2024-12-01'), undefined],
+      ['null', null, undefined],
+    ])(
+      'updateAdministeredOn: sets expiryDate error when new administeredOn is %s',
+      (_label, newAdministeredOn, expectedError) => {
+        const { result } = renderHook(() => useImmunizationHistoryStore());
+
+        act(() => {
+          result.current.setAttributes([]);
+          result.current.addImmunization(mockVaccineCode);
+        });
+        const id = result.current.selectedImmunizations[0].id;
+        act(() => {
+          result.current.updateExpiryDate(id, new Date('2025-01-01'));
+          result.current.validateAll();
+          result.current.updateAdministeredOn(id, newAdministeredOn);
+        });
+
+        expect(result.current.selectedImmunizations[0].errors.expiryDate).toBe(
+          expectedError,
+        );
+      },
+    );
   });
 
   describe('updateNote', () => {

--- a/apps/clinical/src/components/forms/immunizationHistory/stores.ts
+++ b/apps/clinical/src/components/forms/immunizationHistory/stores.ts
@@ -51,9 +51,17 @@ export const useImmunizationHistoryStore = create<ImmunizationHistoryState>(
         selectedImmunizations: state.selectedImmunizations.map((entry) => {
           if (entry.id !== id) return entry;
           const updated = { ...entry, administeredOn: value };
-          if (entry.hasBeenValidated && value) {
+          if (entry.hasBeenValidated) {
             updated.errors = { ...entry.errors };
-            delete updated.errors.administeredOn;
+            if (value) delete updated.errors.administeredOn;
+            if (entry.expiryDate) {
+              if (value && entry.expiryDate < value) {
+                updated.errors.expiryDate =
+                  'IMMUNIZATION_HISTORY_EXPIRY_DATE_BEFORE_ADMINISTERED_ON';
+              } else {
+                delete updated.errors.expiryDate;
+              }
+            }
           }
           return updated;
         }),
@@ -126,7 +134,12 @@ export const useImmunizationHistoryStore = create<ImmunizationHistoryState>(
           const updated = { ...entry, expiryDate: value };
           if (entry.hasBeenValidated && value) {
             updated.errors = { ...entry.errors };
-            delete updated.errors.expiryDate;
+            if (entry.administeredOn && value < entry.administeredOn) {
+              updated.errors.expiryDate =
+                'IMMUNIZATION_HISTORY_EXPIRY_DATE_BEFORE_ADMINISTERED_ON';
+            } else {
+              delete updated.errors.expiryDate;
+            }
           }
           return updated;
         }),
@@ -248,6 +261,16 @@ export const useImmunizationHistoryStore = create<ImmunizationHistoryState>(
               !entry.batchNumber?.trim(),
               'IMMUNIZATION_HISTORY_BATCH_NUMBER_REQUIRED',
             );
+
+          if (
+            entry.expiryDate &&
+            entry.administeredOn &&
+            entry.expiryDate < entry.administeredOn
+          ) {
+            errors.expiryDate =
+              'IMMUNIZATION_HISTORY_EXPIRY_DATE_BEFORE_ADMINISTERED_ON';
+            isValid = false;
+          }
 
           return { ...entry, errors, hasBeenValidated: true };
         }),

--- a/apps/clinical/src/components/forms/immunizationHistory/styles/ImmunizationHistoryForm.module.scss
+++ b/apps/clinical/src/components/forms/immunizationHistory/styles/ImmunizationHistoryForm.module.scss
@@ -3,8 +3,9 @@
 @use "@carbon/react/scss/type" as *;
 @use "@carbon/react/scss/theme" as *;
 
-.tile {
+.form {
   margin: $spacing-03;
+  padding: $spacing-05;
   background-color: $background
 }
 


### PR DESCRIPTION
JIRA → [BAH-4551](https://bahmni.atlassian.net/browse/BAH-4551)

## Description

Adds cross-field validation to the Immunization History form to prevent an expiry date being set before the administered-on date. The check runs both at submit time (validateAll) and inline as either date field is updated, so users get immediate feedback without waiting for form submission. Also includes a minor fix to replace the Tile wrapper with a div and correct the associated styles.

[BAH-4551]: https://bahmni.atlassian.net/browse/BAH-4551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ