### PR TITLE
BAH-4693| Kanchi, Kabita | Add logic to show patient name on breadcrumb

### DIFF
--- a/apps/clinical/src/components/patientHeader/PatientHeader.tsx
+++ b/apps/clinical/src/components/patientHeader/PatientHeader.tsx
@@ -1,4 +1,4 @@
-import { useTranslation } from '@bahmni/services';
+import { type FormattedPatientData, useTranslation } from '@bahmni/services';
 import { PatientDetails } from '@bahmni/widgets';
 import React from 'react';
 import ConsultationActionButton from './ConsultationActionButton';
@@ -6,6 +6,9 @@ import styles from './styles/PatientHeader.module.scss';
 
 interface PatientHeaderProps {
   isActionAreaVisible: boolean;
+  patient?: FormattedPatientData | null;
+  loading?: boolean;
+  error?: Error | null;
 }
 
 /**
@@ -13,10 +16,16 @@ interface PatientHeaderProps {
  * Displays patient details with consultation action button
  *
  * @param {boolean} isActionAreaVisible - Whether the action area is currently visible
+ * @param {FormattedPatientData | null} patient - Optional pre-fetched patient data
+ * @param {boolean} loading - Optional loading state from parent
+ * @param {Error | null} error - Optional error state from parent
  * @returns {React.ReactElement} The Header component
  */
 const PatientHeader: React.FC<PatientHeaderProps> = ({
   isActionAreaVisible,
+  patient,
+  loading,
+  error,
 }) => {
   const { t } = useTranslation();
 
@@ -26,7 +35,7 @@ const PatientHeader: React.FC<PatientHeaderProps> = ({
       className={styles.header}
       data-testid="patient-header"
     >
-      <PatientDetails />
+      <PatientDetails patient={patient} loading={loading} error={error} />
       <ConsultationActionButton isActionAreaVisible={isActionAreaVisible} />
     </div>
   );

--- a/apps/clinical/src/components/patientHeader/__tests__/PatientHeader.test.tsx
+++ b/apps/clinical/src/components/patientHeader/__tests__/PatientHeader.test.tsx
@@ -15,12 +15,21 @@ jest.mock('@bahmni/services', () => ({
 jest.mock('../../../events/startConsultation', () => ({
   dispatchConsultationStart: jest.fn(),
 }));
-// Mock the PatientDetails component
+// Mock the PatientDetails component – capture props for assertion
+const mockPatientDetails = jest.fn(({ patient, loading, error }: any) => (
+  <div
+    data-testid="patient-details-mock"
+    data-patient-name={patient?.fullName}
+    data-loading={String(loading)}
+    data-error={error?.message}
+  >
+    PatientDetails Mock
+  </div>
+));
+
 jest.mock('@bahmni/widgets', () => ({
   ...jest.requireActual('@bahmni/widgets'),
-  PatientDetails: () => (
-    <div data-testid="patient-details-mock">PatientDetails Mock</div>
-  ),
+  PatientDetails: (...args: any[]) => mockPatientDetails(...args),
   useActivePractitioner: jest.fn(() => ({
     uuid: 'active-practitioner-uuid',
     practitioner: { uuid: 'active-practitioner-uuid' },
@@ -91,6 +100,27 @@ describe('PatientHeader Component', () => {
       renderComponent();
       const patientDetails = screen.getByTestId('patient-details-mock');
       expect(patientDetails).toBeInTheDocument();
+    });
+  });
+
+  // Patient data forwarding tests
+  describe('Patient data forwarding', () => {
+    test('forwards patient, loading, and error props to PatientDetails', () => {
+      const patient = { fullName: 'Jane Doe' } as any;
+      const error = new Error('fetch failed');
+      renderComponent({ patient, loading: true, error });
+
+      const patientDetails = screen.getByTestId('patient-details-mock');
+      expect(patientDetails).toHaveAttribute('data-patient-name', 'Jane Doe');
+      expect(patientDetails).toHaveAttribute('data-loading', 'true');
+      expect(patientDetails).toHaveAttribute('data-error', 'fetch failed');
+    });
+
+    test('renders PatientDetails without patient props when none provided', () => {
+      renderComponent();
+
+      const patientDetails = screen.getByTestId('patient-details-mock');
+      expect(patientDetails).not.toHaveAttribute('data-patient-name');
     });
   });
 

--- a/apps/clinical/src/pages/ConsultationPage.tsx
+++ b/apps/clinical/src/pages/ConsultationPage.tsx
@@ -15,6 +15,7 @@ import {
 import {
   ProgramDetails,
   useNotification,
+  usePatient,
   useUserPrivilege,
 } from '@bahmni/widgets';
 import { useQuery } from '@tanstack/react-query';
@@ -118,6 +119,11 @@ const ConsultationPage: React.FC = () => {
     [handleSearchOpen, t],
   );
   const viewingForm = useObservationFormsStore((state) => state.viewingForm);
+  const {
+    patient,
+    loading: patientLoading,
+    error: patientError,
+  } = usePatient();
 
   const breadcrumbItems = [
     { id: 'home', label: 'Home', href: BAHMNI_HOME_PATH },
@@ -126,7 +132,11 @@ const ConsultationPage: React.FC = () => {
       label: 'Clinical',
       href: BAHMNI_CLINICAL_PATH,
     },
-    { id: 'current', label: t('CURRENT_PATIENT'), isCurrentPage: true },
+    {
+      id: 'current',
+      label: patient?.fullName ?? t('CURRENT_PATIENT'),
+      isCurrentPage: true,
+    },
   ];
 
   const episodeUuids = useMemo(() => {
@@ -288,7 +298,12 @@ const ConsultationPage: React.FC = () => {
               aria-label={t('PATIENT_HEADER_SECTION')}
               className={styles.stickySection}
             >
-              <PatientHeader isActionAreaVisible={isActionAreaVisible} />
+              <PatientHeader
+                isActionAreaVisible={isActionAreaVisible}
+                patient={patient}
+                loading={patientLoading}
+                error={patientError}
+              />
               {renderContextInformation()}
             </div>
             <DashboardContainer

--- a/apps/clinical/src/pages/__tests__/ConsultationPage.test.tsx
+++ b/apps/clinical/src/pages/__tests__/ConsultationPage.test.tsx
@@ -2,6 +2,7 @@ import { getConfig } from '@bahmni/services';
 import {
   useHasPrivilege,
   useNotification,
+  usePatient,
   useUserPrivilege,
 } from '@bahmni/widgets';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -47,9 +48,18 @@ jest.mock('../../stores/observationFormsStore', () => ({
   ),
 }));
 
+const MockPatientHeader = jest.fn(({ patient, loading, error }: any) => (
+  <div
+    data-testid="mocked-patient-header"
+    data-patient-name={patient?.fullName}
+    data-loading={String(loading)}
+    data-error={error?.message}
+  />
+));
+
 jest.mock('../../components/patientHeader/PatientHeader', () => ({
   __esModule: true,
-  default: jest.fn(() => <div data-testid="mocked-patient-header" />),
+  default: (...args: any[]) => MockPatientHeader(...args),
 }));
 
 jest.mock('../../components/dashboardContainer/DashboardContainer', () => ({
@@ -110,38 +120,52 @@ jest.mock('@bahmni/design-system', () => ({
       </div>
     ),
   ),
-  Header: jest.fn(({ sideNavItems, activeSideNavItemId, globalActions }) => (
-    <div data-testid="mocked-header-component">
-      {globalActions?.map(
-        (action: { id: string; label: string; onClick: () => void }) => (
-          <button
-            key={action.id}
-            data-testid={`global-action-${action.id}`}
-            onClick={action.onClick}
-            tabIndex={0}
-          >
-            {action.label}
-          </button>
-        ),
-      )}
-      {sideNavItems.map(
-        (item: {
-          id: string;
-          icon: string;
-          label: string;
-          href?: string;
-          renderIcon?: ReactNode;
-        }) => (
-          <div key={item.id} data-testid={`sidenav-item-${item.id}`}>
-            {item.label}
-          </div>
-        ),
-      )}
-      <div data-testid="active-sidenav-item">
-        {activeSideNavItemId ?? 'none'}
+  Header: jest.fn(
+    ({ sideNavItems, activeSideNavItemId, globalActions, breadcrumbItems }) => (
+      <div data-testid="mocked-header-component">
+        {breadcrumbItems?.map(
+          (item: {
+            id: string;
+            label: string;
+            href?: string;
+            isCurrentPage?: boolean;
+          }) => (
+            <span key={item.id} data-testid={`breadcrumb-item-${item.id}`}>
+              {item.label}
+            </span>
+          ),
+        )}
+        {globalActions?.map(
+          (action: { id: string; label: string; onClick: () => void }) => (
+            <button
+              key={action.id}
+              data-testid={`global-action-${action.id}`}
+              onClick={action.onClick}
+              tabIndex={0}
+            >
+              {action.label}
+            </button>
+          ),
+        )}
+        {sideNavItems.map(
+          (item: {
+            id: string;
+            icon: string;
+            label: string;
+            href?: string;
+            renderIcon?: ReactNode;
+          }) => (
+            <div key={item.id} data-testid={`sidenav-item-${item.id}`}>
+              {item.label}
+            </div>
+          ),
+        )}
+        <div data-testid="active-sidenav-item">
+          {activeSideNavItemId ?? 'none'}
+        </div>
       </div>
-    </div>
-  )),
+    ),
+  ),
 }));
 
 jest.mock('@bahmni/widgets', () => ({
@@ -149,6 +173,7 @@ jest.mock('@bahmni/widgets', () => ({
   useUserPrivilege: jest.fn(),
   useHasPrivilege: jest.fn(),
   useNotification: jest.fn(),
+  usePatient: jest.fn(),
 }));
 
 jest.mock('@bahmni/services', () => ({
@@ -234,6 +259,13 @@ describe('ConsultationPage', () => {
       clearAllNotifications: jest.fn(),
     });
 
+    (usePatient as jest.Mock).mockReturnValue({
+      patient: null,
+      loading: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+
     (getConfig as jest.Mock).mockResolvedValue(mockDashboardConfig);
   });
 
@@ -296,6 +328,64 @@ describe('ConsultationPage', () => {
       renderWithProvider();
 
       expect(screen.getByTestId('carbon-loading')).toBeInTheDocument();
+    });
+
+    it('should show patient name in breadcrumb when patient data is loaded', async () => {
+      (usePatient as jest.Mock).mockReturnValue({
+        patient: { fullName: 'John Doe' },
+        loading: false,
+        error: null,
+        refetch: jest.fn(),
+      });
+
+      renderWithProvider();
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('carbon-loading')).not.toBeInTheDocument();
+      });
+
+      expect(screen.getByTestId('breadcrumb-item-current')).toHaveTextContent(
+        'John Doe',
+      );
+    });
+
+    it('should show fallback text in breadcrumb when patient is null', async () => {
+      (usePatient as jest.Mock).mockReturnValue({
+        patient: null,
+        loading: false,
+        error: null,
+        refetch: jest.fn(),
+      });
+
+      renderWithProvider();
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('carbon-loading')).not.toBeInTheDocument();
+      });
+
+      expect(screen.getByTestId('breadcrumb-item-current')).toHaveTextContent(
+        'Current Patient',
+      );
+    });
+
+    it('should pass patient data down to PatientHeader to avoid duplicate fetch', async () => {
+      const mockPatient = { fullName: 'John Doe' };
+      (usePatient as jest.Mock).mockReturnValue({
+        patient: mockPatient,
+        loading: false,
+        error: null,
+        refetch: jest.fn(),
+      });
+
+      renderWithProvider();
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('carbon-loading')).not.toBeInTheDocument();
+      });
+
+      const patientHeader = screen.getByTestId('mocked-patient-header');
+      expect(patientHeader).toHaveAttribute('data-patient-name', 'John Doe');
+      expect(patientHeader).toHaveAttribute('data-loading', 'false');
     });
 
     it('should show error when no default dashboard is available', () => {

--- a/apps/clinical/src/pages/__tests__/__snapshots__/ConsultationPage.test.tsx.snap
+++ b/apps/clinical/src/pages/__tests__/__snapshots__/ConsultationPage.test.tsx.snap
@@ -12,6 +12,21 @@ exports[`ConsultationPage Snapshot should match the snapshot 1`] = `
       <div
         data-testid="mocked-header-component"
       >
+        <span
+          data-testid="breadcrumb-item-home"
+        >
+          Home
+        </span>
+        <span
+          data-testid="breadcrumb-item-clinical"
+        >
+          Clinical
+        </span>
+        <span
+          data-testid="breadcrumb-item-current"
+        >
+          Current Patient
+        </span>
         <button
           data-testid="global-action-search"
           tabindex="0"
@@ -59,6 +74,7 @@ exports[`ConsultationPage Snapshot should match the snapshot 1`] = `
         role="region"
       >
         <div
+          data-loading="false"
           data-testid="mocked-patient-header"
         />
       </div>

--- a/packages/bahmni-widgets/src/index.ts
+++ b/packages/bahmni-widgets/src/index.ts
@@ -27,6 +27,7 @@ export {
 
 // Hooks
 export { usePatientUUID } from './hooks/usePatientUUID';
+export { usePatient } from './patientDetails/usePatient';
 export { useUserPrivilege } from './userPrivileges/useUserPrivilege';
 export { useHasPrivilege } from './userPrivileges/useHasPrivilege';
 

--- a/packages/bahmni-widgets/src/patientDetails/PatientDetails.tsx
+++ b/packages/bahmni-widgets/src/patientDetails/PatientDetails.tsx
@@ -1,14 +1,36 @@
 import { Icon, ICON_SIZE } from '@bahmni/design-system';
-import { getFormattedAge, formatDateTime } from '@bahmni/services';
+import {
+  type FormattedPatientData,
+  getFormattedAge,
+  formatDateTime,
+} from '@bahmni/services';
 import { SkeletonText } from '@carbon/react';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import styles from './__styles__/PatientDetails.module.scss';
 import { usePatient } from './usePatient';
 
-const PatientDetails: React.FC = () => {
+interface PatientDetailsProps {
+  patient?: FormattedPatientData | null;
+  loading?: boolean;
+  error?: Error | null;
+}
+
+const PatientDetails: React.FC<PatientDetailsProps> = ({
+  patient: patientProp,
+  loading: loadingProp,
+  error: errorProp,
+}) => {
   const { t } = useTranslation();
-  const { patient, loading, error } = usePatient();
+  const hasExternalData = patientProp !== undefined;
+  const {
+    patient: internalPatient,
+    loading: internalLoading,
+    error: internalError,
+  } = usePatient({ enabled: !hasExternalData });
+  const patient = hasExternalData ? patientProp : internalPatient;
+  const loading = hasExternalData ? (loadingProp ?? false) : internalLoading;
+  const error = hasExternalData ? (errorProp ?? null) : internalError;
 
   if (loading || error || !patient) {
     return (

--- a/packages/bahmni-widgets/src/patientDetails/__tests__/PatientDetails.test.tsx
+++ b/packages/bahmni-widgets/src/patientDetails/__tests__/PatientDetails.test.tsx
@@ -227,6 +227,102 @@ describe('PatientDetails Component', () => {
     });
   });
 
+  describe('External props override internal hook', () => {
+    it('uses patient data from props when provided, skipping the internal hook', () => {
+      const externalPatient = createMockPatient({
+        fullName: 'External Patient',
+      });
+      // usePatient mock returns different data — should be ignored
+      mockedUsePatient.mockReturnValue({
+        patient: createMockPatient({ fullName: 'Internal Patient' }),
+        loading: false,
+        error: null,
+        refetch: jest.fn(),
+      });
+
+      render(
+        <PatientDetails
+          patient={externalPatient}
+          loading={false}
+          error={null}
+        />,
+      );
+
+      expect(screen.getByTestId('patient-name')).toHaveTextContent(
+        'External Patient',
+      );
+      expect(screen.queryByText('Internal Patient')).not.toBeInTheDocument();
+    });
+
+    it('shows skeleton when loading prop is true, even if internal hook has patient data', () => {
+      mockedUsePatient.mockReturnValue({
+        patient: createMockPatient({ fullName: 'Internal Patient' }),
+        loading: false,
+        error: null,
+        refetch: jest.fn(),
+      });
+
+      // Passing loading=true via props with patient=null
+      render(<PatientDetails patient={null} loading error={null} />);
+
+      expect(screen.getByTestId('skeleton-loader')).toBeInTheDocument();
+      expect(screen.queryByTestId('patient-name')).not.toBeInTheDocument();
+    });
+
+    it('shows skeleton when error prop is set, even if internal hook has patient data', () => {
+      mockedUsePatient.mockReturnValue({
+        patient: createMockPatient({ fullName: 'Internal Patient' }),
+        loading: false,
+        error: null,
+        refetch: jest.fn(),
+      });
+
+      render(
+        <PatientDetails
+          patient={null}
+          loading={false}
+          error={new Error('External error')}
+        />,
+      );
+
+      expect(screen.getByTestId('skeleton-loader')).toBeInTheDocument();
+    });
+
+    it('disables internal hook fetch when patient prop is provided', () => {
+      const externalPatient = createMockPatient();
+      // usePatient should be called with enabled: false
+      mockedUsePatient.mockReturnValue({
+        patient: null,
+        loading: false,
+        error: null,
+        refetch: jest.fn(),
+      });
+
+      render(
+        <PatientDetails
+          patient={externalPatient}
+          loading={false}
+          error={null}
+        />,
+      );
+
+      expect(mockedUsePatient).toHaveBeenCalledWith({ enabled: false });
+    });
+
+    it('enables internal hook fetch when no patient prop is provided', () => {
+      mockedUsePatient.mockReturnValue({
+        patient: null,
+        loading: false,
+        error: null,
+        refetch: jest.fn(),
+      });
+
+      render(<PatientDetails />);
+
+      expect(mockedUsePatient).toHaveBeenCalledWith({ enabled: true });
+    });
+  });
+
   describe('Accessibility', () => {
     it('passes axe accessibility tests with patient data', async () => {
       jest.useRealTimers(); // axe doesn't work well with fake timers

--- a/packages/bahmni-widgets/src/patientDetails/__tests__/usePatient.test.ts
+++ b/packages/bahmni-widgets/src/patientDetails/__tests__/usePatient.test.ts
@@ -179,6 +179,48 @@ describe('usePatient hook', () => {
     expect(mockedGetFormattedPatientById).toHaveBeenCalledWith('new-uuid');
   });
 
+  describe('enabled option', () => {
+    it('does not fetch when enabled is false', async () => {
+      mockedUsePatientUUID.mockReturnValue('test-uuid');
+
+      const { result } = renderHook(() => usePatient({ enabled: false }));
+
+      // Allow any async operations to settle
+      await act(async () => {});
+
+      expect(mockedGetFormattedPatientById).not.toHaveBeenCalled();
+      expect(result.current.patient).toBeNull();
+      expect(result.current.loading).toBe(false);
+      expect(result.current.error).toBeNull();
+    });
+
+    it('fetches normally when enabled is true', async () => {
+      mockedUsePatientUUID.mockReturnValue('test-uuid');
+      mockedGetFormattedPatientById.mockResolvedValueOnce(mockPatientData);
+
+      const { result } = renderHook(() => usePatient({ enabled: true }));
+
+      await waitFor(() => {
+        expect(result.current.patient).toEqual(mockPatientData);
+      });
+
+      expect(mockedGetFormattedPatientById).toHaveBeenCalledWith('test-uuid');
+    });
+
+    it('fetches normally when options are not provided', async () => {
+      mockedUsePatientUUID.mockReturnValue('test-uuid');
+      mockedGetFormattedPatientById.mockResolvedValueOnce(mockPatientData);
+
+      const { result } = renderHook(() => usePatient());
+
+      await waitFor(() => {
+        expect(result.current.patient).toEqual(mockPatientData);
+      });
+
+      expect(mockedGetFormattedPatientById).toHaveBeenCalledWith('test-uuid');
+    });
+  });
+
   it('clears error on successful refetch after failure', async () => {
     const mockError = new Error('Network error');
     mockedUsePatientUUID.mockReturnValue('test-uuid');

--- a/packages/bahmni-widgets/src/patientDetails/usePatient.ts
+++ b/packages/bahmni-widgets/src/patientDetails/usePatient.ts
@@ -6,6 +6,10 @@ import {
 import { useState, useEffect, useCallback } from 'react';
 import { usePatientUUID } from '../hooks/usePatientUUID';
 
+interface UsePatientOptions {
+  enabled?: boolean;
+}
+
 interface UsePatientResult {
   patient: FormattedPatientData | null;
   loading: boolean;
@@ -15,15 +19,19 @@ interface UsePatientResult {
 
 /**
  * Custom hook to fetch and manage patient data
+ * @param options - Optional configuration. Set `enabled: false` to skip the fetch
+ *   (e.g. when patient data is already provided via props from a parent component).
  * @returns Object containing patient, loading state, error state, and refetch function
  */
-export const usePatient = (): UsePatientResult => {
+export const usePatient = (options?: UsePatientOptions): UsePatientResult => {
+  const enabled = options?.enabled !== false;
   const patientUUID = usePatientUUID();
   const [patient, setPatient] = useState<FormattedPatientData | null>(null);
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<Error | null>(null);
 
   const fetchPatient = useCallback(async () => {
+    if (!enabled) return;
     if (!patientUUID) {
       setError(new Error('Invalid patient UUID'));
       return;
@@ -40,11 +48,11 @@ export const usePatient = (): UsePatientResult => {
     } finally {
       setLoading(false);
     }
-  }, [patientUUID]);
+  }, [patientUUID, enabled]);
 
   useEffect(() => {
-    fetchPatient();
-  }, [patientUUID, fetchPatient]);
+    if (enabled) fetchPatient();
+  }, [patientUUID, fetchPatient, enabled]);
 
   return { patient, loading, error, refetch: fetchPatient };
 };


### PR DESCRIPTION
> [!NOTE]
> Thank you for your contribution. Please find the details of this pull request below.

**JIRA** → https://bahmni.atlassian.net/browse/BAH-4693

BAH-4693 | Display patient name in Clinical Dashboard breadcrumb                                                                                                             
                                                                                                                                                                               
  Summary                                                                                                                                                                    

  - Fetches patient data once at the ConsultationPage level using usePatient and uses patient.fullName in the breadcrumb, replacing the static "Current Patient" label.        
  - Passes the fetched patient data down through PatientHeader into PatientDetails to eliminate a duplicate API call — PatientDetails disables its internal usePatient fetch
  when data is supplied via props.                                                                                                                                             
  - Adds an enabled option to usePatient so callers can conditionally skip the fetch.                                                                                        
  - Falls back to the translated "Current Patient" string while loading, on error, or when the name is unavailable.                                                            
  - Exports usePatient from @bahmni/widgets for use across apps.                                                                                                             
                                                                                                                                                                               
  Files Changed
                                                                                                                                                                               
  - ConsultationPage.tsx — Calls usePatient at the page level; injects fullName into breadcrumb; passes patient state to PatientHeader                                         
  - PatientHeader.tsx — Accepts and forwards optional patient / loading / error props to PatientDetails
  - PatientDetails.tsx — Accepts optional external patient props; disables internal hook fetch when props are provided                                                         
  - usePatient.ts — Adds enabled option to skip fetch when external data is already available                                                                                  
  - bahmni-widgets/src/index.ts — Exports usePatient hook
  - Tests — New tests covering breadcrumb name display, fallback behavior, prop forwarding, and enabled flag on the hook                                                       
                                                                                                                                                                             
  Acceptance Criteria Coverage                                                                                                                                                 
                                                                                                                                                                             
  - Patient name shown in breadcrumb when data is loaded
  - Falls back to "Current Patient" while loading or on error
  - Falls back to "Current Patient" when name is null                                                                                                                          
  - Breadcrumb updates on patient switch (reactive via usePatient)
  - Fallback text uses i18n translation key (CURRENT_PATIENT)                                                                                                                  
                                                                                                                                                                               
---

### **Implementation Details**

 Problem                                                                                                                                                                      
  The breadcrumb in ConsultationPage was hardcoded to show the translated string "Current Patient". Also, PatientDetails was fetching patient data independently via its own
  internal usePatient call — meaning if the parent also needed patient data (e.g. for the breadcrumb), there would be two separate API calls for the same data.                
                                                                                                                                                                             
  ---                                                                                                                                                                          
  1. usePatient.ts — Added enabled option                                                                                                                                    
                                         
  Added an optional UsePatientOptions interface with an enabled flag. When enabled: false, the hook skips the fetch entirely — no API call, no state update. This is the
  foundation that allows parent components to "take over" the fetch and pass data down.                                                                                        
   
  interface UsePatientOptions {                                                                                                                                                
    enabled?: boolean;                                                                                                                                                       
  }

  export const usePatient = (options?: UsePatientOptions): UsePatientResult => {                                                                                               
    const enabled = options?.enabled !== false; // defaults to true
    ...                                                                                                                                                                        
    const fetchPatient = useCallback(async () => {                                                                                                                           
      if (!enabled) return;                                                                                                                                                    
      ...
    }, [patientUUID, enabled]);                                                                                                                                                
                                                                                                                                                                               
    useEffect(() => {
      if (enabled) fetchPatient();                                                                                                                                             
    }, [patientUUID, fetchPatient, enabled]);                                                                                                                                

  ---                                                                                                                                                                          
  2. PatientDetails.tsx — Accept external data via props
                                                                                                                                                                               
  PatientDetails now accepts optional patient, loading, and error props. When any of these props are passed (detected via patientProp !== undefined), the component uses the 
  external data and disables its internal usePatient hook fetch by passing { enabled: false }.                                                                                 
   
  const hasExternalData = patientProp !== undefined;                                                                                                                           
  const { patient: internalPatient, loading: internalLoading, error: internalError } =                                                                                         
    usePatient({ enabled: !hasExternalData });                                                                                                                                 
                                                                                                                                                                               
  const patient = hasExternalData ? patientProp : internalPatient;                                                                                                             
  const loading = hasExternalData ? (loadingProp ?? false) : internalLoading;                                                                                                
  const error   = hasExternalData ? (errorProp ?? null)  : internalError;                                                                                                      
                                                                                                                                                                             
  This keeps PatientDetails backwards compatible — it still works standalone (self-fetching) when no props are passed.                                                         
   
  ---                                                                                                                                                                          
  3. PatientHeader.tsx — Forward props down                                                                                                                                  
                                           
  PatientHeader accepts the same optional patient, loading, and error props and forwards them straight to PatientDetails. It does not own any fetch logic — it is purely a
  pass-through.                                                                                                                                                                
   
  ---                                                                                                                                                                          
  4. ConsultationPage.tsx — Single fetch at the page level                                                                                                                   
                                                          
  ConsultationPage is now the single source of truth for patient data. It calls usePatient() once and:
                                                                                                                                                                               
  - Uses patient?.fullName in the breadcrumb with a fallback to t('CURRENT_PATIENT'):                                                                                          
  {                                                                                                                                                                            
    id: 'current',                                                                                                                                                             
    label: patient?.fullName ?? t('CURRENT_PATIENT'),                                                                                                                        
    isCurrentPage: true,                                                                                                                                                       
  }                     
  - Passes the same patient, loading, and error down to PatientHeader → PatientDetails, so no second fetch happens.                                                            
                                                                                                                                                                             
  ---                                                                                                                                                                          
  5. bahmni-widgets/src/index.ts — Export usePatient
                                                                                                                                                                               
  usePatient was previously internal to the patientDetails folder. It is now exported from @bahmni/widgets so ConsultationPage (in apps/clinical) can import and use it      
  directly.                                                                                                                                                                    
   
  ---                                                                                                                                                                          
  Data flow after this change                                                                                                                                                
                                                                                                                                                                               
  ConsultationPage
    └── usePatient()          ← single API call                                                                                                                                
          ├── breadcrumb label (patient.fullName ?? fallback)                                                                                                                  
          └── PatientHeader (patient, loading, error)
                └── PatientDetails (patient, loading, error)                                                                                                                   
                      └── usePatient({ enabled: false })  ← no-op, skips fetch 

### **Testing & Type Definitions**

 usePatient.test.ts                                                                                                                                                           
  - enabled: false — hook skips fetch, all state stays at initial values                                                                                                       
  - enabled: true — fetch runs normally                                                                                                                                        
  - No options passed — defaults to fetching (backwards compatible)                                                                                                          
                                                                                                                                                                               
  PatientDetails.test.tsx                                                                                                                                                      
  - External patient prop is rendered, internal hook data is ignored
  - loading: true prop shows skeleton even if internal hook has data                                                                                                           
  - error prop shows skeleton even if internal hook has data                                                                                                                 
  - Confirms usePatient({ enabled: false }) is called when prop is provided                                                                                                    
  - Confirms usePatient({ enabled: true }) is called when no prop is provided                                                                                                
                                                                                                                                                                               
  PatientHeader.test.tsx
  - patient, loading, error are correctly forwarded to PatientDetails                                                                                                          
  - No unintended props injected when none are passed                                                                                                                        
  - Mock upgraded from static render to jest.fn to enable prop assertions                                                                                                      
                                                                                                                                                                               
  ConsultationPage.test.tsx                                                                                                                                                    
  - Breadcrumb shows patient.fullName when patient is loaded                                                                                                                   
  - Breadcrumb falls back to "Current Patient" when patient is null                                                                                                            
  - PatientHeader receives correct patient and loading props from page-level fetch                                                                                           
  - Header mock updated to render breadcrumbItems as testable <span> elements                                                                                                  
  - usePatient initialised in beforeEach with null defaults so existing tests are unaffected 

---

### **Screenshots**
<img width="579" height="324" alt="Screenshot 2026-05-08 at 4 09 12 PM" src="https://github.com/user-attachments/assets/0adc40e4-959f-4032-86d2-3f4b506c454e" />
<img width="1505" height="710" alt="Screenshot 2026-05-08 at 1 34 27 PM" src="https://github.com/user-attachments/assets/41f18cef-2f7d-4b9d-a84d-6f88aef52770" />


_Note: Please ensure sensitive information is not included in screenshots._

---


---

### **Reviewer(s)**
@ravinderkabli 
@narmadhaTW 

---
