### PR TITLE
BAH-4552 | Add. Resolve Transitive Vulnerability By Pinning fast-uri To 3.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,8 @@
   },
   "resolutions": {
     "path-to-regexp": "0.1.13",
-    "picomatch": "4.0.4"
+    "picomatch": "4.0.4",
+    "fast-uri": "3.1.2"
   },
   "workspaces": [
     "apps/*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1066,7 +1066,7 @@
     ajv "^8.17.1"
     base64-inline-loader "^1.1.0"
     classnames "^2.2.5"
-    immutable "3.8.1"
+    immutable "4.3.8"
     lodash "^4.17.21"
     prop-types "^15.6.2"
     react-intl "^3.12.0"
@@ -8671,10 +8671,10 @@ fast-levenshtein@^2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
-fast-uri@^3.0.1:
-  version "3.0.6"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.0.6.tgz#88f130b77cfaea2378d56bf970dea21257a68748"
-  integrity sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==
+fast-uri@3.1.2, fast-uri@^3.0.1:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.2.tgz#8af3d4fc9d3e71b11572cc2673b514a7d1a8c8ec"
+  integrity sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==
 
 fastest-levenshtein@^1.0.12:
   version "1.0.16"


### PR DESCRIPTION
Addresses transitive security vulnerabilities by pinning fast-uri to 3.1.2 via Yarn resolutions and upgrading immutable from 3.8.1 to 4.3.8.

Key Features

  - Pins fast-uri@3.1.2 in resolutions to override vulnerable transitive dependency versions pulled in by downstream packages.
  - Upgrades immutable from 3.8.1 to 4.3.8 to resolve known vulnerabilities in the older version.