### PR TITLE
BAH-4659 | Add. Stock Batch Selection For Immunization Batch Number

### DIFF
--- a/apps/clinical/public/locales/locale_en.json
+++ b/apps/clinical/public/locales/locale_en.json
@@ -166,6 +166,7 @@
   "ERROR_LOADING_PINNED_FORMS": "Error loading Pinned Forms",
   "ERROR_LOADING_OBSERVATIONS": "Error loading observations",
   "ERROR_LOADING_PINNED_FORMS_MESSAGE": "Unable to load your pinned Forms preferences",
+  "ERROR_LOADING_STOCK_BATCHES": "Error loading stock batches",
   "ERROR_NO_ACTIVE_VISIT_FOUND": "No active visit found",
   "ERROR_NO_DEFAULT_DASHBOARD": "No default dashboard configured",
   "ERROR_SAVING_PINNED_FORMS": "Error Saving Pinned Forms",

--- a/apps/clinical/public/locales/locale_en.json
+++ b/apps/clinical/public/locales/locale_en.json
@@ -336,6 +336,7 @@
   "NO_RADIOLOGY_INVESTIGATIONS": "No Radiology investigations recorded",
   "NO_REPORT_DATA": "No report data available",
   "NO_SERVICE_REQUESTS": "No Service requests recorded",
+  "NO_STOCK_BATCHES_AVAILABLE": "No stock batches available",
   "NO_VITAL_SIGNS_DATA": "No Vital signs data found",
   "OBSERVATION_FORMS_ADDED_FORMS": "Added Forms",
   "OBSERVATION_FORMS_ERROR_LOADING_FORMS": "Error loading forms. Please try again later.",

--- a/apps/clinical/public/locales/locale_es.json
+++ b/apps/clinical/public/locales/locale_es.json
@@ -336,6 +336,7 @@
   "NO_RADIOLOGY_INVESTIGATIONS": "No se encontraron investigaciones de radiología",
   "NO_REPORT_DATA": "No hay datos de informe disponibles",
   "NO_SERVICE_REQUESTS": "No hay solicitudes de servicio registradas",
+  "NO_STOCK_BATCHES_AVAILABLE": "No hay lotes de stock disponibles",
   "NO_VITAL_SIGNS_DATA": "No se encontraron datos de signos vitales",
   "OBSERVATION_FORMS_ADDED_FORMS": "Formularios Agregados",
   "OBSERVATION_FORMS_ERROR_LOADING_FORMS": "Error al cargar formularios. Por favor, inténtelo de nuevo más tarde.",

--- a/apps/clinical/public/locales/locale_es.json
+++ b/apps/clinical/public/locales/locale_es.json
@@ -166,6 +166,7 @@
   "ERROR_LOADING_PINNED_FORMS": "Error al cargar Formularios Anclados",
   "ERROR_LOADING_OBSERVATIONS": "Error al cargar observaciones",
   "ERROR_LOADING_PINNED_FORMS_MESSAGE": "No se pueden cargar sus preferencias de formularios anclados",
+  "ERROR_LOADING_STOCK_BATCHES": "Error al cargar los lotes de stock",
   "ERROR_NO_ACTIVE_VISIT_FOUND": "No se encontró visita activa",
   "ERROR_NO_DEFAULT_DASHBOARD": "No hay panel predeterminado configurado",
   "ERROR_SAVING_PINNED_FORMS": "Error al Guardar Formularios Anclados",

--- a/apps/clinical/src/components/forms/immunizationHistory/ImmunizationHistoryForm.tsx
+++ b/apps/clinical/src/components/forms/immunizationHistory/ImmunizationHistoryForm.tsx
@@ -5,6 +5,7 @@ import {
   SelectedItem,
 } from '@bahmni/design-system';
 import {
+  getAvailableStocks,
   getLocationByTag,
   getMedicationByUuid,
   getUserLoginLocation,
@@ -12,7 +13,7 @@ import {
   searchFHIRConcepts,
   useTranslation,
 } from '@bahmni/services';
-import { useQuery } from '@tanstack/react-query';
+import { useQueries, useQuery } from '@tanstack/react-query';
 import { Medication, MedicationRequest } from 'fhir/r4';
 import { useEffect, useMemo, useState } from 'react';
 import type { EncounterSessionStartContext } from '../../../events/startConsultation';
@@ -162,6 +163,18 @@ const ImmunizationHistoryForm = ({
     queryKey: ['vaccinations'],
     queryFn: getVaccinations,
     staleTime: Infinity,
+  });
+
+  const stockQueries = useQueries({
+    queries: selectedImmunizations.map((immunization) => {
+      const locationUuid = immunization.administeredLocation?.uuid;
+      return {
+        queryKey: ['availableStocks', immunization.drug?.code, locationUuid],
+        queryFn: () =>
+          getAvailableStocks(immunization.drug!.code!, locationUuid!),
+        enabled: !!immunization.drug?.code && !!locationUuid,
+      };
+    }),
   });
 
   const vaccineMedications = useMemo(
@@ -317,7 +330,7 @@ const ImmunizationHistoryForm = ({
       ) : null}
       {showSelectedImmunizations && (
         <BoxWHeader title={t('IMMUNIZATION_HISTORY_ADDED_ITEMS')}>
-          {selectedImmunizations.map((immunization) => (
+          {selectedImmunizations.map((immunization, immunizationIndex) => (
             <SelectedItem
               key={immunization.id}
               className={styles.selectedItem}
@@ -331,6 +344,8 @@ const ImmunizationHistoryForm = ({
                 administeredLocationTag={administeredLocationTagData}
                 vaccineDrugs={vaccineMedications}
                 storeKey={immunizationFormType}
+                availableStocks={stockQueries[immunizationIndex]?.data}
+                stocksError={stockQueries[immunizationIndex]?.isError ?? false}
               />
             </SelectedItem>
           ))}

--- a/apps/clinical/src/components/forms/immunizationHistory/ImmunizationHistoryForm.tsx
+++ b/apps/clinical/src/components/forms/immunizationHistory/ImmunizationHistoryForm.tsx
@@ -348,6 +348,7 @@ const ImmunizationHistoryForm = ({
                 storeKey={immunizationFormType}
                 availableStocks={stockQueries[immunizationIndex]?.data}
                 stocksError={stockQueries[immunizationIndex]?.isError ?? false}
+                stockBatchesEnabled={!!fetchStockBatches}
               />
             </SelectedItem>
           ))}

--- a/apps/clinical/src/components/forms/immunizationHistory/ImmunizationHistoryForm.tsx
+++ b/apps/clinical/src/components/forms/immunizationHistory/ImmunizationHistoryForm.tsx
@@ -92,6 +92,7 @@ const ImmunizationHistoryForm = ({
     | undefined;
   const disableAdditionalAdministrations =
     metadata?.disableAdditionalAdministrations as boolean | undefined;
+  const fetchStockBatches = metadata?.fetchStockBatches as boolean | undefined;
 
   useEffect(() => {
     if (attributes) {
@@ -172,7 +173,8 @@ const ImmunizationHistoryForm = ({
         queryKey: ['availableStocks', immunization.drug?.code, locationUuid],
         queryFn: () =>
           getAvailableStocks(immunization.drug!.code!, locationUuid!),
-        enabled: !!immunization.drug?.code && !!locationUuid,
+        enabled:
+          !!fetchStockBatches && !!immunization.drug?.code && !!locationUuid,
       };
     }),
   });

--- a/apps/clinical/src/components/forms/immunizationHistory/__tests__/ImmunizationHistoryForm.test.tsx
+++ b/apps/clinical/src/components/forms/immunizationHistory/__tests__/ImmunizationHistoryForm.test.tsx
@@ -1,5 +1,5 @@
 import { getUserLoginLocation } from '@bahmni/services';
-import { useQuery } from '@tanstack/react-query';
+import { useQueries, useQuery } from '@tanstack/react-query';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe, toHaveNoViolations } from 'jest-axe';
@@ -8,10 +8,12 @@ import ImmunizationHistoryForm from '../ImmunizationHistoryForm';
 import { useImmunizationHistoryStore } from '../stores';
 import {
   mockAdministrationInputControlConfig,
+  mockAvailableStockResponse,
   mockClinicalConfigContext,
   mockFetchedMedication,
-  mockImmunizationInputControlConfig,
   mockImmunizationEntry,
+  mockImmunizationEntryWithBasedOn,
+  mockImmunizationInputControlConfig,
   mockLocations,
   mockMedicationRequest,
   mockMixedVaccinationBundle,
@@ -33,6 +35,7 @@ jest.mock('../../../../providers/clinicalConfig', () => ({
 jest.mock('@tanstack/react-query', () => ({
   ...jest.requireActual('@tanstack/react-query'),
   useQuery: jest.fn(),
+  useQueries: jest.fn(),
 }));
 
 const mockGetUserLoginLocation = jest.mocked(getUserLoginLocation);
@@ -40,6 +43,7 @@ const mockGetUserLoginLocation = jest.mocked(getUserLoginLocation);
 expect.extend(toHaveNoViolations);
 
 const mockUseQuery = jest.mocked(useQuery);
+const mockUseQueries = jest.mocked(useQueries);
 
 Element.prototype.scrollIntoView = jest.fn();
 
@@ -71,6 +75,7 @@ describe('ImmunizationHistoryForm', () => {
     jest.mocked(useImmunizationHistoryStore).mockReturnValue(mockStore);
     jest.mocked(useClinicalConfig).mockReturnValue(mockClinicalConfigContext);
     mockUseQuery.mockImplementation(defaultQueryMock as any);
+    mockUseQueries.mockReturnValue([] as any);
     mockGetUserLoginLocation.mockReturnValue({
       uuid: 'loc-uuid',
       display: 'Login Location',
@@ -496,6 +501,72 @@ describe('ImmunizationHistoryForm', () => {
             administeredOn: expect.any(Date),
           }),
         );
+      });
+    });
+  });
+
+  describe('Stock batch queries', () => {
+    it.each([
+      [
+        'no drug code or administered location set',
+        mockImmunizationEntry,
+        ['availableStocks', undefined, undefined],
+        false,
+      ],
+      [
+        'drug code and administered location uuid set',
+        mockImmunizationEntryWithBasedOn,
+        ['availableStocks', 'covid-drug-uuid', 'location-uuid-1'],
+        true,
+      ],
+    ])(
+      'calls useQueries with correct queryKey and enabled when %s',
+      (_, immunization, expectedQueryKey, expectedEnabled) => {
+        jest.mocked(useImmunizationHistoryStore).mockReturnValue({
+          ...mockStore,
+          selectedImmunizations: [immunization],
+        });
+        render(
+          <ImmunizationHistoryForm
+            encounterSessionStartContext={{}}
+            inputControlConfig={mockImmunizationInputControlConfig}
+          />,
+        );
+        expect(mockUseQueries).toHaveBeenCalledWith(
+          expect.objectContaining({
+            queries: expect.arrayContaining([
+              expect.objectContaining({
+                queryKey: expectedQueryKey,
+                enabled: expectedEnabled,
+              }),
+            ]),
+          }),
+        );
+      },
+    );
+
+    it('passes availableStocks from useQueries to the batch number dropdown', async () => {
+      const user = userEvent.setup();
+      jest.mocked(useImmunizationHistoryStore).mockReturnValue({
+        ...mockStore,
+        selectedImmunizations: [mockImmunizationEntryWithBasedOn],
+      });
+      mockUseQueries.mockReturnValue([
+        { data: mockAvailableStockResponse, isLoading: false, isError: false },
+      ] as any);
+      render(
+        <ImmunizationHistoryForm
+          encounterSessionStartContext={{}}
+          inputControlConfig={{
+            ...mockImmunizationInputControlConfig,
+            attributes: [{ name: 'batchNumber', required: false }],
+          }}
+        />,
+      );
+      await user.click(screen.getByPlaceholderText('Enter batch number'));
+      await waitFor(() => {
+        expect(screen.getByText('BATCH-001')).toBeInTheDocument();
+        expect(screen.getByText('BATCH-002')).toBeInTheDocument();
       });
     });
   });

--- a/apps/clinical/src/components/forms/immunizationHistory/__tests__/ImmunizationHistoryForm.test.tsx
+++ b/apps/clinical/src/components/forms/immunizationHistory/__tests__/ImmunizationHistoryForm.test.tsx
@@ -1,5 +1,10 @@
-import { getUserLoginLocation } from '@bahmni/services';
-import { useQueries, useQuery } from '@tanstack/react-query';
+import { getAvailableStocks, getUserLoginLocation } from '@bahmni/services';
+import {
+  QueryClient,
+  QueryClientProvider,
+  useQueries,
+  useQuery,
+} from '@tanstack/react-query';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe, toHaveNoViolations } from 'jest-axe';
@@ -14,6 +19,7 @@ import {
   mockImmunizationEntry,
   mockImmunizationEntryWithBasedOn,
   mockImmunizationInputControlConfig,
+  mockImmunizationInputControlConfigWithFetchStockBatches,
   mockLocations,
   mockMedicationRequest,
   mockMixedVaccinationBundle,
@@ -26,6 +32,7 @@ import {
 
 jest.mock('@bahmni/services', () => ({
   ...jest.requireActual('@bahmni/services'),
+  getAvailableStocks: jest.fn(),
   getUserLoginLocation: jest.fn(),
 }));
 jest.mock('../stores');
@@ -38,6 +45,7 @@ jest.mock('@tanstack/react-query', () => ({
   useQueries: jest.fn(),
 }));
 
+const mockGetAvailableStocks = jest.mocked(getAvailableStocks);
 const mockGetUserLoginLocation = jest.mocked(getUserLoginLocation);
 
 expect.extend(toHaveNoViolations);
@@ -510,18 +518,27 @@ describe('ImmunizationHistoryForm', () => {
       [
         'no drug code or administered location set',
         mockImmunizationEntry,
+        mockImmunizationInputControlConfig,
         ['availableStocks', undefined, undefined],
         false,
       ],
       [
-        'drug code and administered location uuid set',
+        'drug code and administered location uuid set but fetchStockBatches absent',
         mockImmunizationEntryWithBasedOn,
+        mockImmunizationInputControlConfig,
+        ['availableStocks', 'covid-drug-uuid', 'location-uuid-1'],
+        false,
+      ],
+      [
+        'drug code and administered location uuid set and fetchStockBatches is true',
+        mockImmunizationEntryWithBasedOn,
+        mockImmunizationInputControlConfigWithFetchStockBatches,
         ['availableStocks', 'covid-drug-uuid', 'location-uuid-1'],
         true,
       ],
     ])(
       'calls useQueries with correct queryKey and enabled when %s',
-      (_, immunization, expectedQueryKey, expectedEnabled) => {
+      (_, immunization, config, expectedQueryKey, expectedEnabled) => {
         jest.mocked(useImmunizationHistoryStore).mockReturnValue({
           ...mockStore,
           selectedImmunizations: [immunization],
@@ -529,7 +546,7 @@ describe('ImmunizationHistoryForm', () => {
         render(
           <ImmunizationHistoryForm
             encounterSessionStartContext={{}}
-            inputControlConfig={mockImmunizationInputControlConfig}
+            inputControlConfig={config}
           />,
         );
         expect(mockUseQueries).toHaveBeenCalledWith(
@@ -544,6 +561,36 @@ describe('ImmunizationHistoryForm', () => {
         );
       },
     );
+
+    it('calls getAvailableStocks with drug code and location uuid when enabled', async () => {
+      mockUseQueries.mockImplementation(
+        jest.requireActual('@tanstack/react-query').useQueries,
+      );
+      mockGetAvailableStocks.mockResolvedValue(mockAvailableStockResponse);
+      jest.mocked(useImmunizationHistoryStore).mockReturnValue({
+        ...mockStore,
+        selectedImmunizations: [mockImmunizationEntryWithBasedOn],
+      });
+      const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      });
+      render(
+        <QueryClientProvider client={queryClient}>
+          <ImmunizationHistoryForm
+            encounterSessionStartContext={{}}
+            inputControlConfig={
+              mockImmunizationInputControlConfigWithFetchStockBatches
+            }
+          />
+        </QueryClientProvider>,
+      );
+      await waitFor(() => {
+        expect(mockGetAvailableStocks).toHaveBeenCalledWith(
+          'covid-drug-uuid',
+          'location-uuid-1',
+        );
+      });
+    });
 
     it('passes availableStocks from useQueries to the batch number dropdown', async () => {
       const user = userEvent.setup();

--- a/apps/clinical/src/components/forms/immunizationHistory/__tests__/SelectedImmunizationItem.test.tsx
+++ b/apps/clinical/src/components/forms/immunizationHistory/__tests__/SelectedImmunizationItem.test.tsx
@@ -5,6 +5,7 @@ import SelectedImmunizationItem from '../components/SelectedImmunizationItem';
 import { IMMUNIZATION_HISTORY_INPUT_CONTROL_KEY } from '../constants';
 import { useImmunizationHistoryStore } from '../stores';
 import {
+  mockAvailableStockResponse,
   mockCovid19VaccineDrugs,
   mockFullAttributes,
   mockImmunizationEntry,
@@ -36,6 +37,8 @@ const defaultProps = {
   attributes: mockFullAttributes,
   vaccineDrugs: mockCovid19VaccineDrugs,
   storeKey: IMMUNIZATION_HISTORY_INPUT_CONTROL_KEY,
+  availableStocks: mockAvailableStockResponse,
+  stocksError: false,
 };
 
 describe('SelectedImmunizationItem', () => {
@@ -386,28 +389,20 @@ describe('SelectedImmunizationItem', () => {
       },
     );
 
-    it.each([
-      [
-        'updateManufacturer',
-        `immunization-manufacturer-${id}`,
-        mockStore.updateManufacturer,
-      ],
-      [
-        'updateBatchNumber',
-        `immunization-batch-number-${id}`,
-        mockStore.updateBatchNumber,
-      ],
-    ])(
-      'calls %s when the text input changes',
-      async (_, testId, storeMethod) => {
-        const user = userEvent.setup();
-        render(<SelectedImmunizationItem {...defaultProps} />);
-        await user.type(screen.getByTestId(testId), 'value');
-        await waitFor(() => {
-          expect(storeMethod).toHaveBeenCalledWith(id, expect.any(String));
-        });
-      },
-    );
+    it('calls updateManufacturer when the text input changes', async () => {
+      const user = userEvent.setup();
+      render(<SelectedImmunizationItem {...defaultProps} />);
+      await user.type(
+        screen.getByTestId(`immunization-manufacturer-${id}`),
+        'value',
+      );
+      await waitFor(() => {
+        expect(mockStore.updateManufacturer).toHaveBeenCalledWith(
+          id,
+          expect.any(String),
+        );
+      });
+    });
 
     it('calls updateDoseSequence with a number when value is typed', async () => {
       const user = userEvent.setup();
@@ -452,6 +447,132 @@ describe('SelectedImmunizationItem', () => {
         await waitFor(() => {
           expect(storeMethod).toHaveBeenCalledWith(id, expect.any(Date));
         });
+      },
+    );
+  });
+
+  describe('Batch number ComboBox', () => {
+    it('shows available stock batches as options in the dropdown', async () => {
+      const user = userEvent.setup();
+      render(<SelectedImmunizationItem {...defaultProps} />);
+      await user.click(screen.getByPlaceholderText('Enter batch number'));
+      await waitFor(() => {
+        expect(screen.getByText('BATCH-001')).toBeInTheDocument();
+        expect(screen.getByText('BATCH-002')).toBeInTheDocument();
+      });
+    });
+
+    it('calls updateBatchNumber and updateExpiryDate when a batch is selected from the stock list', async () => {
+      const user = userEvent.setup();
+      render(<SelectedImmunizationItem {...defaultProps} />);
+      await user.click(screen.getByPlaceholderText('Enter batch number'));
+      await user.click(screen.getByText('BATCH-001'));
+      await waitFor(() => {
+        expect(mockStore.updateBatchNumber).toHaveBeenCalledWith(
+          id,
+          'BATCH-001',
+        );
+        expect(mockStore.updateExpiryDate).toHaveBeenCalledWith(
+          id,
+          new Date('2026-12-31'),
+        );
+      });
+    });
+
+    it('calls updateBatchNumber but not updateExpiryDate when a batch without an expiry date is selected', async () => {
+      const user = userEvent.setup();
+      render(
+        <SelectedImmunizationItem
+          {...defaultProps}
+          availableStocks={{
+            count: 1,
+            data: [
+              {
+                stockLocationName: 'Nurse Station',
+                availableQuantity: 5,
+                onHandQuantity: 5,
+                unit: 'vial',
+                batchNumber: 'BATCH-NO-EXPIRY',
+                expiryDate: '',
+              },
+            ],
+          }}
+        />,
+      );
+      await user.click(screen.getByPlaceholderText('Enter batch number'));
+      await user.click(screen.getByText('BATCH-NO-EXPIRY'));
+      await waitFor(() => {
+        expect(mockStore.updateBatchNumber).toHaveBeenCalledWith(
+          id,
+          'BATCH-NO-EXPIRY',
+        );
+      });
+      expect(mockStore.updateExpiryDate).not.toHaveBeenCalled();
+    });
+
+    it('calls updateBatchNumber with custom text without calling updateExpiryDate when a custom value is entered', async () => {
+      const user = userEvent.setup();
+      render(<SelectedImmunizationItem {...defaultProps} />);
+      await user.type(
+        screen.getByPlaceholderText('Enter batch number'),
+        'MY-CUSTOM-BATCH',
+      );
+      await user.keyboard('{Enter}');
+      await waitFor(() => {
+        expect(mockStore.updateBatchNumber).toHaveBeenCalledWith(
+          id,
+          'MY-CUSTOM-BATCH',
+        );
+      });
+      expect(mockStore.updateExpiryDate).not.toHaveBeenCalled();
+    });
+
+    it('calls updateBatchNumber with empty string when the batch number input is cleared', async () => {
+      const user = userEvent.setup();
+      render(<SelectedImmunizationItem {...defaultProps} />);
+      await user.click(screen.getByPlaceholderText('Enter batch number'));
+      await user.click(screen.getByText('BATCH-001'));
+      mockStore.updateBatchNumber.mockClear();
+      await user.click(
+        screen.getByRole('button', { name: 'Clear selected item' }),
+      );
+      await waitFor(() => {
+        expect(mockStore.updateBatchNumber).toHaveBeenCalledWith(id, '');
+      });
+    });
+
+    it('shows disabled error option in the dropdown when stocksError is true', async () => {
+      const user = userEvent.setup();
+      render(
+        <SelectedImmunizationItem
+          {...defaultProps}
+          availableStocks={undefined}
+          stocksError
+        />,
+      );
+      await user.click(screen.getByPlaceholderText('Enter batch number'));
+      await waitFor(() => {
+        expect(
+          screen.getByText('Error loading stock batches'),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it.each([
+      ['matches a stock item', 'BATCH-001'],
+      ['is a custom value not in the stock list', 'MY-CUSTOM-BATCH'],
+    ])(
+      'shows existing batch number from immunization when it %s',
+      (_, batchNumber) => {
+        render(
+          <SelectedImmunizationItem
+            {...defaultProps}
+            immunization={{ ...mockImmunizationEntry, batchNumber }}
+          />,
+        );
+        expect(screen.getByPlaceholderText('Enter batch number')).toHaveValue(
+          batchNumber,
+        );
       },
     );
   });

--- a/apps/clinical/src/components/forms/immunizationHistory/__tests__/SelectedImmunizationItem.test.tsx
+++ b/apps/clinical/src/components/forms/immunizationHistory/__tests__/SelectedImmunizationItem.test.tsx
@@ -6,6 +6,7 @@ import { IMMUNIZATION_HISTORY_INPUT_CONTROL_KEY } from '../constants';
 import { useImmunizationHistoryStore } from '../stores';
 import {
   mockAvailableStockResponse,
+  mockEmptyAvailableStockResponse,
   mockCovid19VaccineDrugs,
   mockFullAttributes,
   mockImmunizationEntry,
@@ -39,6 +40,7 @@ const defaultProps = {
   storeKey: IMMUNIZATION_HISTORY_INPUT_CONTROL_KEY,
   availableStocks: mockAvailableStockResponse,
   stocksError: false,
+  stockBatchesEnabled: true,
 };
 
 describe('SelectedImmunizationItem', () => {
@@ -537,6 +539,23 @@ describe('SelectedImmunizationItem', () => {
       );
       await waitFor(() => {
         expect(mockStore.updateBatchNumber).toHaveBeenCalledWith(id, '');
+      });
+    });
+
+    it('shows disabled no-stock option in the dropdown when there are no available stocks', async () => {
+      const user = userEvent.setup();
+      render(
+        <SelectedImmunizationItem
+          {...defaultProps}
+          availableStocks={mockEmptyAvailableStockResponse}
+          stocksError={false}
+        />,
+      );
+      await user.click(screen.getByPlaceholderText('Enter batch number'));
+      await waitFor(() => {
+        expect(
+          screen.getByText('No stock batches available'),
+        ).toBeInTheDocument();
       });
     });
 

--- a/apps/clinical/src/components/forms/immunizationHistory/__tests__/SelectedImmunizationItem.test.tsx
+++ b/apps/clinical/src/components/forms/immunizationHistory/__tests__/SelectedImmunizationItem.test.tsx
@@ -119,23 +119,22 @@ describe('SelectedImmunizationItem', () => {
       },
     );
 
-    it.each([
-      ['drug', `immunization-drug-name-combobox-${id}-test-id`],
-      ['administeredOn', `immunization-administered-on-input-${id}-test-id`],
-      [
-        'administeredLocation',
-        `immunization-administered-location-${id}-test-id`,
-      ],
-      ['route', `immunization-route-${id}-test-id`],
-      ['site', `immunization-site-${id}-test-id`],
-      ['manufacturer', `immunization-manufacturer-${id}`],
-      ['batchNumber', `immunization-batch-number-${id}`],
-      ['doseSequence', `immunization-dose-sequence-${id}`],
-      ['expiryDate', `immunization-expiry-date-input-${id}`],
-      ['note', `immunization-add-note-link-${id}-test-id`],
-    ])('does not render %s field when attributes is empty', (_, testId) => {
+    it('does not render any field when attributes is empty', () => {
       render(<SelectedImmunizationItem {...defaultProps} attributes={[]} />);
-      expect(screen.queryByTestId(testId)).not.toBeInTheDocument();
+      [
+        `immunization-drug-name-combobox-${id}-test-id`,
+        `immunization-administered-on-input-${id}-test-id`,
+        `immunization-administered-location-${id}-test-id`,
+        `immunization-route-${id}-test-id`,
+        `immunization-site-${id}-test-id`,
+        `immunization-manufacturer-${id}`,
+        `immunization-batch-number-${id}`,
+        `immunization-dose-sequence-${id}`,
+        `immunization-expiry-date-input-${id}`,
+        `immunization-add-note-link-${id}-test-id`,
+      ].forEach((testId) =>
+        expect(screen.queryByTestId(testId)).not.toBeInTheDocument(),
+      );
     });
 
     it.each([

--- a/apps/clinical/src/components/forms/immunizationHistory/__tests__/SelectedImmunizationItem.test.tsx
+++ b/apps/clinical/src/components/forms/immunizationHistory/__tests__/SelectedImmunizationItem.test.tsx
@@ -513,7 +513,12 @@ describe('SelectedImmunizationItem', () => {
 
     it('calls updateBatchNumber with custom text without calling updateExpiryDate when a custom value is entered', async () => {
       const user = userEvent.setup();
-      render(<SelectedImmunizationItem {...defaultProps} />);
+      render(
+        <SelectedImmunizationItem
+          {...defaultProps}
+          stockBatchesEnabled={false}
+        />,
+      );
       await user.type(
         screen.getByPlaceholderText('Enter batch number'),
         'MY-CUSTOM-BATCH',

--- a/apps/clinical/src/components/forms/immunizationHistory/__tests__/__mocks__/immunizationHistoryMocks.ts
+++ b/apps/clinical/src/components/forms/immunizationHistory/__tests__/__mocks__/immunizationHistoryMocks.ts
@@ -1,4 +1,4 @@
-import { Location } from '@bahmni/services';
+import { AvailableStockResponse, Location } from '@bahmni/services';
 import { Medication, MedicationRequest, Reference } from 'fhir/r4';
 import { InputControlAttributes } from '../../../../../providers/clinicalConfig/models';
 import { ImmunizationInputEntry } from '../../models';
@@ -336,6 +336,28 @@ export const mockVaccinationBundleWithCovid = {
   resourceType: 'Bundle',
   type: 'searchset',
   entry: [{ resource: mockCovid19VaccineDrug }],
+};
+
+export const mockAvailableStockResponse: AvailableStockResponse = {
+  count: 2,
+  data: [
+    {
+      stockLocationName: 'Nurse Station',
+      availableQuantity: 10,
+      onHandQuantity: 15,
+      unit: 'vial',
+      batchNumber: 'BATCH-001',
+      expiryDate: '2026-12-31',
+    },
+    {
+      stockLocationName: 'Nurse Station',
+      availableQuantity: 5,
+      onHandQuantity: 5,
+      unit: 'vial',
+      batchNumber: 'BATCH-002',
+      expiryDate: '2027-06-30',
+    },
+  ],
 };
 
 export const mockStore = {

--- a/apps/clinical/src/components/forms/immunizationHistory/__tests__/__mocks__/immunizationHistoryMocks.ts
+++ b/apps/clinical/src/components/forms/immunizationHistory/__tests__/__mocks__/immunizationHistoryMocks.ts
@@ -52,6 +52,14 @@ export const mockImmunizationInputControlConfig = {
   attributes: mockImmunizationHistory.attributes,
 };
 
+export const mockImmunizationInputControlConfigWithFetchStockBatches = {
+  ...mockImmunizationInputControlConfig,
+  metadata: {
+    ...mockImmunizationInputControlConfig.metadata,
+    fetchStockBatches: true,
+  },
+};
+
 export const mockAdministrationInputControlConfig = {
   type: 'immunizationAdministration',
   metadata: {

--- a/apps/clinical/src/components/forms/immunizationHistory/__tests__/__mocks__/immunizationHistoryMocks.ts
+++ b/apps/clinical/src/components/forms/immunizationHistory/__tests__/__mocks__/immunizationHistoryMocks.ts
@@ -368,6 +368,11 @@ export const mockAvailableStockResponse: AvailableStockResponse = {
   ],
 };
 
+export const mockEmptyAvailableStockResponse: AvailableStockResponse = {
+  count: 0,
+  data: [],
+};
+
 export const mockStore = {
   selectedImmunizations: [],
   attributes: undefined,

--- a/apps/clinical/src/components/forms/immunizationHistory/__tests__/__snapshots__/ImmunizationHistoryForm.test.tsx.snap
+++ b/apps/clinical/src/components/forms/immunizationHistory/__tests__/__snapshots__/ImmunizationHistoryForm.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`ImmunizationHistoryForm Snapshots matches snapshot with no immunization
           <input
             aria-activedescendant=""
             aria-autocomplete="list"
-            aria-controls="downshift-_r_53_-menu"
+            aria-controls="downshift-_r_6b_-menu"
             aria-expanded="false"
             aria-haspopup="listbox"
             aria-label="Search to add immunization"
@@ -42,11 +42,11 @@ exports[`ImmunizationHistoryForm Snapshots matches snapshot with no immunization
             value=""
           />
           <button
-            aria-controls="downshift-_r_53_-menu"
+            aria-controls="downshift-_r_6b_-menu"
             aria-expanded="false"
             aria-label="Open"
             class="cds--list-box__menu-icon"
-            id="downshift-_r_53_-toggle-button"
+            id="downshift-_r_6b_-toggle-button"
             tabindex="-1"
             title="Open"
             type="button"
@@ -68,9 +68,9 @@ exports[`ImmunizationHistoryForm Snapshots matches snapshot with no immunization
           </button>
         </div>
         <ul
-          aria-labelledby="downshift-_r_53_-label"
+          aria-labelledby="downshift-_r_6b_-label"
           class="cds--list-box__menu"
-          id="downshift-_r_53_-menu"
+          id="downshift-_r_6b_-menu"
           role="listbox"
           style="position: fixed; left: 0px; top: 0px; visibility: visible; transform: translate(0px, 0px);"
         />
@@ -106,7 +106,7 @@ exports[`ImmunizationHistoryForm Snapshots matches snapshot with selected immuni
           <input
             aria-activedescendant=""
             aria-autocomplete="list"
-            aria-controls="downshift-_r_56_-menu"
+            aria-controls="downshift-_r_6e_-menu"
             aria-expanded="false"
             aria-haspopup="listbox"
             aria-label="Search to add immunization"
@@ -122,11 +122,11 @@ exports[`ImmunizationHistoryForm Snapshots matches snapshot with selected immuni
             value=""
           />
           <button
-            aria-controls="downshift-_r_56_-menu"
+            aria-controls="downshift-_r_6e_-menu"
             aria-expanded="false"
             aria-label="Open"
             class="cds--list-box__menu-icon"
-            id="downshift-_r_56_-toggle-button"
+            id="downshift-_r_6e_-toggle-button"
             tabindex="-1"
             title="Open"
             type="button"
@@ -148,9 +148,9 @@ exports[`ImmunizationHistoryForm Snapshots matches snapshot with selected immuni
           </button>
         </div>
         <ul
-          aria-labelledby="downshift-_r_56_-label"
+          aria-labelledby="downshift-_r_6e_-label"
           class="cds--list-box__menu"
-          id="downshift-_r_56_-menu"
+          id="downshift-_r_6e_-menu"
           role="listbox"
           style="position: fixed; left: 0px; top: 0px; visibility: visible; transform: translate(0px, 0px);"
         />
@@ -203,7 +203,7 @@ exports[`ImmunizationHistoryForm Snapshots matches snapshot with selected immuni
               >
                 <button
                   aria-label="Close Selected Item"
-                  aria-labelledby="tooltip-_r_58_"
+                  aria-labelledby="tooltip-_r_6g_"
                   class="cds--btn cds--btn--lg cds--layout--size-lg cds--btn--primary cds--btn--icon-only"
                   data-testid="selected-item-close-button"
                   id="close-selected-item"
@@ -228,7 +228,7 @@ exports[`ImmunizationHistoryForm Snapshots matches snapshot with selected immuni
               <span
                 aria-hidden="true"
                 class="cds--popover"
-                id="tooltip-_r_58_"
+                id="tooltip-_r_6g_"
                 role="tooltip"
               >
                 <span

--- a/apps/clinical/src/components/forms/immunizationHistory/__tests__/__snapshots__/ImmunizationHistoryForm.test.tsx.snap
+++ b/apps/clinical/src/components/forms/immunizationHistory/__tests__/__snapshots__/ImmunizationHistoryForm.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`ImmunizationHistoryForm Snapshots matches snapshot with no immunization
           <input
             aria-activedescendant=""
             aria-autocomplete="list"
-            aria-controls="downshift-_r_3h_-menu"
+            aria-controls="downshift-_r_53_-menu"
             aria-expanded="false"
             aria-haspopup="listbox"
             aria-label="Search to add immunization"
@@ -42,11 +42,11 @@ exports[`ImmunizationHistoryForm Snapshots matches snapshot with no immunization
             value=""
           />
           <button
-            aria-controls="downshift-_r_3h_-menu"
+            aria-controls="downshift-_r_53_-menu"
             aria-expanded="false"
             aria-label="Open"
             class="cds--list-box__menu-icon"
-            id="downshift-_r_3h_-toggle-button"
+            id="downshift-_r_53_-toggle-button"
             tabindex="-1"
             title="Open"
             type="button"
@@ -68,9 +68,9 @@ exports[`ImmunizationHistoryForm Snapshots matches snapshot with no immunization
           </button>
         </div>
         <ul
-          aria-labelledby="downshift-_r_3h_-label"
+          aria-labelledby="downshift-_r_53_-label"
           class="cds--list-box__menu"
-          id="downshift-_r_3h_-menu"
+          id="downshift-_r_53_-menu"
           role="listbox"
           style="position: fixed; left: 0px; top: 0px; visibility: visible; transform: translate(0px, 0px);"
         />
@@ -106,7 +106,7 @@ exports[`ImmunizationHistoryForm Snapshots matches snapshot with selected immuni
           <input
             aria-activedescendant=""
             aria-autocomplete="list"
-            aria-controls="downshift-_r_3k_-menu"
+            aria-controls="downshift-_r_56_-menu"
             aria-expanded="false"
             aria-haspopup="listbox"
             aria-label="Search to add immunization"
@@ -122,11 +122,11 @@ exports[`ImmunizationHistoryForm Snapshots matches snapshot with selected immuni
             value=""
           />
           <button
-            aria-controls="downshift-_r_3k_-menu"
+            aria-controls="downshift-_r_56_-menu"
             aria-expanded="false"
             aria-label="Open"
             class="cds--list-box__menu-icon"
-            id="downshift-_r_3k_-toggle-button"
+            id="downshift-_r_56_-toggle-button"
             tabindex="-1"
             title="Open"
             type="button"
@@ -148,9 +148,9 @@ exports[`ImmunizationHistoryForm Snapshots matches snapshot with selected immuni
           </button>
         </div>
         <ul
-          aria-labelledby="downshift-_r_3k_-label"
+          aria-labelledby="downshift-_r_56_-label"
           class="cds--list-box__menu"
-          id="downshift-_r_3k_-menu"
+          id="downshift-_r_56_-menu"
           role="listbox"
           style="position: fixed; left: 0px; top: 0px; visibility: visible; transform: translate(0px, 0px);"
         />
@@ -203,7 +203,7 @@ exports[`ImmunizationHistoryForm Snapshots matches snapshot with selected immuni
               >
                 <button
                   aria-label="Close Selected Item"
-                  aria-labelledby="tooltip-_r_3m_"
+                  aria-labelledby="tooltip-_r_58_"
                   class="cds--btn cds--btn--lg cds--layout--size-lg cds--btn--primary cds--btn--icon-only"
                   data-testid="selected-item-close-button"
                   id="close-selected-item"
@@ -228,7 +228,7 @@ exports[`ImmunizationHistoryForm Snapshots matches snapshot with selected immuni
               <span
                 aria-hidden="true"
                 class="cds--popover"
-                id="tooltip-_r_3m_"
+                id="tooltip-_r_58_"
                 role="tooltip"
               >
                 <span

--- a/apps/clinical/src/components/forms/immunizationHistory/__tests__/__snapshots__/SelectedImmunizationItem.test.tsx.snap
+++ b/apps/clinical/src/components/forms/immunizationHistory/__tests__/__snapshots__/SelectedImmunizationItem.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`SelectedImmunizationItem Snapshots matches snapshot with all form field
               <input
                 aria-activedescendant=""
                 aria-autocomplete="list"
-                aria-controls="downshift-_r_f0_-menu"
+                aria-controls="downshift-_r_lq_-menu"
                 aria-expanded="false"
                 aria-haspopup="listbox"
                 aria-label="Choose an item"
@@ -47,11 +47,11 @@ exports[`SelectedImmunizationItem Snapshots matches snapshot with all form field
                 value=""
               />
               <button
-                aria-controls="downshift-_r_f0_-menu"
+                aria-controls="downshift-_r_lq_-menu"
                 aria-expanded="false"
                 aria-label="Open"
                 class="cds--list-box__menu-icon"
-                id="downshift-_r_f0_-toggle-button"
+                id="downshift-_r_lq_-toggle-button"
                 tabindex="-1"
                 title="Open"
                 type="button"
@@ -73,9 +73,9 @@ exports[`SelectedImmunizationItem Snapshots matches snapshot with all form field
               </button>
             </div>
             <ul
-              aria-labelledby="downshift-_r_f0_-label"
+              aria-labelledby="downshift-_r_lq_-label"
               class="cds--list-box__menu"
-              id="downshift-_r_f0_-menu"
+              id="downshift-_r_lq_-menu"
               role="listbox"
               style="position: fixed; left: 0px; top: 0px; visibility: visible; transform: translate(0px, 0px);"
             />
@@ -150,7 +150,7 @@ exports[`SelectedImmunizationItem Snapshots matches snapshot with all form field
               <input
                 aria-activedescendant=""
                 aria-autocomplete="list"
-                aria-controls="downshift-_r_f4_-menu"
+                aria-controls="downshift-_r_lu_-menu"
                 aria-expanded="false"
                 aria-haspopup="listbox"
                 aria-label="Choose an item"
@@ -166,11 +166,11 @@ exports[`SelectedImmunizationItem Snapshots matches snapshot with all form field
                 value=""
               />
               <button
-                aria-controls="downshift-_r_f4_-menu"
+                aria-controls="downshift-_r_lu_-menu"
                 aria-expanded="false"
                 aria-label="Open"
                 class="cds--list-box__menu-icon"
-                id="downshift-_r_f4_-toggle-button"
+                id="downshift-_r_lu_-toggle-button"
                 tabindex="-1"
                 title="Open"
                 type="button"
@@ -192,9 +192,9 @@ exports[`SelectedImmunizationItem Snapshots matches snapshot with all form field
               </button>
             </div>
             <ul
-              aria-labelledby="downshift-_r_f4_-label"
+              aria-labelledby="downshift-_r_lu_-label"
               class="cds--list-box__menu"
-              id="downshift-_r_f4_-menu"
+              id="downshift-_r_lu_-menu"
               role="listbox"
               style="position: fixed; left: 0px; top: 0px; visibility: visible; transform: translate(0px, 0px);"
             />
@@ -216,7 +216,7 @@ exports[`SelectedImmunizationItem Snapshots matches snapshot with all form field
               <input
                 aria-activedescendant=""
                 aria-autocomplete="list"
-                aria-controls="downshift-_r_f7_-menu"
+                aria-controls="downshift-_r_m1_-menu"
                 aria-expanded="false"
                 aria-haspopup="listbox"
                 aria-label="Choose an item"
@@ -232,11 +232,11 @@ exports[`SelectedImmunizationItem Snapshots matches snapshot with all form field
                 value=""
               />
               <button
-                aria-controls="downshift-_r_f7_-menu"
+                aria-controls="downshift-_r_m1_-menu"
                 aria-expanded="false"
                 aria-label="Open"
                 class="cds--list-box__menu-icon"
-                id="downshift-_r_f7_-toggle-button"
+                id="downshift-_r_m1_-toggle-button"
                 tabindex="-1"
                 title="Open"
                 type="button"
@@ -258,9 +258,9 @@ exports[`SelectedImmunizationItem Snapshots matches snapshot with all form field
               </button>
             </div>
             <ul
-              aria-labelledby="downshift-_r_f7_-label"
+              aria-labelledby="downshift-_r_m1_-label"
               class="cds--list-box__menu"
-              id="downshift-_r_f7_-menu"
+              id="downshift-_r_m1_-menu"
               role="listbox"
               style="position: fixed; left: 0px; top: 0px; visibility: visible; transform: translate(0px, 0px);"
             />
@@ -282,7 +282,7 @@ exports[`SelectedImmunizationItem Snapshots matches snapshot with all form field
               <input
                 aria-activedescendant=""
                 aria-autocomplete="list"
-                aria-controls="downshift-_r_fa_-menu"
+                aria-controls="downshift-_r_m4_-menu"
                 aria-expanded="false"
                 aria-haspopup="listbox"
                 aria-label="Choose an item"
@@ -298,11 +298,11 @@ exports[`SelectedImmunizationItem Snapshots matches snapshot with all form field
                 value=""
               />
               <button
-                aria-controls="downshift-_r_fa_-menu"
+                aria-controls="downshift-_r_m4_-menu"
                 aria-expanded="false"
                 aria-label="Open"
                 class="cds--list-box__menu-icon"
-                id="downshift-_r_fa_-toggle-button"
+                id="downshift-_r_m4_-toggle-button"
                 tabindex="-1"
                 title="Open"
                 type="button"
@@ -324,9 +324,9 @@ exports[`SelectedImmunizationItem Snapshots matches snapshot with all form field
               </button>
             </div>
             <ul
-              aria-labelledby="downshift-_r_fa_-label"
+              aria-labelledby="downshift-_r_m4_-label"
               class="cds--list-box__menu"
-              id="downshift-_r_fa_-menu"
+              id="downshift-_r_m4_-menu"
               role="listbox"
               style="position: fixed; left: 0px; top: 0px; visibility: visible; transform: translate(0px, 0px);"
             />
@@ -379,41 +379,65 @@ exports[`SelectedImmunizationItem Snapshots matches snapshot with all form field
         class="column cds--sm:col-span-4 cds--md:col-span-2 cds--lg:col-span-5 cds--css-grid-column"
       >
         <div
-          class="cds--form-item cds--text-input-wrapper"
+          class="cds--list-box__wrapper"
         >
           <div
-            class="cds--text-input__label-wrapper"
-          >
-            <label
-              class="cds--label cds--visually-hidden"
-              dir="auto"
-              for="immunization-batch-number-test-id-1"
-            >
-              Batch Number
-            </label>
-          </div>
-          <div
-            class="cds--text-input__field-outer-wrapper"
+            class="cds--combo-box cds--autoalign cds--list-box"
           >
             <div
-              class="cds--text-input__field-wrapper"
+              class="cds--list-box__field"
             >
               <input
-                class="cds--text-input"
+                aria-activedescendant=""
+                aria-autocomplete="list"
+                aria-controls="downshift-_r_m7_-menu"
+                aria-expanded="false"
+                aria-haspopup="listbox"
+                aria-label="Choose an item"
+                autocomplete="off"
+                class="cds--text-input cds--text-input--empty"
                 data-testid="immunization-batch-number-test-id-1"
                 id="immunization-batch-number-test-id-1"
                 placeholder="Enter batch number"
-                title="Enter batch number"
+                role="combobox"
+                tabindex="0"
+                title=""
                 type="text"
                 value=""
               />
-              <span
-                aria-atomic="true"
-                aria-live="assertive"
-                class="cds--text-input__counter-alert"
-                role="alert"
-              />
+              <button
+                aria-controls="downshift-_r_m7_-menu"
+                aria-expanded="false"
+                aria-label="Open"
+                class="cds--list-box__menu-icon"
+                id="downshift-_r_m7_-toggle-button"
+                tabindex="-1"
+                title="Open"
+                type="button"
+              >
+                <svg
+                  aria-hidden="true"
+                  fill="currentColor"
+                  focusable="false"
+                  height="16"
+                  preserveAspectRatio="xMidYMid meet"
+                  viewBox="0 0 16 16"
+                  width="16"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                  />
+                </svg>
+              </button>
             </div>
+            <ul
+              aria-labelledby="downshift-_r_m7_-label"
+              class="cds--list-box__menu"
+              id="downshift-_r_m7_-menu"
+              role="listbox"
+              style="position: fixed; left: 0px; top: 0px; visibility: visible; transform: translate(0px, 0px);"
+            />
           </div>
         </div>
       </div>

--- a/apps/clinical/src/components/forms/immunizationHistory/__tests__/__snapshots__/SelectedImmunizationItem.test.tsx.snap
+++ b/apps/clinical/src/components/forms/immunizationHistory/__tests__/__snapshots__/SelectedImmunizationItem.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`SelectedImmunizationItem Snapshots matches snapshot with all form field
               <input
                 aria-activedescendant=""
                 aria-autocomplete="list"
-                aria-controls="downshift-_r_lq_-menu"
+                aria-controls="downshift-_r_mb_-menu"
                 aria-expanded="false"
                 aria-haspopup="listbox"
                 aria-label="Choose an item"
@@ -47,11 +47,11 @@ exports[`SelectedImmunizationItem Snapshots matches snapshot with all form field
                 value=""
               />
               <button
-                aria-controls="downshift-_r_lq_-menu"
+                aria-controls="downshift-_r_mb_-menu"
                 aria-expanded="false"
                 aria-label="Open"
                 class="cds--list-box__menu-icon"
-                id="downshift-_r_lq_-toggle-button"
+                id="downshift-_r_mb_-toggle-button"
                 tabindex="-1"
                 title="Open"
                 type="button"
@@ -73,9 +73,9 @@ exports[`SelectedImmunizationItem Snapshots matches snapshot with all form field
               </button>
             </div>
             <ul
-              aria-labelledby="downshift-_r_lq_-label"
+              aria-labelledby="downshift-_r_mb_-label"
               class="cds--list-box__menu"
-              id="downshift-_r_lq_-menu"
+              id="downshift-_r_mb_-menu"
               role="listbox"
               style="position: fixed; left: 0px; top: 0px; visibility: visible; transform: translate(0px, 0px);"
             />
@@ -150,7 +150,7 @@ exports[`SelectedImmunizationItem Snapshots matches snapshot with all form field
               <input
                 aria-activedescendant=""
                 aria-autocomplete="list"
-                aria-controls="downshift-_r_lu_-menu"
+                aria-controls="downshift-_r_mf_-menu"
                 aria-expanded="false"
                 aria-haspopup="listbox"
                 aria-label="Choose an item"
@@ -166,11 +166,11 @@ exports[`SelectedImmunizationItem Snapshots matches snapshot with all form field
                 value=""
               />
               <button
-                aria-controls="downshift-_r_lu_-menu"
+                aria-controls="downshift-_r_mf_-menu"
                 aria-expanded="false"
                 aria-label="Open"
                 class="cds--list-box__menu-icon"
-                id="downshift-_r_lu_-toggle-button"
+                id="downshift-_r_mf_-toggle-button"
                 tabindex="-1"
                 title="Open"
                 type="button"
@@ -192,9 +192,9 @@ exports[`SelectedImmunizationItem Snapshots matches snapshot with all form field
               </button>
             </div>
             <ul
-              aria-labelledby="downshift-_r_lu_-label"
+              aria-labelledby="downshift-_r_mf_-label"
               class="cds--list-box__menu"
-              id="downshift-_r_lu_-menu"
+              id="downshift-_r_mf_-menu"
               role="listbox"
               style="position: fixed; left: 0px; top: 0px; visibility: visible; transform: translate(0px, 0px);"
             />
@@ -216,7 +216,7 @@ exports[`SelectedImmunizationItem Snapshots matches snapshot with all form field
               <input
                 aria-activedescendant=""
                 aria-autocomplete="list"
-                aria-controls="downshift-_r_m1_-menu"
+                aria-controls="downshift-_r_mi_-menu"
                 aria-expanded="false"
                 aria-haspopup="listbox"
                 aria-label="Choose an item"
@@ -232,11 +232,11 @@ exports[`SelectedImmunizationItem Snapshots matches snapshot with all form field
                 value=""
               />
               <button
-                aria-controls="downshift-_r_m1_-menu"
+                aria-controls="downshift-_r_mi_-menu"
                 aria-expanded="false"
                 aria-label="Open"
                 class="cds--list-box__menu-icon"
-                id="downshift-_r_m1_-toggle-button"
+                id="downshift-_r_mi_-toggle-button"
                 tabindex="-1"
                 title="Open"
                 type="button"
@@ -258,9 +258,9 @@ exports[`SelectedImmunizationItem Snapshots matches snapshot with all form field
               </button>
             </div>
             <ul
-              aria-labelledby="downshift-_r_m1_-label"
+              aria-labelledby="downshift-_r_mi_-label"
               class="cds--list-box__menu"
-              id="downshift-_r_m1_-menu"
+              id="downshift-_r_mi_-menu"
               role="listbox"
               style="position: fixed; left: 0px; top: 0px; visibility: visible; transform: translate(0px, 0px);"
             />
@@ -282,7 +282,7 @@ exports[`SelectedImmunizationItem Snapshots matches snapshot with all form field
               <input
                 aria-activedescendant=""
                 aria-autocomplete="list"
-                aria-controls="downshift-_r_m4_-menu"
+                aria-controls="downshift-_r_ml_-menu"
                 aria-expanded="false"
                 aria-haspopup="listbox"
                 aria-label="Choose an item"
@@ -298,11 +298,11 @@ exports[`SelectedImmunizationItem Snapshots matches snapshot with all form field
                 value=""
               />
               <button
-                aria-controls="downshift-_r_m4_-menu"
+                aria-controls="downshift-_r_ml_-menu"
                 aria-expanded="false"
                 aria-label="Open"
                 class="cds--list-box__menu-icon"
-                id="downshift-_r_m4_-toggle-button"
+                id="downshift-_r_ml_-toggle-button"
                 tabindex="-1"
                 title="Open"
                 type="button"
@@ -324,9 +324,9 @@ exports[`SelectedImmunizationItem Snapshots matches snapshot with all form field
               </button>
             </div>
             <ul
-              aria-labelledby="downshift-_r_m4_-label"
+              aria-labelledby="downshift-_r_ml_-label"
               class="cds--list-box__menu"
-              id="downshift-_r_m4_-menu"
+              id="downshift-_r_ml_-menu"
               role="listbox"
               style="position: fixed; left: 0px; top: 0px; visibility: visible; transform: translate(0px, 0px);"
             />
@@ -390,7 +390,7 @@ exports[`SelectedImmunizationItem Snapshots matches snapshot with all form field
               <input
                 aria-activedescendant=""
                 aria-autocomplete="list"
-                aria-controls="downshift-_r_m7_-menu"
+                aria-controls="downshift-_r_mo_-menu"
                 aria-expanded="false"
                 aria-haspopup="listbox"
                 aria-label="Choose an item"
@@ -406,11 +406,11 @@ exports[`SelectedImmunizationItem Snapshots matches snapshot with all form field
                 value=""
               />
               <button
-                aria-controls="downshift-_r_m7_-menu"
+                aria-controls="downshift-_r_mo_-menu"
                 aria-expanded="false"
                 aria-label="Open"
                 class="cds--list-box__menu-icon"
-                id="downshift-_r_m7_-toggle-button"
+                id="downshift-_r_mo_-toggle-button"
                 tabindex="-1"
                 title="Open"
                 type="button"
@@ -432,9 +432,9 @@ exports[`SelectedImmunizationItem Snapshots matches snapshot with all form field
               </button>
             </div>
             <ul
-              aria-labelledby="downshift-_r_m7_-label"
+              aria-labelledby="downshift-_r_mo_-label"
               class="cds--list-box__menu"
-              id="downshift-_r_m7_-menu"
+              id="downshift-_r_mo_-menu"
               role="listbox"
               style="position: fixed; left: 0px; top: 0px; visibility: visible; transform: translate(0px, 0px);"
             />

--- a/apps/clinical/src/components/forms/immunizationHistory/__tests__/utils.test.ts
+++ b/apps/clinical/src/components/forms/immunizationHistory/__tests__/utils.test.ts
@@ -64,12 +64,11 @@ describe('findAttr', () => {
     expect(findAttr(name, attributes)).toEqual(expected);
   });
 
-  it('returns undefined when attribute name is not in the list', () => {
-    expect(findAttr('site', attributes)).toBeUndefined();
-  });
-
-  it('returns undefined when attributes is undefined', () => {
-    expect(findAttr('administeredOn', undefined)).toBeUndefined();
+  it.each([
+    ['attribute name is not in the list', 'site', attributes],
+    ['attributes is undefined', 'administeredOn', undefined],
+  ] as const)('returns undefined when %s', (_, name, attrs) => {
+    expect(findAttr(name, attrs)).toBeUndefined();
   });
 });
 
@@ -351,20 +350,13 @@ describe('createImmunizationBundleEntries', () => {
     expect(result).toHaveLength(2);
   });
 
-  it('sets fullUrl using the generated UUID', () => {
-    const result = createImmunizationBundleEntries({
-      ...BASE_BUNDLE_PARAMS,
-      selectedImmunizations: [mockImmunizationEntry],
-    });
-    expect(result[0].fullUrl).toBe('urn:uuid:mock-uuid');
-  });
-
-  it('constructs the core immunization resource correctly for a minimal entry', () => {
+  it('builds a correct minimal bundle entry', () => {
     const result = createImmunizationBundleEntries({
       ...BASE_BUNDLE_PARAMS,
       selectedImmunizations: [mockImmunizationEntry],
     });
     const resource = result[0].resource as Immunization;
+    expect(result[0].fullUrl).toBe('urn:uuid:mock-uuid');
     expect(resource).toMatchObject({
       resourceType: 'Immunization',
       status: 'completed',
@@ -374,14 +366,6 @@ describe('createImmunizationBundleEntries', () => {
       patient: mockEncounterSubject,
       encounter: { reference: 'Encounter/encounter-uuid' },
     });
-  });
-
-  it('omits optional fields when they are null on a minimal entry', () => {
-    const result = createImmunizationBundleEntries({
-      ...BASE_BUNDLE_PARAMS,
-      selectedImmunizations: [mockImmunizationEntry],
-    });
-    const resource = result[0].resource as Immunization;
     expect(resource.occurrenceDateTime).toBeUndefined();
     expect(resource.location).toBeUndefined();
     expect(resource.route).toBeUndefined();
@@ -512,7 +496,7 @@ describe('createImmunizationBundleEntries', () => {
     expect(resource.location).toEqual({ display: 'Custom Ward' });
   });
 
-  it('sets the performer with the correct practitioner reference', () => {
+  it('sets performer and request method on each entry', () => {
     const result = createImmunizationBundleEntries({
       ...BASE_BUNDLE_PARAMS,
       selectedImmunizations: [mockImmunizationEntry],
@@ -535,13 +519,6 @@ describe('createImmunizationBundleEntries', () => {
         },
       },
     ]);
-  });
-
-  it('sets the bundle request method to POST', () => {
-    const result = createImmunizationBundleEntries({
-      ...BASE_BUNDLE_PARAMS,
-      selectedImmunizations: [mockImmunizationEntry],
-    });
     expect(result[0].request?.method).toBe('POST');
   });
 });

--- a/apps/clinical/src/components/forms/immunizationHistory/__tests__/utils.test.ts
+++ b/apps/clinical/src/components/forms/immunizationHistory/__tests__/utils.test.ts
@@ -16,6 +16,7 @@ import {
 } from '../utils';
 import {
   mockAvailableStockResponse,
+  mockEmptyAvailableStockResponse,
   mockEncounterSubject,
   mockFetchedMedication,
   mockImmunizationEntry,
@@ -259,6 +260,22 @@ describe('getBatchNumberComboBoxItems', () => {
     ).toEqual([
       {
         batchNumber: 'Error loading stock batches',
+        expiryDate: '',
+        disabled: true,
+      },
+    ]);
+  });
+
+  it('returns a disabled empty item when emptyMessage is provided and count is 0', () => {
+    expect(
+      getBatchNumberComboBoxItems(
+        mockEmptyAvailableStockResponse,
+        undefined,
+        'No stock batches available',
+      ),
+    ).toEqual([
+      {
+        batchNumber: 'No stock batches available',
         expiryDate: '',
         disabled: true,
       },

--- a/apps/clinical/src/components/forms/immunizationHistory/__tests__/utils.test.ts
+++ b/apps/clinical/src/components/forms/immunizationHistory/__tests__/utils.test.ts
@@ -8,12 +8,14 @@ import {
   buildBasedOnImmunizationEntry,
   createImmunizationBundleEntries,
   findAttr,
+  getBatchNumberComboBoxItems,
   getComboBoxItems,
   getLocationComboBoxItems,
   getMedicationComboBoxItems,
   getValueSetComboBoxItems,
 } from '../utils';
 import {
+  mockAvailableStockResponse,
   mockEncounterSubject,
   mockFetchedMedication,
   mockImmunizationEntry,
@@ -234,6 +236,34 @@ describe('getLocationComboBoxItems', () => {
 
   it('returns empty array when no locations match', () => {
     expect(getLocationComboBoxItems('xyz', mockLocations)).toEqual([]);
+  });
+});
+
+describe('getBatchNumberComboBoxItems', () => {
+  it('returns empty array when availableStocks is undefined', () => {
+    expect(getBatchNumberComboBoxItems(undefined)).toEqual([]);
+  });
+
+  it('returns mapped BatchNumberComboBoxItems from availableStocks.data', () => {
+    expect(getBatchNumberComboBoxItems(mockAvailableStockResponse)).toEqual([
+      { batchNumber: 'BATCH-001', expiryDate: '2026-12-31' },
+      { batchNumber: 'BATCH-002', expiryDate: '2027-06-30' },
+    ]);
+  });
+
+  it('returns a disabled error item when errorMessage is provided', () => {
+    expect(
+      getBatchNumberComboBoxItems(
+        mockAvailableStockResponse,
+        'Error loading stock batches',
+      ),
+    ).toEqual([
+      {
+        batchNumber: 'Error loading stock batches',
+        expiryDate: '',
+        disabled: true,
+      },
+    ]);
   });
 });
 

--- a/apps/clinical/src/components/forms/immunizationHistory/components/SelectedImmunizationItem.tsx
+++ b/apps/clinical/src/components/forms/immunizationHistory/components/SelectedImmunizationItem.tsx
@@ -9,7 +9,11 @@ import {
   TextAreaWClose,
   TextInput,
 } from '@bahmni/design-system';
-import { useTranslation, Location } from '@bahmni/services';
+import {
+  useTranslation,
+  Location,
+  type AvailableStockResponse,
+} from '@bahmni/services';
 import { Medication, ValueSet } from 'fhir/r4';
 import React, { useMemo, useState } from 'react';
 import { InputControlAttributes } from '../../../../providers/clinicalConfig/models';
@@ -17,6 +21,7 @@ import { ImmunizationInputEntry, ImmunizationStoreKey } from '../models';
 import { useImmunizationHistoryStore } from '../stores';
 import styles from '../styles/ImmunizationHistoryForm.module.scss';
 import {
+  getBatchNumberComboBoxItems,
   getLocationComboBoxItems,
   getMedicationComboBoxItems,
   getValueSetComboBoxItems,
@@ -31,6 +36,8 @@ interface SelectedImmunizationItemProps {
   attributes: InputControlAttributes[] | undefined;
   vaccineDrugs: Medication[] | undefined;
   storeKey: ImmunizationStoreKey;
+  availableStocks: AvailableStockResponse | undefined;
+  stocksError: boolean;
 }
 
 const SelectedImmunizationItem: React.FC<SelectedImmunizationItemProps> = ({
@@ -41,6 +48,8 @@ const SelectedImmunizationItem: React.FC<SelectedImmunizationItemProps> = ({
   administeredLocationTag,
   vaccineDrugs,
   storeKey,
+  availableStocks,
+  stocksError,
 }) => {
   const { t } = useTranslation();
   const {
@@ -103,6 +112,15 @@ const SelectedImmunizationItem: React.FC<SelectedImmunizationItemProps> = ({
         t('NO_MATCHING_SITE_FOUND'),
       ),
     [siteSearchTerm, sites],
+  );
+
+  const batchNumberComboBoxItems = useMemo(
+    () =>
+      getBatchNumberComboBoxItems(
+        availableStocks,
+        stocksError ? t('ERROR_LOADING_STOCK_BATCHES') : undefined,
+      ),
+    [availableStocks, stocksError, t],
   );
 
   const handleRouteInputChange = (value: string) => {
@@ -329,14 +347,32 @@ const SelectedImmunizationItem: React.FC<SelectedImmunizationItemProps> = ({
 
         {findAttr('batchNumber', attributes) && (
           <Column sm={4} md={2} lg={5} className={styles.column}>
-            <TextInput
+            <ComboBox
               id={`immunization-batch-number-${id}`}
               data-testid={`immunization-batch-number-${id}`}
-              labelText={t('IMMUNIZATION_HISTORY_BATCH_NUMBER')}
               placeholder={t('IMMUNIZATION_HISTORY_BATCH_NUMBER_PLACEHOLDER')}
-              value={immunization.batchNumber ?? ''}
-              onChange={(e) => updateBatchNumber(id, e.target.value)}
-              hideLabel
+              autoAlign
+              allowCustomValue
+              items={batchNumberComboBoxItems}
+              itemToString={(item) => item?.batchNumber ?? ''}
+              selectedItem={
+                batchNumberComboBoxItems.find(
+                  (item) => item.batchNumber === immunization.batchNumber,
+                ) ??
+                (immunization.batchNumber
+                  ? { batchNumber: immunization.batchNumber, expiryDate: '' }
+                  : null)
+              }
+              onChange={({ selectedItem, inputValue }) => {
+                if (selectedItem && !selectedItem.disabled) {
+                  updateBatchNumber(id, selectedItem.batchNumber);
+                  if (selectedItem.expiryDate) {
+                    updateExpiryDate(id, new Date(selectedItem.expiryDate));
+                  }
+                } else {
+                  updateBatchNumber(id, inputValue?.trim() ?? '');
+                }
+              }}
               invalid={!!immunization.errors.batchNumber}
               invalidText={
                 immunization.errors.batchNumber

--- a/apps/clinical/src/components/forms/immunizationHistory/components/SelectedImmunizationItem.tsx
+++ b/apps/clinical/src/components/forms/immunizationHistory/components/SelectedImmunizationItem.tsx
@@ -119,6 +119,9 @@ const SelectedImmunizationItem: React.FC<SelectedImmunizationItemProps> = ({
       getBatchNumberComboBoxItems(
         availableStocks,
         stocksError ? t('ERROR_LOADING_STOCK_BATCHES') : undefined,
+        !stocksError && availableStocks?.count === 0
+          ? t('NO_STOCK_BATCHES_AVAILABLE')
+          : undefined,
       ),
     [availableStocks, stocksError, t],
   );

--- a/apps/clinical/src/components/forms/immunizationHistory/components/SelectedImmunizationItem.tsx
+++ b/apps/clinical/src/components/forms/immunizationHistory/components/SelectedImmunizationItem.tsx
@@ -357,7 +357,7 @@ const SelectedImmunizationItem: React.FC<SelectedImmunizationItemProps> = ({
               data-testid={`immunization-batch-number-${id}`}
               placeholder={t('IMMUNIZATION_HISTORY_BATCH_NUMBER_PLACEHOLDER')}
               autoAlign
-              allowCustomValue={!!stockBatchesEnabled}
+              allowCustomValue={!stockBatchesEnabled}
               items={batchNumberComboBoxItems}
               itemToString={(item) => item?.batchNumber ?? ''}
               selectedItem={
@@ -370,7 +370,7 @@ const SelectedImmunizationItem: React.FC<SelectedImmunizationItemProps> = ({
               }
               onChange={({ selectedItem, inputValue }) => {
                 if (selectedItem && !selectedItem.disabled) {
-                  updateBatchNumber(id, selectedItem.batchNumber);
+                  updateBatchNumber(id, selectedItem.batchNumber ?? '');
                   if (selectedItem.expiryDate) {
                     updateExpiryDate(id, new Date(selectedItem.expiryDate));
                   }

--- a/apps/clinical/src/components/forms/immunizationHistory/components/SelectedImmunizationItem.tsx
+++ b/apps/clinical/src/components/forms/immunizationHistory/components/SelectedImmunizationItem.tsx
@@ -38,6 +38,7 @@ interface SelectedImmunizationItemProps {
   storeKey: ImmunizationStoreKey;
   availableStocks: AvailableStockResponse | undefined;
   stocksError: boolean;
+  stockBatchesEnabled: boolean;
 }
 
 const SelectedImmunizationItem: React.FC<SelectedImmunizationItemProps> = ({
@@ -50,6 +51,7 @@ const SelectedImmunizationItem: React.FC<SelectedImmunizationItemProps> = ({
   storeKey,
   availableStocks,
   stocksError,
+  stockBatchesEnabled,
 }) => {
   const { t } = useTranslation();
   const {
@@ -355,7 +357,7 @@ const SelectedImmunizationItem: React.FC<SelectedImmunizationItemProps> = ({
               data-testid={`immunization-batch-number-${id}`}
               placeholder={t('IMMUNIZATION_HISTORY_BATCH_NUMBER_PLACEHOLDER')}
               autoAlign
-              allowCustomValue
+              allowCustomValue={!!stockBatchesEnabled}
               items={batchNumberComboBoxItems}
               itemToString={(item) => item?.batchNumber ?? ''}
               selectedItem={
@@ -372,8 +374,10 @@ const SelectedImmunizationItem: React.FC<SelectedImmunizationItemProps> = ({
                   if (selectedItem.expiryDate) {
                     updateExpiryDate(id, new Date(selectedItem.expiryDate));
                   }
+                } else if (inputValue?.trim()) {
+                  updateBatchNumber(id, inputValue.trim());
                 } else {
-                  updateBatchNumber(id, inputValue?.trim() ?? '');
+                  updateBatchNumber(id, '');
                 }
               }}
               invalid={!!immunization.errors.batchNumber}

--- a/apps/clinical/src/components/forms/immunizationHistory/models.ts
+++ b/apps/clinical/src/components/forms/immunizationHistory/models.ts
@@ -56,6 +56,12 @@ export interface ValueSetComboBoxItem {
   disabled?: boolean;
 }
 
+export interface BatchNumberComboBoxItem {
+  batchNumber: string;
+  expiryDate: string;
+  disabled?: boolean;
+}
+
 export interface LocationComboBoxItem {
   uuid: string;
   display: string;

--- a/apps/clinical/src/components/forms/immunizationHistory/stores.ts
+++ b/apps/clinical/src/components/forms/immunizationHistory/stores.ts
@@ -172,7 +172,7 @@ function createImmunizationHistoryStore() {
         selectedImmunizations: state.selectedImmunizations.map((entry) => {
           if (entry.id !== id) return entry;
           const updated = { ...entry, manufacturer: value };
-          if (entry.hasBeenValidated && value.trim()) {
+          if (entry.hasBeenValidated && value?.trim()) {
             updated.errors = { ...entry.errors };
             delete updated.errors.manufacturer;
           }
@@ -186,7 +186,7 @@ function createImmunizationHistoryStore() {
         selectedImmunizations: state.selectedImmunizations.map((entry) => {
           if (entry.id !== id) return entry;
           const updated = { ...entry, batchNumber: value };
-          if (entry.hasBeenValidated && value.trim()) {
+          if (entry.hasBeenValidated && value?.trim()) {
             updated.errors = { ...entry.errors };
             delete updated.errors.batchNumber;
           }

--- a/apps/clinical/src/components/forms/immunizationHistory/utils.ts
+++ b/apps/clinical/src/components/forms/immunizationHistory/utils.ts
@@ -1,4 +1,9 @@
-import { generateUUID, resolveComboBoxItems, Location } from '@bahmni/services';
+import {
+  generateUUID,
+  resolveComboBoxItems,
+  Location,
+  type AvailableStockResponse,
+} from '@bahmni/services';
 import {
   BundleEntry,
   Extension,
@@ -23,6 +28,7 @@ import {
   ENTERING_PROVIDER_SYSTEM,
 } from './constants';
 import {
+  BatchNumberComboBoxItem,
   CreateImmunizationBundleEntriesParams,
   ImmunizationDrug,
   ImmunizationLocation,
@@ -111,6 +117,19 @@ export function getMedicationComboBoxItems(
       code: med.id ?? '',
       display: getMedicationDisplay(med),
     }));
+}
+
+export function getBatchNumberComboBoxItems(
+  availableStocks: AvailableStockResponse | undefined,
+  errorMessage?: string,
+): BatchNumberComboBoxItem[] {
+  if (errorMessage) {
+    return [{ batchNumber: errorMessage, expiryDate: '', disabled: true }];
+  }
+  return (availableStocks?.data ?? []).map(({ batchNumber, expiryDate }) => ({
+    batchNumber,
+    expiryDate,
+  }));
 }
 
 export function getLocationComboBoxItems(

--- a/apps/clinical/src/components/forms/immunizationHistory/utils.ts
+++ b/apps/clinical/src/components/forms/immunizationHistory/utils.ts
@@ -122,9 +122,13 @@ export function getMedicationComboBoxItems(
 export function getBatchNumberComboBoxItems(
   availableStocks: AvailableStockResponse | undefined,
   errorMessage?: string,
+  emptyMessage?: string,
 ): BatchNumberComboBoxItem[] {
   if (errorMessage) {
     return [{ batchNumber: errorMessage, expiryDate: '', disabled: true }];
+  }
+  if (emptyMessage) {
+    return [{ batchNumber: emptyMessage, expiryDate: '', disabled: true }];
   }
   return (availableStocks?.data ?? []).map(({ batchNumber, expiryDate }) => ({
     batchNumber,

--- a/packages/bahmni-services/src/index.ts
+++ b/packages/bahmni-services/src/index.ts
@@ -354,3 +354,8 @@ export {
   getVisibleModules,
   type Module,
 } from './moduleService';
+
+export {
+  getAvailableStocks,
+  type AvailableStockResponse,
+} from './inventoryService';

--- a/packages/bahmni-services/src/inventoryService/__tests__/inventoryService.test.ts
+++ b/packages/bahmni-services/src/inventoryService/__tests__/inventoryService.test.ts
@@ -1,0 +1,71 @@
+import { get } from '../../api';
+import { AVAILABLE_STOCKS_URL } from '../constants';
+import { getAvailableStocks } from '../inventoryService';
+import { AvailableStockResponse } from '../models';
+
+jest.mock('../../api');
+
+const mockGet = get as jest.MockedFunction<typeof get>;
+
+describe('getAvailableStocks', () => {
+  const productUuid = 'product-uuid-123';
+  const locationUuid = 'location-uuid-456';
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it.each([
+    [
+      'with stock batches',
+      {
+        count: 2,
+        data: [
+          {
+            stockLocationName: 'Nurse Station',
+            availableQuantity: 10,
+            onHandQuantity: 15,
+            unit: 'vial',
+            batchNumber: 'BATCH-001',
+            expiryDate: '2026-12-31',
+          },
+          {
+            stockLocationName: 'Nurse Station',
+            availableQuantity: 5,
+            onHandQuantity: 5,
+            unit: 'vial',
+            batchNumber: 'BATCH-002',
+            expiryDate: '2027-06-30',
+          },
+        ],
+      },
+    ],
+    [
+      'with no stock batches',
+      {
+        count: 0,
+        data: [],
+      },
+    ],
+  ])(
+    'fetches available stocks for a product and location (%s)',
+    async (_, mockResponse: AvailableStockResponse) => {
+      mockGet.mockResolvedValueOnce(mockResponse);
+
+      const result = await getAvailableStocks(productUuid, locationUuid);
+
+      expect(get).toHaveBeenCalledWith(
+        AVAILABLE_STOCKS_URL(productUuid, locationUuid),
+      );
+      expect(result).toEqual(mockResponse);
+    },
+  );
+
+  it('propagates errors from the API', async () => {
+    mockGet.mockRejectedValueOnce(new Error('Network error'));
+
+    await expect(getAvailableStocks(productUuid, locationUuid)).rejects.toThrow(
+      'Network error',
+    );
+  });
+});

--- a/packages/bahmni-services/src/inventoryService/constants.ts
+++ b/packages/bahmni-services/src/inventoryService/constants.ts
@@ -1,0 +1,8 @@
+import { OPENMRS_REST_V1 } from '../constants/app';
+
+export const AVAILABLE_STOCKS_URL = (
+  productUuid: string,
+  locationUuid: string,
+) =>
+  OPENMRS_REST_V1 +
+  `/availableStocks?productUuid=${productUuid}&locationUuid=${locationUuid}`;

--- a/packages/bahmni-services/src/inventoryService/index.ts
+++ b/packages/bahmni-services/src/inventoryService/index.ts
@@ -1,0 +1,2 @@
+export { getAvailableStocks } from './inventoryService';
+export type { AvailableStockResponse } from './models';

--- a/packages/bahmni-services/src/inventoryService/inventoryService.ts
+++ b/packages/bahmni-services/src/inventoryService/inventoryService.ts
@@ -1,0 +1,18 @@
+import { get } from '../api';
+import { AVAILABLE_STOCKS_URL } from './constants';
+import { AvailableStockResponse } from './models';
+
+/**
+ * Fetches available stock batches for a given product (vaccine) at a specific location
+ * @param productUuid - The UUID of the vaccine/drug product
+ * @param locationUuid - The UUID of the location (nurse station)
+ * @returns Promise<AvailableStockResponse> - Available stock count and batches with batch number and expiry date
+ */
+export const getAvailableStocks = async (
+  productUuid: string,
+  locationUuid: string,
+): Promise<AvailableStockResponse> => {
+  return await get<AvailableStockResponse>(
+    AVAILABLE_STOCKS_URL(productUuid, locationUuid),
+  );
+};

--- a/packages/bahmni-services/src/inventoryService/models.ts
+++ b/packages/bahmni-services/src/inventoryService/models.ts
@@ -1,0 +1,13 @@
+interface StockBatch {
+  stockLocationName: string;
+  availableQuantity: number;
+  onHandQuantity: number;
+  unit: string;
+  batchNumber: string;
+  expiryDate: string;
+}
+
+export interface AvailableStockResponse {
+  count: number;
+  data: StockBatch[];
+}


### PR DESCRIPTION
JIRA → [BAH-4659](https://bahmni.atlassian.net/browse/BAH-4659)

##  Description

Replaces the free-text batch number field in the immunization form with a ComboBox that fetches and displays available stock batches from the inventory service. Users can select a batch from the dropdown — which auto-populates the expiry date — or type a custom value if no matching stock is found.

##  Key Features

  - Batch number input upgraded from a plain text field to a ComboBox with stock-aware suggestions.
  - Selecting a batch from the dropdown automatically populates the expiry date.
  - Custom values are still accepted when the batch is not in the stock list.
  - Error state displayed as a disabled dropdown item when stock batches fail to load.

[BAH-4659]: https://bahmni.atlassian.net/browse/BAH-4659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Batch number field now lists available stock batches; selecting a batch can auto-fill expiry date; custom entry allowed when enabled

* **Bug Fixes**
  * Improved form validation to avoid clearing errors incorrectly when manufacturer/batch inputs are empty or whitespace

* **Documentation**
  * Added English and Spanish translations for stock-batch messages and load errors

* **Tests**
  * Added/updated tests for per-item stock queries, dropdown behavior, and stock-response mapping

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Bahmni/bahmni-apps-frontend/pull/397)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->