### PR TITLE
BAH-4692: Add AddMore composite component using bahmni-design-system

### DIFF
--- a/apps/clinical/src/components/forms/addMore/AddMore.tsx
+++ b/apps/clinical/src/components/forms/addMore/AddMore.tsx
@@ -1,0 +1,107 @@
+import { Button, IconButton, TrashCan } from '@bahmni/design-system';
+import { Add } from '@carbon/icons-react';
+import React from 'react';
+import styles from './styles/AddMore.module.scss';
+
+export interface AddMoreProps {
+  /** Called when the "Add More" button is clicked */
+  onAdd?: () => void;
+  /** Called when the remove/delete button is clicked */
+  onRemove?: () => void;
+  /**
+   * Called when the "Add Note" button is clicked.
+   * Only applicable in the 'control' variant (single ObsControl).
+   */
+  onAddNote?: () => void;
+  /**
+   * Whether to show the remove (delete) button.
+   * Typically set to true when there is more than one instance of the control.
+   */
+  showRemove?: boolean;
+  /**
+   * Whether to show the "Add Note" button.
+   * Only rendered in the 'control' variant.
+   */
+  showAddNote?: boolean;
+  /**
+   * Layout variant:
+   * - 'control' (default): inline row next to a single ObsControl field.
+   *   Renders [+ Add More] [Add Note?] [🗑️ Remove?]
+   * - 'group': column-stacked below an ObsControlGroup.
+   *   Renders only [+ Add More] below the group container.
+   */
+  variant?: 'control' | 'group';
+}
+
+/**
+ * AddMore — composite form control component.
+ *
+ * Built using @bahmni/design-system Button, IconButton, and TrashCan.
+ * Replaces the legacy CSS + FontAwesome implementation.
+ *
+ * For a single ObsControl use variant="control" (default).
+ * For an ObsControlGroup use variant="group".
+ */
+const AddMore: React.FC<AddMoreProps> = ({
+  onAdd,
+  onRemove,
+  onAddNote,
+  showRemove = false,
+  showAddNote = false,
+  variant = 'control',
+}) => {
+  const addMoreButton = (
+    <Button
+      kind="ghost"
+      size="sm"
+      renderIcon={Add}
+      onClick={onAdd}
+      data-testid="add-more-button"
+    >
+      Add More
+    </Button>
+  );
+
+  if (variant === 'group') {
+    return (
+      <div
+        className={styles.addMoreGroupContainer}
+        data-testid="add-more-group"
+      >
+        {addMoreButton}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={styles.addMoreControlContainer}
+      data-testid="add-more-control"
+    >
+      {addMoreButton}
+      {showAddNote && (
+        <Button
+          kind="ghost"
+          size="sm"
+          onClick={onAddNote}
+          data-testid="add-note-button"
+        >
+          Add Note
+        </Button>
+      )}
+      {showRemove && (
+        <IconButton
+          kind="ghost"
+          size="sm"
+          label="Remove"
+          onClick={onRemove}
+          testId="remove-button"
+        >
+          <TrashCan />
+        </IconButton>
+      )}
+    </div>
+  );
+};
+
+export default AddMore;

--- a/apps/clinical/src/components/forms/addMore/__tests__/AddMore.test.tsx
+++ b/apps/clinical/src/components/forms/addMore/__tests__/AddMore.test.tsx
@@ -1,0 +1,154 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import React from 'react';
+import AddMore from '../AddMore';
+
+// Lightweight mocks — only verify structural/callback behaviour
+jest.mock('@bahmni/design-system', () => ({
+  Button: ({
+    children,
+    onClick,
+    'data-testid': testId,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+    'data-testid'?: string;
+  }) => (
+    <button data-testid={testId} onClick={onClick}>
+      {children}
+    </button>
+  ),
+  IconButton: ({
+    children,
+    onClick,
+    testId,
+    label,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+    testId?: string;
+    label?: string;
+  }) => (
+    <button data-testid={testId} aria-label={label} onClick={onClick}>
+      {children}
+    </button>
+  ),
+  TrashCan: () => <svg data-testid="trash-can-icon" />,
+}));
+
+jest.mock('@carbon/icons-react', () => ({
+  Add: () => <svg data-testid="add-icon" />,
+}));
+
+describe('AddMore', () => {
+  describe('control variant (default)', () => {
+    it('renders the "Add More" button', () => {
+      render(<AddMore />);
+      expect(screen.getByTestId('add-more-button')).toBeInTheDocument();
+      expect(screen.getByTestId('add-more-control')).toBeInTheDocument();
+    });
+
+    it('calls onAdd when the "Add More" button is clicked', () => {
+      const onAdd = jest.fn();
+      render(<AddMore onAdd={onAdd} />);
+      fireEvent.click(screen.getByTestId('add-more-button'));
+      expect(onAdd).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not render the remove button when showRemove is false (default)', () => {
+      render(<AddMore />);
+      expect(screen.queryByTestId('remove-button')).not.toBeInTheDocument();
+    });
+
+    it('renders the remove button when showRemove is true', () => {
+      render(<AddMore showRemove />);
+      expect(screen.getByTestId('remove-button')).toBeInTheDocument();
+    });
+
+    it('calls onRemove when the remove button is clicked', () => {
+      const onRemove = jest.fn();
+      render(<AddMore showRemove onRemove={onRemove} />);
+      fireEvent.click(screen.getByTestId('remove-button'));
+      expect(onRemove).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not render the "Add Note" button when showAddNote is false (default)', () => {
+      render(<AddMore />);
+      expect(screen.queryByTestId('add-note-button')).not.toBeInTheDocument();
+    });
+
+    it('renders the "Add Note" button when showAddNote is true', () => {
+      render(<AddMore showAddNote />);
+      expect(screen.getByTestId('add-note-button')).toBeInTheDocument();
+    });
+
+    it('calls onAddNote when the "Add Note" button is clicked', () => {
+      const onAddNote = jest.fn();
+      render(<AddMore showAddNote onAddNote={onAddNote} />);
+      fireEvent.click(screen.getByTestId('add-note-button'));
+      expect(onAddNote).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders all three buttons when showRemove and showAddNote are true', () => {
+      render(<AddMore showRemove showAddNote />);
+      expect(screen.getByTestId('add-more-button')).toBeInTheDocument();
+      expect(screen.getByTestId('add-note-button')).toBeInTheDocument();
+      expect(screen.getByTestId('remove-button')).toBeInTheDocument();
+    });
+
+    it('does not render the group container', () => {
+      render(<AddMore />);
+      expect(screen.queryByTestId('add-more-group')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('group variant', () => {
+    it('renders the group container with the "Add More" button below the group', () => {
+      render(<AddMore variant="group" />);
+      expect(screen.getByTestId('add-more-group')).toBeInTheDocument();
+      expect(screen.getByTestId('add-more-button')).toBeInTheDocument();
+    });
+
+    it('calls onAdd when the "Add More" button is clicked in group variant', () => {
+      const onAdd = jest.fn();
+      render(<AddMore variant="group" onAdd={onAdd} />);
+      fireEvent.click(screen.getByTestId('add-more-button'));
+      expect(onAdd).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not render remove button in group variant even when showRemove is true', () => {
+      render(<AddMore variant="group" showRemove />);
+      expect(screen.queryByTestId('remove-button')).not.toBeInTheDocument();
+    });
+
+    it('does not render "Add Note" button in group variant even when showAddNote is true', () => {
+      render(<AddMore variant="group" showAddNote />);
+      expect(screen.queryByTestId('add-note-button')).not.toBeInTheDocument();
+    });
+
+    it('does not render the control container in group variant', () => {
+      render(<AddMore variant="group" />);
+      expect(screen.queryByTestId('add-more-control')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('delete button propagation', () => {
+    it('shows remove buttons independently for multiple instances', () => {
+      const onRemove1 = jest.fn();
+      const onRemove2 = jest.fn();
+      const { container } = render(
+        <div>
+          <AddMore showRemove onRemove={onRemove1} />
+          <AddMore showRemove onRemove={onRemove2} />
+        </div>,
+      );
+      const removeButtons = container.querySelectorAll(
+        '[data-testid="remove-button"]',
+      );
+      expect(removeButtons).toHaveLength(2);
+      fireEvent.click(removeButtons[0]);
+      expect(onRemove1).toHaveBeenCalledTimes(1);
+      expect(onRemove2).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/clinical/src/components/forms/addMore/index.ts
+++ b/apps/clinical/src/components/forms/addMore/index.ts
@@ -1,0 +1,2 @@
+export { default as AddMore } from './AddMore';
+export type { AddMoreProps } from './AddMore';

--- a/apps/clinical/src/components/forms/addMore/styles/AddMore.module.scss
+++ b/apps/clinical/src/components/forms/addMore/styles/AddMore.module.scss
@@ -1,0 +1,12 @@
+.addMoreControlContainer {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  flex-wrap: nowrap;
+}
+
+.addMoreGroupContainer {
+  display: flex;
+  justify-content: flex-start;
+  margin-top: 0.5rem;
+}

--- a/apps/clinical/src/components/forms/index.ts
+++ b/apps/clinical/src/components/forms/index.ts
@@ -6,6 +6,7 @@ import './medications';
 import './vaccinations';
 import './immunizationHistory';
 import './observations';
+import './addMore';
 
 export type { InputControl, EncounterContext } from './models';
 export { default as InputControlRenderer } from './renderer';


### PR DESCRIPTION
## Summary

Introduces the `AddMore` composite component for the form2-controls space, migrating from the legacy CSS + FontAwesome approach to `@bahmni/design-system` primitives (`Button`, `IconButton`, `TrashCan`).

## Component Design

### Props

| Prop | Type | Default | Description |
|------|------|---------|-------------|
| `onAdd` | `() => void` | — | Called when "Add More" is clicked |
| `onRemove` | `() => void` | — | Called when the delete (TrashCan) button is clicked |
| `onAddNote` | `() => void` | — | Called when "Add Note" is clicked (control variant only) |
| `showRemove` | `boolean` | `false` | Show remove button (set true when multiple instances exist) |
| `showAddNote` | `boolean` | `false` | Show "Add Note" button (control variant only) |
| `variant` | `'control' \| 'group'` | `'control'` | Layout variant |

### Variants

**`variant='control'`** (ObsControl — single field):
Inline row layout: `[+ Add More]` `[Add Note?]` `[🗑️ Remove?]`

**`variant='group'`** (ObsControlGroup):
Stacked below the group container: `[+ Add More]`

## Files Changed

- `apps/clinical/src/components/forms/addMore/AddMore.tsx` — main component
- `apps/clinical/src/components/forms/addMore/index.ts` — barrel exports
- `apps/clinical/src/components/forms/addMore/styles/AddMore.module.scss` — flexbox layout styles
- `apps/clinical/src/components/forms/addMore/__tests__/AddMore.test.tsx` — 14 test cases covering all ACs
- `apps/clinical/src/components/forms/index.ts` — register `addMore` module

## Acceptance Criteria Coverage

- ✅ Add button renders using `Button` (ghost) with `Add` icon — both variants
- ✅ Delete button renders using `IconButton` with `TrashCan` icon — control variant only
- ✅ "Add Note" button renders in control variant when `showAddNote=true`
- ✅ `onAdd` / `onRemove` / `onAddNote` callbacks fire on respective button clicks
- ✅ Multiple instances: each instance's remove button fires independently (no propagation)
- ✅ Group variant hides remove/note buttons — only Add More is shown below the group

## Jira

https://bahmni.atlassian.net/browse/BAH-4692

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new controls for dynamically adding items to forms with optional note creation and individual item removal capabilities, supporting both control and group display variants.

* **Tests**
  * Added comprehensive test coverage validating rendering and behavior across all interaction scenarios and display configurations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Bahmni/bahmni-apps-frontend/pull/399)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->