### PR TITLE
BAH-4719 | Add. Default And ReadOnly Attributes To InputControl Config

### DIFF
--- a/apps/clinical/src/providers/clinicalConfig/models.ts
+++ b/apps/clinical/src/providers/clinicalConfig/models.ts
@@ -7,7 +7,9 @@ export interface AllergyConceptMap {
 
 export interface InputControlAttributes {
   name: string;
-  required: boolean;
+  required?: boolean;
+  default?: string | number | boolean;
+  readOnly?: boolean;
 }
 
 export interface InputControl<

--- a/apps/clinical/src/providers/clinicalConfig/schema.json
+++ b/apps/clinical/src/providers/clinicalConfig/schema.json
@@ -47,7 +47,7 @@
           "description": "Form attributes configuration",
           "items": {
             "type": "object",
-            "required": ["name", "required"],
+            "required": ["name"],
             "additionalProperties": false,
             "properties": {
               "name": {
@@ -57,6 +57,14 @@
               "required": {
                 "type": "boolean",
                 "description": "Whether this attribute is required"
+              },
+              "default": {
+                "type": ["string", "number", "boolean"],
+                "description": "Default value to pre-populate the field with"
+              },
+              "readOnly": {
+                "type": "boolean",
+                "description": "Whether this field is non-editable by the user"
               }
             }
           }


### PR DESCRIPTION
JIRA → [BAH-4719](https://bahmni.atlassian.net/browse/BAH-4719)

## Description

Extends the InputControlAttributes model and clinical config JSON schema to support default and readOnly optional attributes for form field configuration, enabling pre-population of field values and restricting user edits at the config level.

##  Key Features

- Form fields can now be configured with a default value (string, number, or boolean) to pre-populate on render.
- Form fields can be marked readOnly via config to prevent user edits.
- required attribute on InputControlAttributes is now optional, relaxing schema strictness.

[BAH-4719]: https://bahmni.atlassian.net/browse/BAH-4719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ