### PR TITLE
BAH-4680: [Registration] Migrate Patient Profile Fetch to FHIR R4 API

### DIFF
--- a/apps/clinical/src/components/patientHeader/ConsultationActionButton.tsx
+++ b/apps/clinical/src/components/patientHeader/ConsultationActionButton.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@bahmni/design-system';
+import { Button, SkeletonPlaceholder } from '@bahmni/design-system';
 import { useTranslation } from '@bahmni/services';
 import { useHasPrivilege, CONSULTATION_PAD_PRIVILEGES } from '@bahmni/widgets';
 import React from 'react';
@@ -24,11 +24,21 @@ const ConsultationActionButton: React.FC<ConsultationActionButtonProps> = ({
   if (!canAddEncounter) {
     return null;
   }
+
+  if (isLoading) {
+    return (
+      <SkeletonPlaceholder
+        className={styles.newConsultationButtonSkeleton}
+        testId="consultation-action-button-skeleton"
+      />
+    );
+  }
+
   return (
     <Button
       className={styles.newConsultationButton}
       size="md"
-      disabled={isActionAreaVisible || isLoading}
+      disabled={isActionAreaVisible}
       onClick={() => dispatchConsultationStart({})}
       data-testid="consultation-action-button"
     >

--- a/apps/clinical/src/components/patientHeader/__tests__/ConsultationActionButton.test.tsx
+++ b/apps/clinical/src/components/patientHeader/__tests__/ConsultationActionButton.test.tsx
@@ -94,12 +94,15 @@ describe('ConsultationActionButton', () => {
       expect(mockDispatchConsultationStart).toHaveBeenCalled();
     });
 
-    it('disables button when loading', () => {
+    it('shows skeleton when loading', () => {
       render(<ConsultationActionButton {...defaultProps} isLoading />);
 
       expect(
-        screen.getByRole('button', { name: /CONSULTATION_ACTION_NEW/i }),
-      ).toBeDisabled();
+        screen.getByTestId('consultation-action-button-skeleton'),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByTestId('consultation-action-button'),
+      ).not.toBeInTheDocument();
     });
   });
 

--- a/apps/clinical/src/components/patientHeader/styles/PatientHeader.module.scss
+++ b/apps/clinical/src/components/patientHeader/styles/PatientHeader.module.scss
@@ -22,6 +22,11 @@
   padding-right: $spacing-05 !important;
 }
 
+.newConsultationButtonSkeleton {
+  width: $spacing-13;
+  height: $spacing-08;
+}
+
 @include breakpoint-down(lg) {
   .header {
     flex-direction: column;

--- a/apps/clinical/src/hooks/__tests__/useEncounterSession.test.ts
+++ b/apps/clinical/src/hooks/__tests__/useEncounterSession.test.ts
@@ -51,13 +51,12 @@ beforeEach(() => {
 
 describe('useEncounterSession', () => {
   describe('early return — missing required values', () => {
-    it('returns empty state when patientUUID is null', async () => {
+    it('returns loading state when patientUUID is null', async () => {
       mockUsePatientUUID.mockReturnValue(null);
 
       const { result } = renderHook(() => useEncounterSession(defaultOptions));
 
-      await waitFor(() => expect(result.current.isLoading).toBe(false));
-
+      expect(result.current.isLoading).toBe(true);
       expect(result.current.hasActiveSession).toBe(false);
       expect(result.current.activeEncounter).toBeNull();
       expect(result.current.matchReason).toEqual([]);
@@ -65,7 +64,7 @@ describe('useEncounterSession', () => {
       expect(mockResolveEncounterMatchDecision).not.toHaveBeenCalled();
     });
 
-    it('returns empty state when practitioner is null', async () => {
+    it('returns loading state when practitioner is null', async () => {
       const { result } = renderHook(() =>
         useEncounterSession({
           practitioner: null,
@@ -73,20 +72,18 @@ describe('useEncounterSession', () => {
         }),
       );
 
-      await waitFor(() => expect(result.current.isLoading).toBe(false));
-
+      expect(result.current.isLoading).toBe(true);
       expect(result.current.hasActiveSession).toBe(false);
       expect(result.current.matchReason).toEqual([]);
       expect(mockResolveEncounterMatchDecision).not.toHaveBeenCalled();
     });
 
-    it('returns empty state when encounterTypeUUID is undefined — prevents unfiltered search', async () => {
+    it('returns loading state when encounterTypeUUID is undefined — prevents unfiltered search', async () => {
       const { result } = renderHook(() =>
         useEncounterSession({ practitioner: mockPractitioner }),
       );
 
-      await waitFor(() => expect(result.current.isLoading).toBe(false));
-
+      expect(result.current.isLoading).toBe(true);
       expect(result.current.matchReason).toEqual([]);
       expect(result.current.editActiveEncounter).toBe(false);
       expect(mockResolveEncounterMatchDecision).not.toHaveBeenCalled();

--- a/apps/clinical/src/hooks/useEncounterSession.ts
+++ b/apps/clinical/src/hooks/useEncounterSession.ts
@@ -36,7 +36,7 @@ export function useEncounterSession(
   );
   const [isPractitionerMatch, setIsPractitionerMatch] =
     useState<boolean>(false);
-  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
   const [matchReason, setMatchReason] = useState<MatchReasonCode[]>([]);
 
@@ -50,7 +50,6 @@ export function useEncounterSession(
       setIsPractitionerMatch(false);
       setMatchReason([]);
       setError(null);
-      setIsLoading(false);
       return;
     }
 

--- a/apps/registration/src/components/forms/profile/__tests__/Profile.test.tsx
+++ b/apps/registration/src/components/forms/profile/__tests__/Profile.test.tsx
@@ -1056,4 +1056,28 @@ describe('Profile', () => {
       expect(incorrectMinYear - correctMinYear).toBe(1);
     });
   });
+
+  describe('Data Persistence', () => {
+    it('should not reset edited data when parent re-renders (accordion toggle)', async () => {
+      const initialData = createBasicInfoData();
+
+      const { rerender } = render(
+        <Profile ref={ref} initialData={initialData} />,
+      );
+
+      const firstNameInput = screen.getByLabelText(
+        /First Name/,
+      ) as HTMLInputElement;
+      fireEvent.change(firstNameInput, { target: { value: 'Updated' } });
+      expect(firstNameInput.value).toBe('Updated');
+
+      // Simulate parent re-render (same initialData reference, as happens after getGenderDisplay fix)
+      rerender(<Profile ref={ref} initialData={initialData} />);
+
+      const firstNameAfter = screen.getByLabelText(
+        /First Name/,
+      ) as HTMLInputElement;
+      expect(firstNameAfter.value).toBe('Updated');
+    });
+  });
 });

--- a/apps/registration/src/hooks/__tests__/usePatientDetails.test.tsx
+++ b/apps/registration/src/hooks/__tests__/usePatientDetails.test.tsx
@@ -1,4 +1,4 @@
-import { getPatientProfile } from '@bahmni/services';
+import { getPatientById } from '@bahmni/services';
 import { useNotification } from '@bahmni/widgets';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
@@ -6,57 +6,93 @@ import { usePatientDetails } from '../usePatientDetails';
 
 jest.mock('@bahmni/services', () => ({
   ...jest.requireActual('@bahmni/services'),
-  getPatientProfile: jest.fn(),
+  getPatientById: jest.fn(),
   formatDateTime: jest.fn(() => ({
-    formattedResult: '01/01/2024 12:00 PM',
-    isValid: true,
+    formattedResult: '04 May 2026 11:53 AM',
+    error: false,
   })),
 }));
 jest.mock('@bahmni/widgets');
 jest.mock('../../utils/identifierGenderUtils', () => ({
   useGenderData: () => ({
-    getGenderDisplay: jest.fn((gender: string) => gender),
+    getGenderDisplay: (code: string) => (code === 'M' ? 'Male' : code),
   }),
 }));
-jest.mock('../../utils/patientDataConverter', () => ({
-  convertToBasicInfoData: jest.fn(() => ({})),
-  convertToPersonAttributesData: jest.fn(() => ({})),
-  convertToAddressData: jest.fn(() => ({})),
-  convertToAdditionalIdentifiersData: jest.fn(() => ({})),
-  convertToRelationshipsData: jest.fn(() => []),
+jest.mock('../usePersonAttributes', () => ({
+  usePersonAttributes: () => ({
+    personAttributes: [
+      {
+        uuid: 'phone-uuid',
+        name: 'phoneNumber',
+        format: 'java.lang.String',
+        sortWeight: 1,
+      },
+      {
+        uuid: 'email-uuid',
+        name: 'email',
+        format: 'java.lang.String',
+        sortWeight: 2,
+      },
+    ],
+  }),
 }));
 
-const mockGetPatientProfile = getPatientProfile as jest.MockedFunction<
-  typeof getPatientProfile
->;
+const mockGetPatientById = getPatientById as jest.Mock;
 const mockUseNotification = useNotification as jest.MockedFunction<
   typeof useNotification
 >;
 
-const mockPatientData = {
-  patient: {
-    uuid: 'patient-123',
-    identifiers: [
-      {
-        identifier: 'ID123',
-        identifierType: { uuid: 'type-1', name: 'Patient ID' },
-        preferred: true,
-      },
-    ],
-    person: {
-      uuid: 'person-123',
-      display: 'John Doe',
-      birthdateEstimated: false,
-      birthdate: '1990-01-01',
-      gender: 'M',
-      names: [{ givenName: 'John', familyName: 'Doe' }],
-      addresses: [{ country: 'USA' }],
-      attributes: [],
+const mockFhirPatient = {
+  resourceType: 'Patient',
+  id: 'patient-123',
+  identifier: [
+    {
+      id: 'id-1',
+      use: 'official',
+      type: { coding: [{ code: 'type-uuid' }], text: 'Patient Identifier' },
+      value: 'ABC200000',
     },
-    auditInfo: {
-      dateCreated: '2024-01-01T10:00:00.000Z',
+    {
+      id: 'id-2',
+      type: { coding: [{ code: 'old-id-uuid' }], text: 'Old ID' },
+      value: 'OLD123',
     },
-  },
+  ],
+  name: [{ id: 'name-uuid', given: ['John', 'Michael'], family: 'Doe' }],
+  gender: 'male',
+  birthDate: '1990-05-15',
+  extension: [
+    {
+      url: 'http://fhir.bahmni.org/ext/patient/phonenumber',
+      valueString: '+91123',
+    },
+    {
+      url: 'http://fhir.bahmni.org/ext/patient/email',
+      valueString: 'john@test.com',
+    },
+    {
+      url: 'http://fhir.bahmni.org/ext/patient/date-created',
+      valueDateTime: '2026-05-04T11:53:11+00:00',
+    },
+  ],
+  address: [
+    {
+      use: 'home',
+      city: 'Delhi',
+      state: 'Delhi',
+      extension: [
+        {
+          url: 'http://fhir.openmrs.org/ext/address',
+          extension: [
+            {
+              url: 'http://fhir.openmrs.org/ext/address#address1',
+              valueString: 'Flat 1',
+            },
+          ],
+        },
+      ],
+    },
+  ],
 };
 
 const createWrapper = () => {
@@ -83,54 +119,135 @@ describe('usePatientDetails', () => {
     });
   });
 
-  it('should fetch patient details when patientUuid is provided', async () => {
-    mockGetPatientProfile.mockResolvedValue(mockPatientData);
+  it('should fetch patient via FHIR and populate metadata', async () => {
+    mockGetPatientById.mockResolvedValue(mockFhirPatient);
 
     const { result } = renderHook(
-      () =>
-        usePatientDetails({
-          patientUuid: 'patient-123',
-        }),
+      () => usePatientDetails({ patientUuid: 'patient-123' }),
       { wrapper: createWrapper() },
     );
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-    expect(mockGetPatientProfile).toHaveBeenCalledWith('patient-123');
+    expect(mockGetPatientById).toHaveBeenCalledWith('patient-123');
     expect(result.current.metadata.patientUuid).toBe('patient-123');
-    expect(result.current.metadata.patientIdentifier).toBe('ID123');
+    expect(result.current.metadata.patientIdentifier).toBe('ABC200000');
+    expect(result.current.metadata.patientName).toBe('John Michael Doe');
+    expect(result.current.metadata.registerDate).toBe('04 May 2026 11:53 AM');
+  });
+
+  it('should convert basic info from FHIR response', async () => {
+    mockGetPatientById.mockResolvedValue(mockFhirPatient);
+
+    const { result } = renderHook(
+      () => usePatientDetails({ patientUuid: 'patient-123' }),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.profileInitialData).toEqual(
+      expect.objectContaining({
+        firstName: 'John',
+        middleName: 'Michael',
+        lastName: 'Doe',
+        gender: 'Male',
+        dateOfBirth: '1990-05-15',
+        nameUuid: 'name-uuid',
+      }),
+    );
+    expect(result.current.initialDobEstimated).toBe(false);
+  });
+
+  it('should convert person attributes from extensions', async () => {
+    mockGetPatientById.mockResolvedValue(mockFhirPatient);
+
+    const { result } = renderHook(
+      () => usePatientDetails({ patientUuid: 'patient-123' }),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.personAttributesInitialData).toEqual({
+      phoneNumber: '+91123',
+      email: 'john@test.com',
+    });
+  });
+
+  it('should convert address from FHIR with extensions', async () => {
+    mockGetPatientById.mockResolvedValue(mockFhirPatient);
+
+    const { result } = renderHook(
+      () => usePatientDetails({ patientUuid: 'patient-123' }),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.addressInitialData).toEqual(
+      expect.objectContaining({
+        address1: 'Flat 1',
+        cityVillage: 'Delhi',
+        stateProvince: 'Delhi',
+      }),
+    );
+  });
+
+  it('should convert additional identifiers', async () => {
+    mockGetPatientById.mockResolvedValue(mockFhirPatient);
+
+    const { result } = renderHook(
+      () => usePatientDetails({ patientUuid: 'patient-123' }),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.additionalIdentifiersInitialData).toEqual({
+      'old-id-uuid': 'OLD123',
+    });
+  });
+
+  it('should detect estimated birthdate from YYYY precision', async () => {
+    mockGetPatientById.mockResolvedValue({
+      ...mockFhirPatient,
+      birthDate: '1990',
+    });
+
+    const { result } = renderHook(
+      () => usePatientDetails({ patientUuid: 'patient-123' }),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.initialDobEstimated).toBe(true);
+    expect(result.current.profileInitialData?.dateOfBirth).toBe('1990-01-01');
   });
 
   it('should not fetch when patientUuid is undefined', () => {
     const { result } = renderHook(
-      () =>
-        usePatientDetails({
-          patientUuid: undefined,
-        }),
+      () => usePatientDetails({ patientUuid: undefined }),
       { wrapper: createWrapper() },
     );
 
-    expect(mockGetPatientProfile).not.toHaveBeenCalled();
+    expect(mockGetPatientById).not.toHaveBeenCalled();
     expect(result.current.patientDetails).toBeUndefined();
   });
 
   it('should show error notification on failure', async () => {
-    const error = new Error('Failed to fetch patient');
-    mockGetPatientProfile.mockRejectedValue(error);
+    mockGetPatientById.mockRejectedValue(new Error('Failed to fetch'));
 
-    renderHook(
-      () =>
-        usePatientDetails({
-          patientUuid: 'patient-123',
-        }),
-      { wrapper: createWrapper() },
-    );
+    renderHook(() => usePatientDetails({ patientUuid: 'patient-123' }), {
+      wrapper: createWrapper(),
+    });
 
     await waitFor(() => {
       expect(mockAddNotification).toHaveBeenCalledWith({
         type: 'error',
         title: 'Error loading patient details',
-        message: 'Failed to fetch patient',
+        message: 'Failed to fetch',
       });
     });
   });

--- a/apps/registration/src/hooks/usePatientDetails.ts
+++ b/apps/registration/src/hooks/usePatientDetails.ts
@@ -1,19 +1,17 @@
-import {
-  getPatientProfile,
-  formatDateTime,
-  useTranslation,
-} from '@bahmni/services';
+import { getPatientById, useTranslation } from '@bahmni/services';
 import { useNotification } from '@bahmni/widgets';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { useEffect, useMemo, useState } from 'react';
-import { useGenderData } from '../utils/identifierGenderUtils';
 import {
-  convertToBasicInfoData,
-  convertToPersonAttributesData,
-  convertToAddressData,
-  convertToAdditionalIdentifiersData,
-  convertToRelationshipsData,
-} from '../utils/patientDataConverter';
+  convertFhirToBasicInfo,
+  convertFhirToPersonAttributes,
+  convertFhirToAddressData,
+  convertFhirToAdditionalIdentifiers,
+  extractMetadata,
+  extractDobEstimated,
+} from '../utils/fhirPatientToFormData';
+import { useGenderData } from '../utils/identifierGenderUtils';
+import { usePersonAttributes } from './usePersonAttributes';
 
 interface UsePatientDetailsProps {
   patientUuid: string | undefined;
@@ -30,7 +28,7 @@ export const usePatientDetails = ({ patientUuid }: UsePatientDetailsProps) => {
   const { t } = useTranslation();
   const { getGenderDisplay } = useGenderData(t);
   const { addNotification } = useNotification();
-  const queryClient = useQueryClient();
+  const { personAttributes } = usePersonAttributes();
 
   const [metadata, setMetadata] = useState<PatientMetadata>({
     patientUuid: '',
@@ -45,7 +43,7 @@ export const usePatientDetails = ({ patientUuid }: UsePatientDetailsProps) => {
     error,
   } = useQuery({
     queryKey: ['formattedPatient', patientUuid],
-    queryFn: () => getPatientProfile(patientUuid!),
+    queryFn: () => getPatientById(patientUuid!),
     enabled: !!patientUuid,
   });
 
@@ -60,56 +58,45 @@ export const usePatientDetails = ({ patientUuid }: UsePatientDetailsProps) => {
   }, [error, t, addNotification]);
 
   const profileInitialData = useMemo(
-    () => convertToBasicInfoData(patientDetails, getGenderDisplay),
+    () =>
+      patientDetails
+        ? convertFhirToBasicInfo(patientDetails, getGenderDisplay)
+        : undefined,
     [patientDetails, getGenderDisplay],
   );
 
   const personAttributesInitialData = useMemo(
-    () => convertToPersonAttributesData(patientDetails),
-    [patientDetails],
+    () =>
+      patientDetails
+        ? convertFhirToPersonAttributes(patientDetails, personAttributes)
+        : undefined,
+    [patientDetails, personAttributes],
   );
 
   const addressInitialData = useMemo(
-    () => convertToAddressData(patientDetails),
+    () =>
+      patientDetails ? convertFhirToAddressData(patientDetails) : undefined,
     [patientDetails],
   );
 
   const additionalIdentifiersInitialData = useMemo(
-    () => convertToAdditionalIdentifiersData(patientDetails),
-    [patientDetails],
-  );
-
-  const relationshipsInitialData = useMemo(
-    () => convertToRelationshipsData(patientDetails),
+    () =>
+      patientDetails
+        ? convertFhirToAdditionalIdentifiers(patientDetails)
+        : undefined,
     [patientDetails],
   );
 
   const initialDobEstimated = useMemo(
-    () => patientDetails?.patient?.person?.birthdateEstimated ?? false,
+    () => (patientDetails ? extractDobEstimated(patientDetails) : false),
     [patientDetails],
   );
 
   useEffect(() => {
     if (patientDetails) {
-      const dateCreated = patientDetails.patient?.auditInfo?.dateCreated;
-      let formattedDate = '';
-
-      if (dateCreated) {
-        const result = formatDateTime(dateCreated, t);
-        if (!result.error) {
-          formattedDate = result.formattedResult;
-        }
-      }
-
-      setMetadata({
-        patientUuid: patientDetails.patient.uuid,
-        patientIdentifier:
-          patientDetails.patient.identifiers[0]?.identifier ?? '',
-        patientName: patientDetails.patient.person.display ?? '',
-        registerDate: formattedDate,
-      });
+      setMetadata(extractMetadata(patientDetails, t));
     }
-  }, [patientDetails, patientUuid, queryClient, t]);
+  }, [patientDetails, t]);
 
   return {
     patientDetails,
@@ -118,7 +105,6 @@ export const usePatientDetails = ({ patientUuid }: UsePatientDetailsProps) => {
     personAttributesInitialData,
     addressInitialData,
     additionalIdentifiersInitialData,
-    relationshipsInitialData,
     initialDobEstimated,
     metadata,
   };

--- a/apps/registration/src/pages/PatientRegister/PatientRegister.tsx
+++ b/apps/registration/src/pages/PatientRegister/PatientRegister.tsx
@@ -67,7 +67,6 @@ const PatientRegister = () => {
     personAttributesInitialData,
     addressInitialData,
     additionalIdentifiersInitialData,
-    relationshipsInitialData,
     initialDobEstimated,
     metadata: initialMetadata,
   } = usePatientDetails({
@@ -253,7 +252,6 @@ const PatientRegister = () => {
       addressInitialData,
       personAttributesInitialData,
       additionalIdentifiersInitialData,
-      relationshipsInitialData,
       initialDobEstimated,
       patientPhoto: patientPhoto ?? undefined,
     }),
@@ -262,7 +260,6 @@ const PatientRegister = () => {
       addressInitialData,
       personAttributesInitialData,
       additionalIdentifiersInitialData,
-      relationshipsInitialData,
       initialDobEstimated,
       patientPhoto,
     ],

--- a/apps/registration/src/pages/PatientRegister/formSectionMap.tsx
+++ b/apps/registration/src/pages/PatientRegister/formSectionMap.tsx
@@ -54,12 +54,7 @@ export const builtInFormSections: FormSectionConfig[] = [
       ) {
         return null;
       }
-      return (
-        <PatientRelationships
-          ref={refs.relationshipsRef}
-          initialData={data.relationshipsInitialData}
-        />
-      );
+      return <PatientRelationships ref={refs.relationshipsRef} />;
     },
   },
 ];

--- a/apps/registration/src/pages/PatientRegister/models.ts
+++ b/apps/registration/src/pages/PatientRegister/models.ts
@@ -2,10 +2,7 @@ import type { AdditionalIdentifiersRef } from '../../components/forms/additional
 import type { AdditionalInfoRef } from '../../components/forms/additionalInfo/AdditionalInfo';
 import type { AddressInfoRef } from '../../components/forms/addressInfo/AddressInfo';
 import type { ContactInfoRef } from '../../components/forms/contactInfo/ContactInfo';
-import type {
-  PatientRelationshipsRef,
-  RelationshipData,
-} from '../../components/forms/patientRelationships/PatientRelationships';
+import type { PatientRelationshipsRef } from '../../components/forms/patientRelationships/PatientRelationships';
 import type { RelationshipType } from '../../components/forms/patientRelationships/RelationshipRow';
 import type { ProfileRef } from '../../components/forms/profile/Profile';
 import type { AddressData } from '../../hooks/useAddressFields';
@@ -29,7 +26,6 @@ export interface FormControlData {
   addressInitialData: AddressData | undefined;
   personAttributesInitialData: PersonAttributesData | undefined;
   additionalIdentifiersInitialData: AdditionalIdentifiersData | undefined;
-  relationshipsInitialData: RelationshipData[] | undefined;
   initialDobEstimated: boolean;
   patientPhoto: string | undefined;
 }

--- a/apps/registration/src/pages/patientSearchPage/styles/index.module.scss
+++ b/apps/registration/src/pages/patientSearchPage/styles/index.module.scss
@@ -79,7 +79,7 @@
 }
 
 .headerButton {
-  position: absolute !important;
+  position: fixed !important;
   top: $spacing-02;
   right: $spacing-09;
   padding-inline: $spacing-05 !important;

--- a/apps/registration/src/providers/PersonAttributesProvider.tsx
+++ b/apps/registration/src/providers/PersonAttributesProvider.tsx
@@ -73,7 +73,12 @@ export const PersonAttributesProvider: React.FC<
       setPersonAttributes,
       isLoading,
       setIsLoading,
-      error: queryError ? new Error(String(queryError)) : null,
+      error:
+        queryError == null
+          ? null
+          : queryError instanceof Error
+            ? queryError
+            : new Error(String(queryError)),
       setError,
       refetch,
     }),

--- a/apps/registration/src/providers/PersonAttributesProvider.tsx
+++ b/apps/registration/src/providers/PersonAttributesProvider.tsx
@@ -5,7 +5,13 @@ import {
   PersonAttributeType,
 } from '@bahmni/services';
 import { useQuery } from '@tanstack/react-query';
-import React, { ReactNode, useEffect, useMemo, useState } from 'react';
+import React, {
+  ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 import { PersonAttributesContext } from '../contexts/PersonAttributesContext';
 
 interface PersonAttributesProviderProps {
@@ -53,15 +59,13 @@ export const PersonAttributesProvider: React.FC<
   }, [queryError]);
 
   const isLoading = initialAttributes ? false : queryIsLoading;
-  const error = queryError ? new Error(String(queryError)) : null;
 
   const setIsLoading = () => {};
   const setError = () => {};
 
-  // Refetch wrapper to maintain async signature
-  const refetch = async () => {
+  const refetch = useCallback(async () => {
     await queryRefetch();
-  };
+  }, [queryRefetch]);
 
   const value = useMemo(
     () => ({
@@ -69,11 +73,11 @@ export const PersonAttributesProvider: React.FC<
       setPersonAttributes,
       isLoading,
       setIsLoading,
-      error,
+      error: queryError ? new Error(String(queryError)) : null,
       setError,
       refetch,
     }),
-    [personAttributes, isLoading, error, refetch],
+    [personAttributes, isLoading, queryError, refetch],
   );
 
   return (

--- a/apps/registration/src/providers/__tests__/PersonAttributesProvider.test.tsx
+++ b/apps/registration/src/providers/__tests__/PersonAttributesProvider.test.tsx
@@ -1,0 +1,217 @@
+import { notificationService, PersonAttributeType } from '@bahmni/services';
+import { renderHook, act } from '@testing-library/react';
+import React, { useContext } from 'react';
+import { PersonAttributesContext } from '../../contexts/PersonAttributesContext';
+import { PersonAttributesProvider } from '../PersonAttributesProvider';
+
+jest.mock('@bahmni/services', () => ({
+  getPersonAttributeTypes: jest.fn(),
+  getFormattedError: jest.fn((err: unknown) => ({
+    title: 'Error',
+    message: String(err),
+  })),
+  notificationService: {
+    showError: jest.fn(),
+  },
+}));
+
+const mockQueryRefetch = jest.fn();
+let mockQueryReturn: {
+  data: PersonAttributeType[] | undefined;
+  isLoading: boolean;
+  error: unknown;
+  refetch: jest.Mock;
+};
+
+jest.mock('@tanstack/react-query', () => ({
+  useQuery: () => mockQueryReturn,
+}));
+
+const useTestContext = () => {
+  const ctx = useContext(PersonAttributesContext);
+  if (!ctx) throw new Error('No context');
+  return ctx;
+};
+
+describe('PersonAttributesProvider', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockQueryReturn = {
+      data: undefined,
+      isLoading: false,
+      error: null,
+      refetch: mockQueryRefetch,
+    };
+  });
+
+  describe('with initialAttributes', () => {
+    const initialAttrs: PersonAttributeType[] = [
+      {
+        uuid: 'attr-1',
+        name: 'phone',
+        description: '',
+        format: 'java.lang.String',
+        sortWeight: 1,
+        concept: null,
+      },
+    ];
+
+    it('should use initialAttributes and set isLoading to false', () => {
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <PersonAttributesProvider initialAttributes={initialAttrs}>
+          {children}
+        </PersonAttributesProvider>
+      );
+
+      const { result } = renderHook(() => useTestContext(), { wrapper });
+
+      expect(result.current.personAttributes).toEqual(initialAttrs);
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
+
+  describe('without initialAttributes', () => {
+    it('should use query data when loaded', () => {
+      const queryAttrs: PersonAttributeType[] = [
+        {
+          uuid: 'attr-2',
+          name: 'email',
+          description: '',
+          format: 'java.lang.String',
+          sortWeight: 2,
+          concept: null,
+        },
+      ];
+      mockQueryReturn = {
+        data: queryAttrs,
+        isLoading: false,
+        error: null,
+        refetch: mockQueryRefetch,
+      };
+
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <PersonAttributesProvider>{children}</PersonAttributesProvider>
+      );
+
+      const { result } = renderHook(() => useTestContext(), { wrapper });
+
+      expect(result.current.personAttributes).toEqual(queryAttrs);
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    it('should set isLoading to true when query is loading', () => {
+      mockQueryReturn = {
+        data: undefined,
+        isLoading: true,
+        error: null,
+        refetch: mockQueryRefetch,
+      };
+
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <PersonAttributesProvider>{children}</PersonAttributesProvider>
+      );
+
+      const { result } = renderHook(() => useTestContext(), { wrapper });
+
+      expect(result.current.isLoading).toBe(true);
+    });
+  });
+
+  describe('error handling', () => {
+    it('should preserve Error instance in context', () => {
+      const error = new Error('fetch failed');
+      mockQueryReturn = {
+        data: undefined,
+        isLoading: false,
+        error,
+        refetch: mockQueryRefetch,
+      };
+
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <PersonAttributesProvider>{children}</PersonAttributesProvider>
+      );
+
+      const { result } = renderHook(() => useTestContext(), { wrapper });
+
+      expect(result.current.error).toBe(error);
+    });
+
+    it('should wrap non-Error values in Error', () => {
+      mockQueryReturn = {
+        data: undefined,
+        isLoading: false,
+        error: 'string error',
+        refetch: mockQueryRefetch,
+      };
+
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <PersonAttributesProvider>{children}</PersonAttributesProvider>
+      );
+
+      const { result } = renderHook(() => useTestContext(), { wrapper });
+
+      expect(result.current.error).toBeInstanceOf(Error);
+      expect(result.current.error?.message).toBe('string error');
+    });
+
+    it('should set error to null when no query error', () => {
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <PersonAttributesProvider>{children}</PersonAttributesProvider>
+      );
+
+      const { result } = renderHook(() => useTestContext(), { wrapper });
+
+      expect(result.current.error).toBeNull();
+    });
+
+    it('should show error notification when query fails', () => {
+      mockQueryReturn = {
+        data: undefined,
+        isLoading: false,
+        error: new Error('API error'),
+        refetch: mockQueryRefetch,
+      };
+
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <PersonAttributesProvider>{children}</PersonAttributesProvider>
+      );
+
+      renderHook(() => useTestContext(), { wrapper });
+
+      expect(notificationService.showError).toHaveBeenCalled();
+    });
+  });
+
+  describe('refetch stability', () => {
+    it('should return stable refetch reference across re-renders', () => {
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <PersonAttributesProvider>{children}</PersonAttributesProvider>
+      );
+
+      const { result, rerender } = renderHook(() => useTestContext(), {
+        wrapper,
+      });
+      const firstRef = result.current.refetch;
+
+      rerender();
+
+      expect(result.current.refetch).toBe(firstRef);
+    });
+
+    it('should call queryRefetch when refetch is invoked', async () => {
+      mockQueryRefetch.mockResolvedValue(undefined);
+
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <PersonAttributesProvider>{children}</PersonAttributesProvider>
+      );
+
+      const { result } = renderHook(() => useTestContext(), { wrapper });
+
+      await act(async () => {
+        await result.current.refetch();
+      });
+
+      expect(mockQueryRefetch).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/registration/src/utils/__tests__/fhirPatientMapper.test.ts
+++ b/apps/registration/src/utils/__tests__/fhirPatientMapper.test.ts
@@ -128,6 +128,18 @@ describe('buildFhirPatient', () => {
     expect(buildFhirPatient(baseInput).id).toBeUndefined();
   });
 
+  it('should include nameUuid in name for update, omit for create', () => {
+    const updateResult = buildFhirPatient({
+      ...baseInput,
+      patientUuid: 'uuid-123',
+      profile: { ...baseProfile, nameUuid: 'name-uuid-456' },
+    });
+    expect(updateResult.name![0].id).toBe('name-uuid-456');
+
+    const createResult = buildFhirPatient(baseInput);
+    expect(createResult.name![0].id).toBeUndefined();
+  });
+
   it('should include primary identifier with type text and location', () => {
     const result = buildFhirPatient({
       ...baseInput,

--- a/apps/registration/src/utils/__tests__/fhirPatientToFormData.test.ts
+++ b/apps/registration/src/utils/__tests__/fhirPatientToFormData.test.ts
@@ -1,0 +1,247 @@
+import type { PersonAttributeType } from '@bahmni/services';
+import { format, parseISO } from 'date-fns';
+import type { Patient } from 'fhir/r4';
+import {
+  convertFhirToBasicInfo,
+  convertFhirToPersonAttributes,
+  convertFhirToAddressData,
+  convertFhirToAdditionalIdentifiers,
+  extractMetadata,
+  extractDobEstimated,
+} from '../fhirPatientToFormData';
+
+jest.mock('@bahmni/services', () => ({
+  ...jest.requireActual('@bahmni/services'),
+  formatDateTime: jest.fn(() => ({
+    formattedResult: '04 May 2026',
+    error: false,
+  })),
+}));
+
+const personAttributes: PersonAttributeType[] = [
+  {
+    uuid: 'p1',
+    name: 'phoneNumber',
+    format: 'java.lang.String',
+    sortWeight: 1,
+    description: null,
+    concept: null,
+  },
+  {
+    uuid: 'p2',
+    name: 'email',
+    format: 'java.lang.String',
+    sortWeight: 2,
+    description: null,
+    concept: null,
+  },
+];
+
+const baseFhirPatient: Patient = {
+  resourceType: 'Patient',
+  id: 'uuid-123',
+  identifier: [
+    {
+      id: 'id-1',
+      use: 'official',
+      type: { coding: [{ code: 'type-1' }], text: 'Primary' },
+      value: 'ABC100',
+    },
+    { id: 'id-2', type: { coding: [{ code: 'old-type' }] }, value: 'OLD999' },
+  ],
+  name: [{ id: 'name-1', given: ['John', 'Michael'], family: 'Doe' }],
+  gender: 'male',
+  birthDate: '1990-05-15',
+  extension: [
+    {
+      url: 'http://fhir.bahmni.org/ext/patient/phonenumber',
+      valueString: '+91123',
+    },
+    { url: 'http://fhir.bahmni.org/ext/patient/email', valueString: 'j@t.com' },
+    {
+      url: 'http://fhir.bahmni.org/ext/patient/date-created',
+      valueDateTime: '2026-05-04T11:53:11+00:00',
+    },
+  ],
+  address: [
+    {
+      use: 'home',
+      city: 'Delhi',
+      state: 'Haryana',
+      postalCode: '122001',
+      extension: [
+        {
+          url: 'http://fhir.openmrs.org/ext/address',
+          extension: [
+            {
+              url: 'http://fhir.openmrs.org/ext/address#address1',
+              valueString: 'Flat 1',
+            },
+            {
+              url: 'http://fhir.openmrs.org/ext/address#address2',
+              valueString: 'Sector 5',
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+describe('convertFhirToBasicInfo', () => {
+  it('should extract name, gender, birthDate', () => {
+    const result = convertFhirToBasicInfo(baseFhirPatient);
+    expect(result.firstName).toBe('John');
+    expect(result.middleName).toBe('Michael');
+    expect(result.lastName).toBe('Doe');
+    expect(result.gender).toBe('M');
+    expect(result.dateOfBirth).toBe('1990-05-15');
+    expect(result.nameUuid).toBe('name-1');
+    expect(result.entryType).toBe(false);
+  });
+
+  it('should apply gender display function', () => {
+    const display = (code: string) => (code === 'M' ? 'Male' : code);
+    const result = convertFhirToBasicInfo(baseFhirPatient, display);
+    expect(result.gender).toBe('Male');
+  });
+
+  it('should extract birthTime from _birthDate extension', () => {
+    const patientWithBirthTime = {
+      ...baseFhirPatient,
+      _birthDate: {
+        extension: [
+          {
+            url: 'http://hl7.org/fhir/StructureDefinition/patient-birthTime',
+            valueDateTime: '1990-05-15T08:30:00.000Z',
+          },
+        ],
+      },
+    };
+    const result = convertFhirToBasicInfo(patientWithBirthTime);
+    const expected = format(parseISO('1990-05-15T08:30:00.000Z'), 'HH:mm');
+    expect(result.birthTime).toBe(expected);
+  });
+
+  it('should return empty birthTime when no _birthDate', () => {
+    const result = convertFhirToBasicInfo(baseFhirPatient);
+    expect(result.birthTime).toBe('');
+  });
+
+  it('should handle estimated birthdate YYYY', () => {
+    const result = convertFhirToBasicInfo({
+      ...baseFhirPatient,
+      birthDate: '1990',
+    });
+    expect(result.dateOfBirth).toBe('1990-01-01');
+    expect(result.entryType).toBe(true);
+  });
+
+  it('should handle estimated birthdate YYYY-MM', () => {
+    const result = convertFhirToBasicInfo({
+      ...baseFhirPatient,
+      birthDate: '2023-03',
+    });
+    expect(result.dateOfBirth).toBe('2023-03-01');
+    expect(result.entryType).toBe(true);
+  });
+});
+
+describe('convertFhirToPersonAttributes', () => {
+  it('should map slug extensions to attribute names', () => {
+    const result = convertFhirToPersonAttributes(
+      baseFhirPatient,
+      personAttributes,
+    );
+    expect(result).toEqual({ phoneNumber: '+91123', email: 'j@t.com' });
+  });
+
+  it('should skip date-created and unknown slugs', () => {
+    const patient: Patient = {
+      ...baseFhirPatient,
+      extension: [
+        {
+          url: 'http://fhir.bahmni.org/ext/patient/date-created',
+          valueDateTime: '2026-01-01',
+        },
+        {
+          url: 'http://fhir.bahmni.org/ext/patient/unknownattr',
+          valueString: 'x',
+        },
+      ],
+    };
+    const result = convertFhirToPersonAttributes(patient, personAttributes);
+    expect(result).toBeUndefined();
+  });
+
+  it('should return undefined when no extensions', () => {
+    const result = convertFhirToPersonAttributes(
+      { ...baseFhirPatient, extension: undefined },
+      personAttributes,
+    );
+    expect(result).toBeUndefined();
+  });
+});
+
+describe('convertFhirToAddressData', () => {
+  it('should extract address fields and extensions', () => {
+    const result = convertFhirToAddressData(baseFhirPatient);
+    expect(result).toEqual({
+      address1: 'Flat 1',
+      address2: 'Sector 5',
+      cityVillage: 'Delhi',
+      stateProvince: 'Haryana',
+      postalCode: '122001',
+    });
+  });
+
+  it('should return undefined when no address', () => {
+    expect(
+      convertFhirToAddressData({ ...baseFhirPatient, address: undefined }),
+    ).toBeUndefined();
+  });
+});
+
+describe('convertFhirToAdditionalIdentifiers', () => {
+  it('should extract non-primary identifiers by type code', () => {
+    const result = convertFhirToAdditionalIdentifiers(baseFhirPatient);
+    expect(result).toEqual({ 'old-type': 'OLD999' });
+  });
+
+  it('should return undefined when only primary identifier', () => {
+    const patient = {
+      ...baseFhirPatient,
+      identifier: [baseFhirPatient.identifier![0]],
+    };
+    expect(convertFhirToAdditionalIdentifiers(patient)).toBeUndefined();
+  });
+});
+
+describe('extractMetadata', () => {
+  it('should extract uuid, identifier, name, registerDate', () => {
+    const t = (key: string) => key;
+    const result = extractMetadata(baseFhirPatient, t);
+    expect(result.patientUuid).toBe('uuid-123');
+    expect(result.patientIdentifier).toBe('ABC100');
+    expect(result.patientName).toBe('John Michael Doe');
+    expect(result.registerDate).toBe('04 May 2026');
+  });
+});
+
+describe('extractDobEstimated', () => {
+  it('should return true for YYYY', () => {
+    expect(extractDobEstimated({ ...baseFhirPatient, birthDate: '1990' })).toBe(
+      true,
+    );
+  });
+
+  it('should return true for YYYY-MM', () => {
+    expect(
+      extractDobEstimated({ ...baseFhirPatient, birthDate: '2023-01' }),
+    ).toBe(true);
+  });
+
+  it('should return false for YYYY-MM-DD', () => {
+    expect(extractDobEstimated(baseFhirPatient)).toBe(false);
+  });
+});

--- a/apps/registration/src/utils/__tests__/fhirUtils.test.ts
+++ b/apps/registration/src/utils/__tests__/fhirUtils.test.ts
@@ -1,0 +1,42 @@
+import { toSlugCase, mapGenderToFhir, mapGenderFromFhir } from '../fhirUtils';
+
+describe('toSlugCase', () => {
+  it('should lowercase camelCase', () => {
+    expect(toSlugCase('phoneNumber')).toBe('phonenumber');
+    expect(toSlugCase('altPhoneNumber')).toBe('altphonenumber');
+  });
+
+  it('should replace spaces with hyphens', () => {
+    expect(toSlugCase('Phone Number')).toBe('phone-number');
+  });
+
+  it('should strip special characters', () => {
+    expect(toSlugCase('email@address!')).toBe('emailaddress');
+  });
+
+  it('should collapse multiple hyphens', () => {
+    expect(toSlugCase('a  -  b')).toBe('a-b');
+  });
+});
+
+describe('mapGenderToFhir', () => {
+  it('should map M/F/O to FHIR codes', () => {
+    expect(mapGenderToFhir('Male')).toBe('male');
+    expect(mapGenderToFhir('Female')).toBe('female');
+    expect(mapGenderToFhir('Other')).toBe('other');
+  });
+
+  it('should return unknown for empty or unrecognized', () => {
+    expect(mapGenderToFhir('')).toBe('unknown');
+    expect(mapGenderToFhir('X')).toBe('unknown');
+  });
+});
+
+describe('mapGenderFromFhir', () => {
+  it('should reverse map FHIR codes to OpenMRS codes', () => {
+    expect(mapGenderFromFhir('male')).toBe('M');
+    expect(mapGenderFromFhir('female')).toBe('F');
+    expect(mapGenderFromFhir('other')).toBe('O');
+    expect(mapGenderFromFhir('unknown')).toBe('U');
+  });
+});

--- a/apps/registration/src/utils/__tests__/identifierGenderUtils.test.ts
+++ b/apps/registration/src/utils/__tests__/identifierGenderUtils.test.ts
@@ -1,0 +1,93 @@
+import { renderHook } from '@testing-library/react';
+import { useGenderData, useIdentifierData } from '../identifierGenderUtils';
+
+jest.mock('@bahmni/services', () => ({
+  getGenders: jest.fn(),
+  getIdentifierData: jest.fn(),
+}));
+
+const mockUseQuery = jest.fn();
+jest.mock('@tanstack/react-query', () => ({
+  useQuery: (options: unknown) => mockUseQuery(options),
+}));
+
+describe('useIdentifierData', () => {
+  it('should return identifier prefixes from query data', () => {
+    const prefixes = ['BAH', 'GAN'];
+    mockUseQuery.mockReturnValue({
+      data: {
+        prefixes,
+        sourcesByPrefix: new Map([['BAH', 'src-1']]),
+        primaryIdentifierTypeUuid: 'type-uuid',
+        primaryIdentifierTypeName: 'Patient ID',
+      },
+    });
+
+    const { result } = renderHook(() => useIdentifierData());
+
+    expect(result.current.identifierPrefixes).toEqual(prefixes);
+    expect(result.current.primaryIdentifierType).toBe('type-uuid');
+    expect(result.current.primaryIdentifierTypeName).toBe('Patient ID');
+  });
+
+  it('should return empty defaults when query data is undefined', () => {
+    mockUseQuery.mockReturnValue({ data: undefined });
+
+    const { result } = renderHook(() => useIdentifierData());
+
+    expect(result.current.identifierPrefixes).toEqual([]);
+    expect(result.current.identifierSources).toBeUndefined();
+    expect(result.current.primaryIdentifierType).toBeUndefined();
+    expect(result.current.primaryIdentifierTypeName).toBeUndefined();
+  });
+});
+
+describe('useGenderData', () => {
+  const mockT = jest.fn((key: string) => key);
+
+  beforeEach(() => {
+    mockUseQuery.mockReturnValue({
+      data: { M: 'Male', F: 'Female' },
+    });
+  });
+
+  it('should return translated gender values', () => {
+    const { result } = renderHook(() => useGenderData(mockT));
+
+    expect(result.current.genders).toEqual([
+      'CREATE_PATIENT_GENDER_MALE',
+      'CREATE_PATIENT_GENDER_FEMALE',
+    ]);
+  });
+
+  it('should return stable getGenderDisplay reference across re-renders', () => {
+    const { result, rerender } = renderHook(() => useGenderData(mockT));
+    const firstRef = result.current.getGenderDisplay;
+
+    rerender();
+
+    expect(result.current.getGenderDisplay).toBe(firstRef);
+  });
+
+  it('should translate gender code via getGenderDisplay', () => {
+    const { result } = renderHook(() => useGenderData(mockT));
+
+    expect(result.current.getGenderDisplay('M')).toBe(
+      'CREATE_PATIENT_GENDER_MALE',
+    );
+  });
+
+  it('should return code as-is when gender code is unknown', () => {
+    const { result } = renderHook(() => useGenderData(mockT));
+
+    expect(result.current.getGenderDisplay('X')).toBe('X');
+  });
+
+  it('should handle empty gender data', () => {
+    mockUseQuery.mockReturnValue({ data: {} });
+
+    const { result } = renderHook(() => useGenderData(mockT));
+
+    expect(result.current.genders).toEqual([]);
+  });
+});

--- a/apps/registration/src/utils/fhirPatientMapper.ts
+++ b/apps/registration/src/utils/fhirPatientMapper.ts
@@ -206,7 +206,13 @@ export function buildFhirPatient(input: MapperInput): Patient {
     resourceType: 'Patient',
     ...(patientUuid && { id: patientUuid }),
     ...(identifiers.length > 0 ? { identifier: identifiers } : {}),
-    name: [{ given, family: profile.lastName }],
+    name: [
+      {
+        ...(profile.nameUuid && { id: profile.nameUuid }),
+        given,
+        family: profile.lastName,
+      },
+    ],
     gender: mapGender(profile.gender),
     birthDate: buildBirthDate(profile.dateOfBirth, profile.dobEstimated),
     ...(birthTimeISO && {

--- a/apps/registration/src/utils/fhirPatientMapper.ts
+++ b/apps/registration/src/utils/fhirPatientMapper.ts
@@ -10,10 +10,12 @@ import {
   AdditionalIdentifiersData,
 } from '../models/patient';
 import { convertTimeToISODateTime } from './dateTimeUtils';
-
-const PATIENT_ATTRIBUTE_EXT_PREFIX = 'http://fhir.bahmni.org/ext/patient/'; // NOSONAR
-const IDENTIFIER_LOCATION_EXT_URL =
-  'http://fhir.openmrs.org/ext/patient/identifier#location'; // NOSONAR
+import {
+  PATIENT_ATTRIBUTE_PREFIX,
+  IDENTIFIER_LOCATION_EXT_URL,
+  toSlugCase,
+  mapGenderToFhir,
+} from './fhirUtils';
 
 function buildLocationExtension(
   locationUuid?: string,
@@ -25,22 +27,6 @@ function buildLocationExtension(
       valueReference: { reference: `Location/${locationUuid}` },
     },
   ];
-}
-
-function toSlugCase(str: string): string {
-  return str
-    .replace(/\s+/g, '-')
-    .replace(/[^a-zA-Z0-9-]/g, '')
-    .replace(/-{2,}/g, '-')
-    .toLowerCase();
-}
-
-function mapGender(gender: string): 'male' | 'female' | 'other' | 'unknown' {
-  const char = (gender ?? '').charAt(0).toUpperCase();
-  if (char === 'M') return 'male';
-  if (char === 'F') return 'female';
-  if (char === 'O') return 'other';
-  return 'unknown';
 }
 
 function buildBirthDate(
@@ -135,7 +121,7 @@ export function buildFhirPatient(input: MapperInput): Patient {
 
     const value = allAttributes[attrType.name];
     const slug = toSlugCase(attrType.name);
-    const url = PATIENT_ATTRIBUTE_EXT_PREFIX + slug;
+    const url = PATIENT_ATTRIBUTE_PREFIX + slug;
 
     if (value !== undefined && value !== null && String(value).trim() !== '') {
       if (typeof value === 'boolean') {
@@ -213,7 +199,7 @@ export function buildFhirPatient(input: MapperInput): Patient {
         family: profile.lastName,
       },
     ],
-    gender: mapGender(profile.gender),
+    gender: mapGenderToFhir(profile.gender),
     birthDate: buildBirthDate(profile.dateOfBirth, profile.dobEstimated),
     ...(birthTimeISO && {
       _birthDate: {

--- a/apps/registration/src/utils/fhirPatientMapper.ts
+++ b/apps/registration/src/utils/fhirPatientMapper.ts
@@ -208,7 +208,7 @@ export function buildFhirPatient(input: MapperInput): Patient {
     ...(identifiers.length > 0 ? { identifier: identifiers } : {}),
     name: [
       {
-        ...(profile.nameUuid && { id: profile.nameUuid }),
+        ...(patientUuid && profile.nameUuid && { id: profile.nameUuid }),
         given,
         family: profile.lastName,
       },

--- a/apps/registration/src/utils/fhirPatientToFormData.ts
+++ b/apps/registration/src/utils/fhirPatientToFormData.ts
@@ -1,0 +1,171 @@
+import {
+  calculateAge,
+  formatDateTime,
+  type PersonAttributeType,
+} from '@bahmni/services';
+import { format, isValid, parseISO } from 'date-fns';
+import type { Patient } from 'fhir/r4';
+import type { AddressData } from '../hooks/useAddressFields';
+import type { BasicInfoData, PersonAttributesData } from '../models/patient';
+import {
+  PATIENT_ATTRIBUTE_PREFIX,
+  ADDRESS_EXT_URL,
+  BIRTH_TIME_EXT_URL,
+  DATE_CREATED_EXT_URL,
+  toSlugCase,
+  mapGenderFromFhir,
+} from './fhirUtils';
+
+function parseBirthDate(birthDate?: string): {
+  dateOfBirth: string;
+  estimated: boolean;
+} {
+  if (!birthDate) return { dateOfBirth: '', estimated: false };
+  const len = birthDate.length;
+  if (len === 4) return { dateOfBirth: `${birthDate}-01-01`, estimated: true };
+  if (len === 7) return { dateOfBirth: `${birthDate}-01`, estimated: true };
+  return { dateOfBirth: birthDate, estimated: false };
+}
+
+function extractBirthTime(patient: Patient): string {
+  const el = (patient as Record<string, unknown>)._birthDate as
+    | { extension?: { url: string; valueDateTime?: string }[] }
+    | undefined;
+  const ext = el?.extension?.find((e) => e.url === BIRTH_TIME_EXT_URL);
+  if (!ext?.valueDateTime) return '';
+  const date = parseISO(ext.valueDateTime);
+  return isValid(date) ? format(date, 'HH:mm') : '';
+}
+
+export function convertFhirToBasicInfo(
+  patient: Patient,
+  getGenderDisplay?: (code: string) => string,
+): BasicInfoData {
+  const name = patient.name?.[0];
+  const given = name?.given ?? [];
+  const genderCode = mapGenderFromFhir(patient.gender ?? '');
+  const { dateOfBirth, estimated } = parseBirthDate(patient.birthDate);
+  const age = dateOfBirth ? calculateAge(dateOfBirth) : null;
+
+  return {
+    patientIdFormat: '',
+    entryType: estimated,
+    firstName: given[0] ?? '',
+    middleName: given.slice(1).join(' '),
+    lastName: name?.family ?? '',
+    gender: getGenderDisplay?.(genderCode) ?? genderCode,
+    ageYears: age?.years.toString() ?? '',
+    ageMonths: age?.months.toString() ?? '',
+    ageDays: age?.days.toString() ?? '',
+    dateOfBirth,
+    birthTime: extractBirthTime(patient),
+    nameUuid: name?.id,
+  };
+}
+
+export function convertFhirToPersonAttributes(
+  patient: Patient,
+  personAttributes: PersonAttributeType[],
+): PersonAttributesData | undefined {
+  const slugToName: Record<string, string> = {};
+  personAttributes.forEach((attr) => {
+    slugToName[toSlugCase(attr.name)] = attr.name;
+  });
+
+  const data: PersonAttributesData = {};
+  let found = false;
+
+  for (const ext of patient.extension ?? []) {
+    if (!ext.url?.startsWith(PATIENT_ATTRIBUTE_PREFIX)) continue;
+    const slug = ext.url.substring(PATIENT_ATTRIBUTE_PREFIX.length);
+    if (slug === 'date-created') continue;
+
+    const attrName = slugToName[slug];
+    if (!attrName) continue;
+
+    const value = ext.valueString ?? ext.valueBoolean;
+    if (value !== undefined) {
+      data[attrName] = typeof value === 'boolean' ? value : String(value);
+      found = true;
+    }
+  }
+
+  return found ? data : undefined;
+}
+
+export function convertFhirToAddressData(
+  patient: Patient,
+): AddressData | undefined {
+  const addr = patient.address?.[0];
+  if (!addr) return undefined;
+
+  const data: AddressData = {};
+  if (addr.city) data.cityVillage = addr.city;
+  if (addr.district) data.countyDistrict = addr.district;
+  if (addr.state) data.stateProvince = addr.state;
+  if (addr.postalCode) data.postalCode = addr.postalCode;
+
+  const addrExt = addr.extension?.find((e) => e.url === ADDRESS_EXT_URL);
+  if (addrExt?.extension) {
+    for (const sub of addrExt.extension) {
+      if (sub.url?.endsWith('#address1') && sub.valueString)
+        data.address1 = sub.valueString;
+      if (sub.url?.endsWith('#address2') && sub.valueString)
+        data.address2 = sub.valueString;
+    }
+  }
+
+  return Object.keys(data).length > 0 ? data : undefined;
+}
+
+export function convertFhirToAdditionalIdentifiers(
+  patient: Patient,
+): Record<string, string> | undefined {
+  const identifiers = patient.identifier ?? [];
+  if (identifiers.length <= 1) return undefined;
+
+  const data: Record<string, string> = {};
+  identifiers.slice(1).forEach((id) => {
+    const typeCode = id.type?.coding?.[0]?.code;
+    if (typeCode && id.value) data[typeCode] = id.value;
+  });
+
+  return Object.keys(data).length > 0 ? data : undefined;
+}
+
+export function extractMetadata(
+  patient: Patient,
+  t: (key: string) => string,
+): {
+  patientUuid: string;
+  patientIdentifier: string;
+  patientName: string;
+  registerDate: string;
+} {
+  const dateCreatedExt = patient.extension?.find(
+    (e) => e.url === DATE_CREATED_EXT_URL,
+  );
+  let registerDate = '';
+  if (dateCreatedExt?.valueDateTime) {
+    const result = formatDateTime(dateCreatedExt.valueDateTime, t);
+    if (!result.error) registerDate = result.formattedResult;
+  }
+
+  const displayName = [
+    patient.name?.[0]?.given?.join(' '),
+    patient.name?.[0]?.family,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return {
+    patientUuid: patient.id ?? '',
+    patientIdentifier: patient.identifier?.[0]?.value ?? '',
+    patientName: displayName,
+    registerDate,
+  };
+}
+
+export function extractDobEstimated(patient: Patient): boolean {
+  return parseBirthDate(patient.birthDate).estimated;
+}

--- a/apps/registration/src/utils/fhirUtils.ts
+++ b/apps/registration/src/utils/fhirUtils.ts
@@ -1,0 +1,32 @@
+export const PATIENT_ATTRIBUTE_PREFIX = 'http://fhir.bahmni.org/ext/patient/'; // NOSONAR
+export const ADDRESS_EXT_URL = 'http://fhir.openmrs.org/ext/address'; // NOSONAR
+export const BIRTH_TIME_EXT_URL =
+  'http://hl7.org/fhir/StructureDefinition/patient-birthTime'; // NOSONAR
+export const IDENTIFIER_LOCATION_EXT_URL =
+  'http://fhir.openmrs.org/ext/patient/identifier#location'; // NOSONAR
+export const DATE_CREATED_EXT_URL = PATIENT_ATTRIBUTE_PREFIX + 'date-created';
+
+export function toSlugCase(str: string): string {
+  return str
+    .replace(/\s+/g, '-')
+    .replace(/[^a-zA-Z0-9-]/g, '')
+    .replace(/-{2,}/g, '-')
+    .toLowerCase();
+}
+
+export function mapGenderToFhir(
+  gender: string,
+): 'male' | 'female' | 'other' | 'unknown' {
+  const char = (gender ?? '').charAt(0).toUpperCase();
+  if (char === 'M') return 'male';
+  if (char === 'F') return 'female';
+  if (char === 'O') return 'other';
+  return 'unknown';
+}
+
+export function mapGenderFromFhir(fhirGender: string): string {
+  if (fhirGender === 'male') return 'M';
+  if (fhirGender === 'female') return 'F';
+  if (fhirGender === 'other') return 'O';
+  return 'U';
+}

--- a/apps/registration/src/utils/identifierGenderUtils.ts
+++ b/apps/registration/src/utils/identifierGenderUtils.ts
@@ -1,6 +1,6 @@
 import { getGenders, getIdentifierData } from '@bahmni/services';
 import { useQuery } from '@tanstack/react-query';
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 
 export const useIdentifierData = () => {
   const { data: identifierData } = useQuery({
@@ -57,13 +57,16 @@ export const useGenderData = (t: (key: string) => string) => {
     });
   }, [gendersFromApi, t]);
 
-  const getGenderDisplay = (code: string): string => {
-    const genderValue = gendersFromApi[code];
-    if (!genderValue) return code;
-    const genderStr = String(genderValue);
-    const genderKey = `CREATE_PATIENT_GENDER_${genderStr.toUpperCase()}`;
-    return t(genderKey);
-  };
+  const getGenderDisplay = useCallback(
+    (code: string): string => {
+      const genderValue = gendersFromApi[code];
+      if (!genderValue) return code;
+      const genderStr = String(genderValue);
+      const genderKey = `CREATE_PATIENT_GENDER_${genderStr.toUpperCase()}`;
+      return t(genderKey);
+    },
+    [gendersFromApi, t],
+  );
 
   return { genders, getGenderDisplay };
 };


### PR DESCRIPTION
## Summary

Migrates patient profile fetch in the Registration app from the legacy OpenMRS REST API to the FHIR R4 Patient API, while preserving the existing `usePatientDetails` hook contract and all data converter functions.

## Changes

### `apps/registration/src/utils/fhirPatientMapper.ts`
- Added `toPatientProfileResponse(fhirPatient, options)` — reverse mapper: FHIR R4 `Patient` → `PatientProfileResponse`
  - Reverse-maps gender (`male`→`M`, `female`→`F`, etc.)
  - Detects estimated birthdate from `YYYY-MM` format (vs `YYYY-MM-DD`) and pads to `YYYY-MM-01` for downstream `calculateAge` compatibility
  - Extracts birthtime from `_birthDate` FHIR extension
  - Maps identifiers, names, addresses (including `address1`/`address2` from FHIR nested extensions)
  - Resolves person-attribute slugs to original attribute names using an optional `attributeTypes` list
  - Accepts relationships fetched from supplementary REST call (FHIR `Patient` resource does not include relationships)

### `packages/bahmni-services/src/patientService/patientService.ts`
- Replaced `getPatientProfile()` implementation:
  - **Before:** `GET /openmrs/ws/rest/v1/patientprofile/{uuid}?v=full`
  - **After:** `GET /openmrs/ws/fhir2/R4/Patient/{uuid}` (+ two parallel supplementary calls)
- Uses `Promise.all` to concurrently fetch:
  1. FHIR Patient (`PATIENT_RESOURCE_URL`)
  2. Relationships (`PATIENT_RELATIONSHIPS_URL` — new)
  3. Person attribute types (`PERSON_ATTRIBUTE_TYPES_URL`) — for slug resolution
- Internal `fhirPatientToProfileResponse()` maps FHIR data to `PatientProfileResponse` (same shape as before)

### `packages/bahmni-services/src/patientService/constants.ts`
- Added `PATIENT_RELATIONSHIPS_URL` constant: `/openmrs/ws/rest/v1/relationship?v=full&person={uuid}`

### `packages/bahmni-services/src/patientService/models.ts`
- Added `RelationshipsResponse` interface (wraps `Relationship[]` results from the relationships endpoint)

### `packages/bahmni-services/src/patientService/index.ts` + `src/index.ts`
- Exported `Relationship` and `RelationshipsResponse` from `@bahmni/services`

## What's unchanged
- `usePatientDetails` hook — same inputs, same outputs, same contract
- `patientDataConverter.ts` functions — no changes
- `buildFhirPatient` — no changes (used for create/update, not fetch)

## Tests
- **12 new tests** for `toPatientProfileResponse()` in `fhirPatientMapper.test.ts`
  - Gender reverse-mapping, estimated birthdate detection, name/identifier/address mapping, attribute slug resolution, relationship inclusion, birthtime extraction
- **6 new tests** for `getPatientProfile()` FHIR migration in `patientService.test.ts`
  - Verifies parallel API calls (FHIR + relationships + attribute types)
  - Verifies full `PatientProfileResponse` mapping
  - Estimated birthdate padding, slug resolution, relationship forwarding, error propagation
- All 84 `@bahmni/services` tests pass ✅
- All 624 `@bahmni/registration-app` tests pass ✅

## Jira
https://bahmni.atlassian.net/browse/BAH-4680

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Patient profile retrieval now integrates with FHIR R4 standard format
  * Patient relationships are automatically retrieved and included in profiles
  * Improved birthdate handling with automatic formatting for estimated dates
  * Enhanced person attribute resolution with better metadata mapping

* **Tests**
  * Expanded test coverage for patient profile retrieval, relationship mapping, and attribute handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Bahmni/bahmni-apps-frontend/pull/420?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->