### PR TITLE
BAH-4721 | Fix. Remove Vaccination-Specific STAT And Frequency Hardcoding

### DIFF
--- a/apps/clinical/src/components/forms/medicationRequest/__tests__/SelectedMedicationRequestItem.test.tsx
+++ b/apps/clinical/src/components/forms/medicationRequest/__tests__/SelectedMedicationRequestItem.test.tsx
@@ -14,7 +14,6 @@ import {
   mockRequiredMedicationAttributes,
   mockSelectedMedication,
   mockSelectedMedicationWithAllErrors,
-  mockSelectedVaccination,
 } from './__mocks__/MedicationRequestFormMocks';
 
 expect.extend(toHaveNoViolations);
@@ -366,65 +365,6 @@ describe('SelectedMedicationRequestItem', () => {
         screen.queryByRole('textbox', { name: 'Add Note' }),
       ).not.toBeInTheDocument();
       expect(store.getState().selectedMedicationRequests[0].note).toBe('');
-    });
-
-    describe('vaccination STAT behavior', () => {
-      let vacStore: ReturnType<typeof getMedicationRequestStore>;
-
-      const VaccinationTestWrapper = () => {
-        const { selectedMedicationRequests } =
-          useMedicationRequestStore('vaccination');
-        const entry = selectedMedicationRequests[0];
-        if (!entry) return null;
-        return (
-          <SelectedMedicationRequestItem
-            entry={entry}
-            medicationConfig={mockMedicationConfig}
-            inputControlType="vaccination"
-            attributes={[{ name: 'stat' }, { name: 'frequency' }]}
-          />
-        );
-      };
-
-      beforeEach(() => {
-        vacStore = getMedicationRequestStore('vaccination');
-      });
-
-      afterEach(async () => {
-        await act(async () => {
-          vacStore.getState().reset();
-        });
-      });
-
-      it('resets frequency to null when STAT is unchecked', async () => {
-        vacStore.setState({
-          selectedMedicationRequests: [{ ...mockSelectedVaccination }],
-        });
-
-        await act(async () => {
-          render(<VaccinationTestWrapper />);
-        });
-
-        expect(vacStore.getState().selectedMedicationRequests[0].isSTAT).toBe(
-          true,
-        );
-        expect(
-          vacStore.getState().selectedMedicationRequests[0].frequency,
-        ).toEqual({ uuid: '0', name: 'Immediately', frequencyPerDay: 1 });
-
-        await user.click(
-          screen.getByTestId(
-            `vaccination-stat-checkbox-${mockSelectedVaccination.id}-test-id`,
-          ),
-        );
-
-        expect(vacStore.getState().selectedMedicationRequests[0].isSTAT).toBe(
-          false,
-        );
-        expect(
-          vacStore.getState().selectedMedicationRequests[0].frequency,
-        ).toBeNull();
-      });
     });
   });
 

--- a/apps/clinical/src/components/forms/medicationRequest/__tests__/SelectedMedicationRequestItem.test.tsx
+++ b/apps/clinical/src/components/forms/medicationRequest/__tests__/SelectedMedicationRequestItem.test.tsx
@@ -14,6 +14,7 @@ import {
   mockRequiredMedicationAttributes,
   mockSelectedMedication,
   mockSelectedMedicationWithAllErrors,
+  mockSelectedVaccination,
 } from './__mocks__/MedicationRequestFormMocks';
 
 expect.extend(toHaveNoViolations);
@@ -428,6 +429,39 @@ describe('SelectedMedicationRequestItem', () => {
     expect(mockStore.updateDurationUnit).toHaveBeenCalledWith(
       mockMinimalMedicationEntry.id,
       { code: 'd', display: 'DURATION_UNIT_DAYS', daysMultiplier: 1 },
+    );
+  });
+
+  it('sets immediate frequency, clears duration, and updates start date when vaccination isSTAT is true', async () => {
+    const mockStore = makeMockStore();
+    mockUseMedicationRequestStore.mockReturnValue(mockStore);
+
+    await act(async () => {
+      render(
+        <SelectedMedicationRequestItem
+          entry={{ ...mockSelectedVaccination, isSTAT: true }}
+          medicationConfig={mockMedicationConfig}
+          inputControlType="vaccination"
+          attributes={[{ name: 'stat' }, { name: 'frequency' }]}
+        />,
+      );
+    });
+
+    expect(mockStore.updateFrequency).toHaveBeenCalledWith(
+      mockSelectedVaccination.id,
+      { uuid: '0', name: 'Immediately', frequencyPerDay: 1 },
+    );
+    expect(mockStore.updateDuration).toHaveBeenCalledWith(
+      mockSelectedVaccination.id,
+      0,
+    );
+    expect(mockStore.updateDurationUnit).toHaveBeenCalledWith(
+      mockSelectedVaccination.id,
+      null,
+    );
+    expect(mockStore.updateStartDate).toHaveBeenCalledWith(
+      mockSelectedVaccination.id,
+      expect.any(Date),
     );
   });
 

--- a/apps/clinical/src/components/forms/medicationRequest/__tests__/__snapshots__/SelectedMedicationRequestItem.test.tsx.snap
+++ b/apps/clinical/src/components/forms/medicationRequest/__tests__/__snapshots__/SelectedMedicationRequestItem.test.tsx.snap
@@ -187,8 +187,8 @@ exports[`SelectedMedicationRequestItem Snapshot matches snapshot with all attrib
       >
         <label
           class="cds--label cds--visually-hidden"
-          for="downshift-_r_3u_-toggle-button"
-          id="downshift-_r_3u_-label"
+          for="downshift-_r_42_-toggle-button"
+          id="downshift-_r_42_-label"
         >
           Dosage unit
         </label>
@@ -198,12 +198,12 @@ exports[`SelectedMedicationRequestItem Snapshot matches snapshot with all attrib
         >
           <button
             aria-activedescendant=""
-            aria-controls="downshift-_r_3u_-menu"
+            aria-controls="downshift-_r_42_-menu"
             aria-expanded="false"
             aria-haspopup="listbox"
             aria-label="Dosage Unit"
             class="cds--list-box__field"
-            id="downshift-_r_3u_-toggle-button"
+            id="downshift-_r_42_-toggle-button"
             role="combobox"
             tabindex="0"
             title="mg"
@@ -239,9 +239,9 @@ exports[`SelectedMedicationRequestItem Snapshot matches snapshot with all attrib
             </div>
           </button>
           <ul
-            aria-labelledby="downshift-_r_3u_-label"
+            aria-labelledby="downshift-_r_42_-label"
             class="cds--list-box__menu"
-            id="downshift-_r_3u_-menu"
+            id="downshift-_r_42_-menu"
             role="listbox"
             style="position: fixed; left: 0px; top: 0px; visibility: visible; transform: translate(0px, 0px); width: 0px;"
           />
@@ -257,8 +257,8 @@ exports[`SelectedMedicationRequestItem Snapshot matches snapshot with all attrib
       >
         <label
           class="cds--label cds--visually-hidden"
-          for="downshift-_r_41_-toggle-button"
-          id="downshift-_r_41_-label"
+          for="downshift-_r_45_-toggle-button"
+          id="downshift-_r_45_-label"
         >
           Frequency
         </label>
@@ -268,12 +268,12 @@ exports[`SelectedMedicationRequestItem Snapshot matches snapshot with all attrib
         >
           <button
             aria-activedescendant=""
-            aria-controls="downshift-_r_41_-menu"
+            aria-controls="downshift-_r_45_-menu"
             aria-expanded="false"
             aria-haspopup="listbox"
             aria-label="Frequency"
             class="cds--list-box__field"
-            id="downshift-_r_41_-toggle-button"
+            id="downshift-_r_45_-toggle-button"
             role="combobox"
             tabindex="0"
             title="BD"
@@ -309,9 +309,9 @@ exports[`SelectedMedicationRequestItem Snapshot matches snapshot with all attrib
             </div>
           </button>
           <ul
-            aria-labelledby="downshift-_r_41_-label"
+            aria-labelledby="downshift-_r_45_-label"
             class="cds--list-box__menu"
-            id="downshift-_r_41_-menu"
+            id="downshift-_r_45_-menu"
             role="listbox"
             style="position: fixed; left: 0px; top: 0px; visibility: visible; transform: translate(0px, 0px); width: 0px;"
           />
@@ -414,8 +414,8 @@ exports[`SelectedMedicationRequestItem Snapshot matches snapshot with all attrib
       >
         <label
           class="cds--label cds--visually-hidden"
-          for="downshift-_r_44_-toggle-button"
-          id="downshift-_r_44_-label"
+          for="downshift-_r_48_-toggle-button"
+          id="downshift-_r_48_-label"
         >
           Duration unit
         </label>
@@ -425,12 +425,12 @@ exports[`SelectedMedicationRequestItem Snapshot matches snapshot with all attrib
         >
           <button
             aria-activedescendant=""
-            aria-controls="downshift-_r_44_-menu"
+            aria-controls="downshift-_r_48_-menu"
             aria-expanded="false"
             aria-haspopup="listbox"
             aria-label="Duration Unit"
             class="cds--list-box__field"
-            id="downshift-_r_44_-toggle-button"
+            id="downshift-_r_48_-toggle-button"
             role="combobox"
             tabindex="0"
             title="d"
@@ -466,9 +466,9 @@ exports[`SelectedMedicationRequestItem Snapshot matches snapshot with all attrib
             </div>
           </button>
           <ul
-            aria-labelledby="downshift-_r_44_-label"
+            aria-labelledby="downshift-_r_48_-label"
             class="cds--list-box__menu"
-            id="downshift-_r_44_-menu"
+            id="downshift-_r_48_-menu"
             role="listbox"
             style="position: fixed; left: 0px; top: 0px; visibility: visible; transform: translate(0px, 0px); width: 0px;"
           />
@@ -484,8 +484,8 @@ exports[`SelectedMedicationRequestItem Snapshot matches snapshot with all attrib
       >
         <label
           class="cds--label cds--visually-hidden"
-          for="downshift-_r_47_-toggle-button"
-          id="downshift-_r_47_-label"
+          for="downshift-_r_4b_-toggle-button"
+          id="downshift-_r_4b_-label"
         >
           Instructions
         </label>
@@ -495,12 +495,12 @@ exports[`SelectedMedicationRequestItem Snapshot matches snapshot with all attrib
         >
           <button
             aria-activedescendant=""
-            aria-controls="downshift-_r_47_-menu"
+            aria-controls="downshift-_r_4b_-menu"
             aria-expanded="false"
             aria-haspopup="listbox"
-            aria-labelledby="downshift-_r_47_-label"
+            aria-labelledby="downshift-_r_4b_-label"
             class="cds--list-box__field"
-            id="downshift-_r_47_-toggle-button"
+            id="downshift-_r_4b_-toggle-button"
             role="combobox"
             tabindex="0"
             title="Instructions"
@@ -536,9 +536,9 @@ exports[`SelectedMedicationRequestItem Snapshot matches snapshot with all attrib
             </div>
           </button>
           <ul
-            aria-labelledby="downshift-_r_47_-label"
+            aria-labelledby="downshift-_r_4b_-label"
             class="cds--list-box__menu"
-            id="downshift-_r_47_-menu"
+            id="downshift-_r_4b_-menu"
             role="listbox"
             style="position: fixed; left: 0px; top: 0px; visibility: visible; transform: translate(0px, 0px); width: 0px;"
           />
@@ -554,8 +554,8 @@ exports[`SelectedMedicationRequestItem Snapshot matches snapshot with all attrib
       >
         <label
           class="cds--label cds--visually-hidden"
-          for="downshift-_r_4a_-toggle-button"
-          id="downshift-_r_4a_-label"
+          for="downshift-_r_4e_-toggle-button"
+          id="downshift-_r_4e_-label"
         >
           Route
         </label>
@@ -565,12 +565,12 @@ exports[`SelectedMedicationRequestItem Snapshot matches snapshot with all attrib
         >
           <button
             aria-activedescendant=""
-            aria-controls="downshift-_r_4a_-menu"
+            aria-controls="downshift-_r_4e_-menu"
             aria-expanded="false"
             aria-haspopup="listbox"
             aria-label="Route"
             class="cds--list-box__field"
-            id="downshift-_r_4a_-toggle-button"
+            id="downshift-_r_4e_-toggle-button"
             role="combobox"
             tabindex="0"
             title="Oral"
@@ -606,9 +606,9 @@ exports[`SelectedMedicationRequestItem Snapshot matches snapshot with all attrib
             </div>
           </button>
           <ul
-            aria-labelledby="downshift-_r_4a_-label"
+            aria-labelledby="downshift-_r_4e_-label"
             class="cds--list-box__menu"
-            id="downshift-_r_4a_-menu"
+            id="downshift-_r_4e_-menu"
             role="listbox"
             style="position: fixed; left: 0px; top: 0px; visibility: visible; transform: translate(0px, 0px); width: 0px;"
           />

--- a/apps/clinical/src/components/forms/medicationRequest/__tests__/__snapshots__/SelectedMedicationRequestItem.test.tsx.snap
+++ b/apps/clinical/src/components/forms/medicationRequest/__tests__/__snapshots__/SelectedMedicationRequestItem.test.tsx.snap
@@ -187,8 +187,8 @@ exports[`SelectedMedicationRequestItem Snapshot matches snapshot with all attrib
       >
         <label
           class="cds--label cds--visually-hidden"
-          for="downshift-_r_42_-toggle-button"
-          id="downshift-_r_42_-label"
+          for="downshift-_r_3u_-toggle-button"
+          id="downshift-_r_3u_-label"
         >
           Dosage unit
         </label>
@@ -198,12 +198,12 @@ exports[`SelectedMedicationRequestItem Snapshot matches snapshot with all attrib
         >
           <button
             aria-activedescendant=""
-            aria-controls="downshift-_r_42_-menu"
+            aria-controls="downshift-_r_3u_-menu"
             aria-expanded="false"
             aria-haspopup="listbox"
             aria-label="Dosage Unit"
             class="cds--list-box__field"
-            id="downshift-_r_42_-toggle-button"
+            id="downshift-_r_3u_-toggle-button"
             role="combobox"
             tabindex="0"
             title="mg"
@@ -239,9 +239,9 @@ exports[`SelectedMedicationRequestItem Snapshot matches snapshot with all attrib
             </div>
           </button>
           <ul
-            aria-labelledby="downshift-_r_42_-label"
+            aria-labelledby="downshift-_r_3u_-label"
             class="cds--list-box__menu"
-            id="downshift-_r_42_-menu"
+            id="downshift-_r_3u_-menu"
             role="listbox"
             style="position: fixed; left: 0px; top: 0px; visibility: visible; transform: translate(0px, 0px); width: 0px;"
           />
@@ -257,8 +257,8 @@ exports[`SelectedMedicationRequestItem Snapshot matches snapshot with all attrib
       >
         <label
           class="cds--label cds--visually-hidden"
-          for="downshift-_r_45_-toggle-button"
-          id="downshift-_r_45_-label"
+          for="downshift-_r_41_-toggle-button"
+          id="downshift-_r_41_-label"
         >
           Frequency
         </label>
@@ -268,12 +268,12 @@ exports[`SelectedMedicationRequestItem Snapshot matches snapshot with all attrib
         >
           <button
             aria-activedescendant=""
-            aria-controls="downshift-_r_45_-menu"
+            aria-controls="downshift-_r_41_-menu"
             aria-expanded="false"
             aria-haspopup="listbox"
             aria-label="Frequency"
             class="cds--list-box__field"
-            id="downshift-_r_45_-toggle-button"
+            id="downshift-_r_41_-toggle-button"
             role="combobox"
             tabindex="0"
             title="BD"
@@ -309,9 +309,9 @@ exports[`SelectedMedicationRequestItem Snapshot matches snapshot with all attrib
             </div>
           </button>
           <ul
-            aria-labelledby="downshift-_r_45_-label"
+            aria-labelledby="downshift-_r_41_-label"
             class="cds--list-box__menu"
-            id="downshift-_r_45_-menu"
+            id="downshift-_r_41_-menu"
             role="listbox"
             style="position: fixed; left: 0px; top: 0px; visibility: visible; transform: translate(0px, 0px); width: 0px;"
           />
@@ -414,8 +414,8 @@ exports[`SelectedMedicationRequestItem Snapshot matches snapshot with all attrib
       >
         <label
           class="cds--label cds--visually-hidden"
-          for="downshift-_r_48_-toggle-button"
-          id="downshift-_r_48_-label"
+          for="downshift-_r_44_-toggle-button"
+          id="downshift-_r_44_-label"
         >
           Duration unit
         </label>
@@ -425,12 +425,12 @@ exports[`SelectedMedicationRequestItem Snapshot matches snapshot with all attrib
         >
           <button
             aria-activedescendant=""
-            aria-controls="downshift-_r_48_-menu"
+            aria-controls="downshift-_r_44_-menu"
             aria-expanded="false"
             aria-haspopup="listbox"
             aria-label="Duration Unit"
             class="cds--list-box__field"
-            id="downshift-_r_48_-toggle-button"
+            id="downshift-_r_44_-toggle-button"
             role="combobox"
             tabindex="0"
             title="d"
@@ -466,9 +466,9 @@ exports[`SelectedMedicationRequestItem Snapshot matches snapshot with all attrib
             </div>
           </button>
           <ul
-            aria-labelledby="downshift-_r_48_-label"
+            aria-labelledby="downshift-_r_44_-label"
             class="cds--list-box__menu"
-            id="downshift-_r_48_-menu"
+            id="downshift-_r_44_-menu"
             role="listbox"
             style="position: fixed; left: 0px; top: 0px; visibility: visible; transform: translate(0px, 0px); width: 0px;"
           />
@@ -484,8 +484,8 @@ exports[`SelectedMedicationRequestItem Snapshot matches snapshot with all attrib
       >
         <label
           class="cds--label cds--visually-hidden"
-          for="downshift-_r_4b_-toggle-button"
-          id="downshift-_r_4b_-label"
+          for="downshift-_r_47_-toggle-button"
+          id="downshift-_r_47_-label"
         >
           Instructions
         </label>
@@ -495,12 +495,12 @@ exports[`SelectedMedicationRequestItem Snapshot matches snapshot with all attrib
         >
           <button
             aria-activedescendant=""
-            aria-controls="downshift-_r_4b_-menu"
+            aria-controls="downshift-_r_47_-menu"
             aria-expanded="false"
             aria-haspopup="listbox"
-            aria-labelledby="downshift-_r_4b_-label"
+            aria-labelledby="downshift-_r_47_-label"
             class="cds--list-box__field"
-            id="downshift-_r_4b_-toggle-button"
+            id="downshift-_r_47_-toggle-button"
             role="combobox"
             tabindex="0"
             title="Instructions"
@@ -536,9 +536,9 @@ exports[`SelectedMedicationRequestItem Snapshot matches snapshot with all attrib
             </div>
           </button>
           <ul
-            aria-labelledby="downshift-_r_4b_-label"
+            aria-labelledby="downshift-_r_47_-label"
             class="cds--list-box__menu"
-            id="downshift-_r_4b_-menu"
+            id="downshift-_r_47_-menu"
             role="listbox"
             style="position: fixed; left: 0px; top: 0px; visibility: visible; transform: translate(0px, 0px); width: 0px;"
           />
@@ -554,8 +554,8 @@ exports[`SelectedMedicationRequestItem Snapshot matches snapshot with all attrib
       >
         <label
           class="cds--label cds--visually-hidden"
-          for="downshift-_r_4e_-toggle-button"
-          id="downshift-_r_4e_-label"
+          for="downshift-_r_4a_-toggle-button"
+          id="downshift-_r_4a_-label"
         >
           Route
         </label>
@@ -565,12 +565,12 @@ exports[`SelectedMedicationRequestItem Snapshot matches snapshot with all attrib
         >
           <button
             aria-activedescendant=""
-            aria-controls="downshift-_r_4e_-menu"
+            aria-controls="downshift-_r_4a_-menu"
             aria-expanded="false"
             aria-haspopup="listbox"
             aria-label="Route"
             class="cds--list-box__field"
-            id="downshift-_r_4e_-toggle-button"
+            id="downshift-_r_4a_-toggle-button"
             role="combobox"
             tabindex="0"
             title="Oral"
@@ -606,9 +606,9 @@ exports[`SelectedMedicationRequestItem Snapshot matches snapshot with all attrib
             </div>
           </button>
           <ul
-            aria-labelledby="downshift-_r_4e_-label"
+            aria-labelledby="downshift-_r_4a_-label"
             class="cds--list-box__menu"
-            id="downshift-_r_4e_-menu"
+            id="downshift-_r_4a_-menu"
             role="listbox"
             style="position: fixed; left: 0px; top: 0px; visibility: visible; transform: translate(0px, 0px); width: 0px;"
           />

--- a/apps/clinical/src/components/forms/medicationRequest/__tests__/store.test.ts
+++ b/apps/clinical/src/components/forms/medicationRequest/__tests__/store.test.ts
@@ -97,10 +97,22 @@ describe('useMedicationRequestStore', () => {
       });
     });
 
-    it('defaults isSTAT to false for medications key', () => {
-      store().addItem(mockMedication, 'Paracetamol 500mg');
-      expect(store().selectedMedicationRequests[0].isSTAT).toBe(false);
-    });
+    it.each(['medication', 'vaccination'] as const)(
+      'defaults isSTAT to false for "%s" key when no stat default is configured',
+      (key) => {
+        getMedicationRequestStore(key).getState().reset();
+        getMedicationRequestStore(key)
+          .getState()
+          .setAttributes(mockRequiredMedicationAttributes);
+        getMedicationRequestStore(key)
+          .getState()
+          .addItem(mockMedication, 'Paracetamol 500mg');
+        expect(
+          getMedicationRequestStore(key).getState()
+            .selectedMedicationRequests[0].isSTAT,
+        ).toBe(false);
+      },
+    );
 
     it('applies attribute defaults for dosage, stat, prn, and note on addItem', () => {
       store().reset();

--- a/apps/clinical/src/components/forms/medicationRequest/__tests__/store.test.ts
+++ b/apps/clinical/src/components/forms/medicationRequest/__tests__/store.test.ts
@@ -102,11 +102,6 @@ describe('useMedicationRequestStore', () => {
       expect(store().selectedMedicationRequests[0].isSTAT).toBe(false);
     });
 
-    it('defaults isSTAT to true for vaccinations key', () => {
-      vacStore().addItem(mockVaccination, 'COVID-19 Vaccine');
-      expect(vacStore().selectedMedicationRequests[0].isSTAT).toBe(true);
-    });
-
     it('applies attribute defaults for dosage, stat, prn, and note on addItem', () => {
       store().reset();
       store().setAttributes(mockMedicationAttributesWithDefaults);
@@ -430,7 +425,12 @@ describe('useMedicationRequestStore', () => {
   });
 
   describe('validateAll - vaccinations', () => {
-    it('does not require duration or durationUnit for vaccinations', () => {
+    it('does not require duration or durationUnit for vaccinations when stat is defaulted to true', () => {
+      vacStore().setAttributes(
+        mockRequiredMedicationAttributes.map((a) =>
+          a.name === 'stat' ? { ...a, default: true } : a,
+        ),
+      );
       vacStore().addItem(mockVaccination, 'COVID-19 Vaccine');
 
       vacStore().validateAll();

--- a/apps/clinical/src/components/forms/medicationRequest/__tests__/utils.test.ts
+++ b/apps/clinical/src/components/forms/medicationRequest/__tests__/utils.test.ts
@@ -77,6 +77,22 @@ describe('applyDefaultFrequency', () => {
     );
     expect(updateFrequency).not.toHaveBeenCalled();
   });
+
+  it('applies default frequency when default matches an immediate frequency', () => {
+    const updateFrequency = jest.fn();
+    applyDefaultFrequency(
+      [{ name: 'frequency', default: 'Immediately' }],
+      mockMedicationConfig,
+      null,
+      'id',
+      updateFrequency,
+    );
+    expect(updateFrequency).toHaveBeenCalledWith('id', {
+      uuid: '0',
+      name: 'Immediately',
+      frequencyPerDay: 1,
+    });
+  });
 });
 
 describe('applyDefaultInstruction', () => {

--- a/apps/clinical/src/components/forms/medicationRequest/__tests__/utils.test.ts
+++ b/apps/clinical/src/components/forms/medicationRequest/__tests__/utils.test.ts
@@ -54,28 +54,24 @@ describe('applyDefaultFrequency', () => {
     });
   });
 
-  it.each([
-    [
-      'does nothing when frequency is already set',
-      { uuid: 'bd-uuid', name: 'BD', frequencyPerDay: 2 },
-      [{ name: 'frequency', default: 'BD' }],
-    ],
-    [
-      'does nothing when no default configured on the attribute',
-      null,
-      [{ name: 'frequency' }],
-    ],
-    [
-      'does nothing when default name matches an immediate frequency',
-      null,
-      [{ name: 'frequency', default: 'Immediately' }],
-    ],
-  ])('%s', (_, frequency, attrs) => {
+  it('does nothing when frequency is already set', () => {
     const updateFrequency = jest.fn();
     applyDefaultFrequency(
-      attrs,
+      [{ name: 'frequency', default: 'BD' }],
       mockMedicationConfig,
-      frequency,
+      { uuid: 'bd-uuid', name: 'BD', frequencyPerDay: 2 },
+      'id',
+      updateFrequency,
+    );
+    expect(updateFrequency).not.toHaveBeenCalled();
+  });
+
+  it('does nothing when no default configured on the attribute', () => {
+    const updateFrequency = jest.fn();
+    applyDefaultFrequency(
+      [{ name: 'frequency' }],
+      mockMedicationConfig,
+      null,
       'id',
       updateFrequency,
     );

--- a/apps/clinical/src/components/forms/medicationRequest/components/SelectedMedicationRequestItem.tsx
+++ b/apps/clinical/src/components/forms/medicationRequest/components/SelectedMedicationRequestItem.tsx
@@ -287,7 +287,7 @@ const SelectedMedicationRequestItem: React.FC<SelectedMedicationRequestItemProps
                 )}
                 aria-label="Frequency"
                 hideLabel
-                items={medicationConfig.frequencies ?? []}
+                items={medicationConfig.frequencies}
                 itemToString={(item) => (item ? item.name : '')}
                 selectedItem={frequency}
                 onChange={(e) => {

--- a/apps/clinical/src/components/forms/medicationRequest/components/SelectedMedicationRequestItem.tsx
+++ b/apps/clinical/src/components/forms/medicationRequest/components/SelectedMedicationRequestItem.tsx
@@ -113,8 +113,6 @@ const SelectedMedicationRequestItem: React.FC<SelectedMedicationRequestItemProps
         updateDuration(id, 0);
         updateDurationUnit(id, null);
         updateStartDate(id, getTodayDate());
-      } else {
-        updateFrequency(id, null);
       }
     }, [
       isSTAT,
@@ -289,11 +287,7 @@ const SelectedMedicationRequestItem: React.FC<SelectedMedicationRequestItemProps
                 )}
                 aria-label="Frequency"
                 hideLabel
-                items={
-                  medicationConfig.frequencies.filter(
-                    (item) => !isImmediateFrequency(item),
-                  ) ?? []
-                }
+                items={medicationConfig.frequencies ?? []}
                 itemToString={(item) => (item ? item.name : '')}
                 selectedItem={frequency}
                 onChange={(e) => {

--- a/apps/clinical/src/components/forms/medicationRequest/store.ts
+++ b/apps/clinical/src/components/forms/medicationRequest/store.ts
@@ -332,7 +332,7 @@ function createMedicationRequestStore(key: MedicationRequestStoreKey) {
         route: null,
         duration: !statDefault && durationDefault ? Number(durationDefault) : 0,
         durationUnit: null,
-        isSTAT: statDefault === true || !isMedicationRequest,
+        isSTAT: statDefault === true,
         isPRN: prnDefault === true,
         startDate: new Date(),
         instruction: null,

--- a/apps/clinical/src/components/forms/medicationRequest/utils.ts
+++ b/apps/clinical/src/components/forms/medicationRequest/utils.ts
@@ -82,7 +82,7 @@ export function applyDefaultFrequency(
   if (!medicationConfig?.frequencies?.length || !defaultValue || frequency)
     return;
   const defaultFrequency = medicationConfig.frequencies.find(
-    (item) => item.name === defaultValue && !isImmediateFrequency(item),
+    (item) => item.name === defaultValue,
   );
   if (defaultFrequency) updateFrequency(id, defaultFrequency);
 }


### PR DESCRIPTION
JIRA → [BAH-4721](https://bahmni.atlassian.net/browse/BAH-4721)

 ## Description

Removes hardcoded vaccination-specific behaviour from the MedicationRequest form. Previously, isSTAT was forced to true for vaccinations regardless of configuration, and the frequency dropdown excluded "immediate" frequencies when STAT was active. These assumptions are now driven purely by attribute configuration (i.e. stat.default = true), making the form consistent across all input control types.

[BAH-4721]: https://bahmni.atlassian.net/browse/BAH-4721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Medication duration, duration unit, and start date now reset when toggling STAT/PRN; immediate frequencies are available in the frequency dropdown and can be applied as defaults.
  * New entries inherit STAT only from configured defaults (STAT no longer forced on creation).

* **Tests**
  * Updated STAT defaulting tests to reflect configurable defaults (STAT defaults to false unless configured).
  * Added/adjusted vaccination and default-frequency tests to verify immediate-frequency, duration, and start-date behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Bahmni/bahmni-apps-frontend/pull/429?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->