### PR TITLE
BAH-4552 | Add. Medication Table to refresh when immunizations are updated

### DIFF
--- a/packages/bahmni-widgets/src/medications/MedicationsTable.tsx
+++ b/packages/bahmni-widgets/src/medications/MedicationsTable.tsx
@@ -136,7 +136,8 @@ const MedicationsTable: React.FC<WidgetProps> = ({
       // 2. Medications were modified during consultation
       if (
         payload.patientUUID === patientUUID &&
-        payload.updatedResources.medications
+        (payload.updatedResources.medications ||
+          payload.updatedResources.immunizationHistory)
       ) {
         refetch();
       }

--- a/packages/bahmni-widgets/src/medications/MedicationsTable.tsx
+++ b/packages/bahmni-widgets/src/medications/MedicationsTable.tsx
@@ -128,12 +128,8 @@ const MedicationsTable: React.FC<WidgetProps> = ({
     }
   }, [isError, error, addNotification]);
 
-  // Listen to consultation saved events and refetch if medications were updated
   useSubscribeConsultationSaved(
     (payload: ConsultationSavedEventPayload) => {
-      // Only refetch if:
-      // 1. Event is for the same patient
-      // 2. Medications were modified during consultation
       if (
         payload.patientUUID === patientUUID &&
         (payload.updatedResources.medications ||

--- a/packages/bahmni-widgets/src/medications/__tests__/MedicationsTable.test.tsx
+++ b/packages/bahmni-widgets/src/medications/__tests__/MedicationsTable.test.tsx
@@ -1,8 +1,10 @@
 import {
+  ConsultationSavedEventPayload,
   formatDateTime,
   groupByDate,
   MedicationRequest,
   MedicationStatus,
+  useSubscribeConsultationSaved,
   useTranslation,
 } from '@bahmni/services';
 import { useQuery } from '@tanstack/react-query';
@@ -83,6 +85,10 @@ const mockGroupByDate = groupByDate as jest.MockedFunction<typeof groupByDate>;
 const mockUseUserPrivilege = useUserPrivilege as jest.MockedFunction<
   typeof useUserPrivilege
 >;
+const mockUseSubscribeConsultationSaved =
+  useSubscribeConsultationSaved as jest.MockedFunction<
+    typeof useSubscribeConsultationSaved
+  >;
 
 const mockMedications: MedicationRequest[] = [
   {
@@ -769,5 +775,84 @@ describe('MedicationsTable', () => {
       expect(screen.getByText('STAT')).toBeInTheDocument();
       expect(screen.getByText('IV Injection | 1 vial')).toBeInTheDocument();
     });
+  });
+
+  describe('Consultation saved event subscription', () => {
+    it.each([
+      {
+        description: 'same patient with medications updated',
+        payload: {
+          patientUUID: 'patient-uuid-123',
+          updatedResources: { medications: true },
+        } as unknown as ConsultationSavedEventPayload,
+        expectedCallCount: 1,
+      },
+      {
+        description: 'same patient with immunizationHistory updated',
+        payload: {
+          patientUUID: 'patient-uuid-123',
+          updatedResources: { immunizationHistory: true },
+        } as unknown as ConsultationSavedEventPayload,
+        expectedCallCount: 1,
+      },
+      {
+        description:
+          'same patient with both medications and immunizationHistory updated',
+        payload: {
+          patientUUID: 'patient-uuid-123',
+          updatedResources: { medications: true, immunizationHistory: true },
+        } as unknown as ConsultationSavedEventPayload,
+        expectedCallCount: 1,
+      },
+      {
+        description:
+          'same patient with neither medications nor immunizationHistory updated',
+        payload: {
+          patientUUID: 'patient-uuid-123',
+          updatedResources: {
+            medications: false,
+            immunizationHistory: false,
+          },
+        } as unknown as ConsultationSavedEventPayload,
+        expectedCallCount: 0,
+      },
+      {
+        description: 'different patient with medications updated',
+        payload: {
+          patientUUID: 'other-uuid',
+          updatedResources: { medications: true },
+        } as unknown as ConsultationSavedEventPayload,
+        expectedCallCount: 0,
+      },
+      {
+        description: 'different patient with immunizationHistory updated',
+        payload: {
+          patientUUID: 'other-uuid',
+          updatedResources: { immunizationHistory: true },
+        } as unknown as ConsultationSavedEventPayload,
+        expectedCallCount: 0,
+      },
+    ])(
+      'ConsultationSaved — $description: refetch called $expectedCallCount time(s)',
+      ({ payload, expectedCallCount }) => {
+        const refetch = jest.fn();
+        mockUseQuery.mockReturnValue({
+          data: [],
+          isLoading: false,
+          isError: false,
+          error: null,
+          refetch,
+        } as any);
+        mockUseSubscribeConsultationSaved.mockImplementation(
+          (callback: (payload: ConsultationSavedEventPayload) => void) => {
+            callback(payload);
+          },
+        );
+
+        render(<MedicationsTable />);
+
+        expect(refetch).toHaveBeenCalledTimes(expectedCallCount);
+      },
+    );
   });
 });


### PR DESCRIPTION
**JIRA** → [BAH-4552](https://bahmni.atlassian.net/browse/BAH-4552)

### **Description**
This PR adds a trigger for the MedicationRequest Table to reload when immunization resources are updated. This is needed so that when immunization orders are administered, their status will get updated automatically without a page refresh.

---



### **Implementation Details**
- Add immunizationHistory as an additional resource to check for MedicationRequest refetch.


> [!IMPORTANT]
> **Checklist**
>
> - [x] Code adheres to project linting and formatting standards.
> - [x] New components added to Storybook.
> - [x] Tests written and passing (unit + integration).
> - [x] Labels and text support i18n.
> - [x] Follows accessibility and responsive design guidelines.
> - [x] PR reviewed by at least one other developer.

---

### **Reviewer(s)**

@bahnew/developers 
_Kindly review the proposed changes when convenient. Your feedback is appreciated._

---


[BAH-4552]: https://bahmni.atlassian.net/browse/BAH-4552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Medications table now refreshes when immunization history is updated, keeping related patient data in sync.

* **Tests**
  * Added test coverage for consultation saved event handling scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Bahmni/bahmni-apps-frontend/pull/433?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->