### PR TITLE
BAH-4672 | Fix. Align Side Panel Icons And Labels

### DIFF
--- a/packages/bahmni-design-system/src/molecules/icon/Icon.tsx
+++ b/packages/bahmni-design-system/src/molecules/icon/Icon.tsx
@@ -12,6 +12,7 @@ export interface IconProps {
   ariaLabel?: string;
   padding?: ICON_PADDING;
   testId?: string;
+  fixedWidth?: boolean;
 }
 
 /**
@@ -26,6 +27,7 @@ export interface IconProps {
  * @param {string} [props.ariaLabel] - Accessibility label (defaults to id if not provided)
  * @param {ICON_PADDING} [props.padding=ICON_PADDING.XXSMALL] - Padding around the icon from ICON_PADDING enum
  * @param {string} [props.testId] - Test identifier for testing purposes
+ * @param {boolean} [props.fixedWidth=false] - When true, forces the icon to render at a consistent fixed width (FontAwesome fa-fw). Use in navigation lists to align icons and labels.
  * @returns {React.ReactElement} React component
  */
 const getPaddingClass = (padding: ICON_PADDING): string => {
@@ -53,6 +55,7 @@ export const Icon: React.FC<IconProps> = ({
   ariaLabel = id,
   padding = ICON_PADDING.XXSMALL,
   testId,
+  fixedWidth = false,
 }) => {
   const paddingClass = getPaddingClass(padding);
 
@@ -72,6 +75,7 @@ export const Icon: React.FC<IconProps> = ({
         icon={['fas', name as IconName]}
         size={size}
         color={color}
+        fixedWidth={fixedWidth}
         data-testid={id}
       />
     </span>

--- a/packages/bahmni-design-system/src/molecules/icon/__tests__/Icon.test.tsx
+++ b/packages/bahmni-design-system/src/molecules/icon/__tests__/Icon.test.tsx
@@ -8,13 +8,14 @@ expect.extend(toHaveNoViolations);
 
 // Mock FontAwesomeIcon and pass props to the rendered element
 jest.mock('@fortawesome/react-fontawesome', () => ({
-  FontAwesomeIcon: ({ icon, size, color, ...props }: any) => (
+  FontAwesomeIcon: ({ icon, size, color, fixedWidth, ...props }: any) => (
     <svg
       data-testid={props['data-testid']}
       data-icon={icon[1]}
       data-prefix={icon[0]}
       data-size={size}
       data-color={color}
+      data-fixed-width={fixedWidth}
       {...props}
     />
   ),
@@ -79,6 +80,18 @@ describe('Icon Component', () => {
       <BahmniIcon name="invalid-name-format" id="invalid-icon" />,
     );
     expect(icon.container).toBeEmptyDOMElement();
+  });
+
+  it('forwards fixedWidth prop to FontAwesomeIcon', () => {
+    render(<BahmniIcon name="fa-home" id="fw-icon" fixedWidth />);
+    const icon = screen.getByTestId('fw-icon');
+    expect(icon).toHaveAttribute('data-fixed-width', 'true');
+  });
+
+  it('does not set data-fixed-width when fixedWidth is not passed', () => {
+    render(<BahmniIcon name="fa-home" id="no-fw-icon" />);
+    const icon = screen.getByTestId('no-fw-icon');
+    expect(icon).not.toHaveAttribute('data-fixed-width', 'true');
   });
 
   describe('Accessibility', () => {

--- a/packages/bahmni-design-system/src/organisms/header/Header.tsx
+++ b/packages/bahmni-design-system/src/organisms/header/Header.tsx
@@ -101,6 +101,7 @@ export const Header: React.FC<HeaderProps> = React.memo(
                     name={item.icon}
                     id={`sidebar-icon-${item.id}`}
                     size={ICON_SIZE.LG}
+                    fixedWidth
                   />
                 )}
                 href={item.href ?? '#'}


### PR DESCRIPTION
## Summary
- Side-nav rows rendered FontAwesome icons at their natural advance widths, so labels next to icons like `fa-pills` / `fa-heart-pulse` shifted a few pixels right vs. narrower icons. The text column appeared ragged in both standard-config and clinic-config patient dashboards.
- Added an opt-in `fixedWidth` prop to the shared `Icon` component and enabled it for the side-nav usage in `Header.tsx`. Every side-nav icon now occupies the same horizontal space and labels align in a single column.

## Why
JIRA: [BAH-4672](https://bahmni.atlassian.net/browse/BAH-4672). Observation raised during BAH-4672 work: side panel icons/labels are not aligned. This change keeps the fix scoped to the side-nav (other `Icon` usages are unaffected because `fixedWidth` defaults to `false`).

## Test plan
- [x] Added unit tests covering `fixedWidth` being forwarded to `FontAwesomeIcon` (and not set when omitted)
- [x] Full `@bahmni/design-system` Jest suite: 295 tests / 28 suites passing
- [x] Manual verification at `localhost:3000/bahmni-new/clinical/<patient>` — icon column is uniform; labels align across all sections in both standard-config and clinic-config

Re-raised from #419 as a direct branch (non-fork) so SonarCloud analysis can run.

[BAH-4672]: https://bahmni.atlassian.net/browse/BAH-4672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Icon component supports an optional fixed-width mode for consistent alignment.
  * Header side navigation icons now use fixed-width formatting, improving spacing and visual alignment.

* **Tests**
  * Unit tests updated to verify fixed-width behavior is forwarded and rendered correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->