### PR TITLE
BAH-4745 | Fix. Medication Instruction Pipe Symbol Only Shown For Multiple Items

### DIFF
--- a/packages/bahmni-widgets/src/medications/__tests__/utils.test.ts
+++ b/packages/bahmni-widgets/src/medications/__tests__/utils.test.ts
@@ -226,6 +226,94 @@ describe('formatMedicationRequest', () => {
       'oral | Take with meals | Monitor blood sugar levels',
     );
   });
+
+  it('shows route only with no pipe when instructions and additionalInstructions are absent', () => {
+    const input: MedicationRequest = {
+      id: '1001',
+      name: 'Aspirin',
+      status: MedicationStatus.Active,
+      quantity: { value: 10, unit: 'tablets' },
+      priority: '',
+      startDate: '',
+      orderDate: '',
+      orderedBy: '',
+      instructions: '',
+      route: 'oral',
+      asNeeded: false,
+      isImmediate: false,
+      fhirResource: fhirMedicationRequestMock,
+    };
+
+    const result = formatMedicationRequest(input);
+
+    expect(result.instruction).toBe('oral');
+  });
+
+  it('shows instructions only with no pipe when route and additionalInstructions are absent', () => {
+    const input: MedicationRequest = {
+      id: '1002',
+      name: 'Aspirin',
+      status: MedicationStatus.Active,
+      quantity: { value: 10, unit: 'tablets' },
+      priority: '',
+      startDate: '',
+      orderDate: '',
+      orderedBy: '',
+      instructions: 'Take with food',
+      asNeeded: false,
+      isImmediate: false,
+      fhirResource: fhirMedicationRequestMock,
+    };
+
+    const result = formatMedicationRequest(input);
+
+    expect(result.instruction).toBe('Take with food');
+  });
+
+  it('shows additionalInstructions only with no pipe when route and instructions are absent', () => {
+    const input: MedicationRequest = {
+      id: '1003',
+      name: 'Aspirin',
+      status: MedicationStatus.Active,
+      quantity: { value: 10, unit: 'tablets' },
+      priority: '',
+      startDate: '',
+      orderDate: '',
+      orderedBy: '',
+      instructions: '',
+      additionalInstructions: 'Monitor blood sugar levels',
+      asNeeded: false,
+      isImmediate: false,
+      fhirResource: fhirMedicationRequestMock,
+    };
+
+    const result = formatMedicationRequest(input);
+
+    expect(result.instruction).toBe('Monitor blood sugar levels');
+  });
+
+  it('joins route and additionalInstructions with single pipe when instructions is empty', () => {
+    const input: MedicationRequest = {
+      id: '1004',
+      name: 'Aspirin',
+      status: MedicationStatus.Active,
+      quantity: { value: 10, unit: 'tablets' },
+      priority: '',
+      startDate: '',
+      orderDate: '',
+      orderedBy: '',
+      instructions: '',
+      route: 'oral',
+      additionalInstructions: 'Monitor blood sugar levels',
+      asNeeded: false,
+      isImmediate: false,
+      fhirResource: fhirMedicationRequestMock,
+    };
+
+    const result = formatMedicationRequest(input);
+
+    expect(result.instruction).toBe('oral | Monitor blood sugar levels');
+  });
 });
 
 describe('getMedicationStatusPriority', () => {

--- a/packages/bahmni-widgets/src/medications/utils.ts
+++ b/packages/bahmni-widgets/src/medications/utils.ts
@@ -153,7 +153,9 @@ export function formatMedicationRequest(
   if (route) {
     instructionParts.push(route);
   }
-  instructionParts.push(instructions);
+  if (instructions) {
+    instructionParts.push(instructions);
+  }
   if (additionalInstructions) {
     instructionParts.push(additionalInstructions);
   }


### PR DESCRIPTION
**JIRA**: [BAH-4745](https://bahmni.atlassian.net/browse/BAH-4745)

## What Changed
- `packages/bahmni-widgets/src/medications/utils.ts`: guarded the `instructions` push inside `formatMedicationRequest`, matching the existing guard pattern used for `route` and `additionalInstructions`.
- `packages/bahmni-widgets/src/medications/__tests__/utils.test.ts`: added unit tests covering single-item instruction scenarios.

## Why
Per BAH-4745: the medication instruction display previously rendered spurious pipes (e.g. `"oral | "`, `" | Monitor blood sugar levels"`) when one of `{route, instructions, additionalInstructions}` was missing. With the guard in place, the existing `Array.prototype.join` naturally produces a pipe only between two or more items.

## How Tested
- [x] Unit tests added/updated (4 new test cases covering single-item scenarios)
- [x] All medication util tests passing (31/31)
- [ ] Manual testing performed (not applicable — pure data-formatting unit covered by tests)

## Acceptance Criteria Met
- [x] Items joined by ` | ` when 2+ exist
- [x] Single item rendered with no surrounding pipe
- [x] No items → empty string (existing behavior preserved)

## Note for Reviewers
The `@bahmni/distro:test` may show `Cannot find module '@bahmni/home-app'` on CI — this is a pre-existing upstream breakage from the recent `apps/home` package split on `main` and is unrelated to this change. This PR only touches `packages/bahmni-widgets/src/medications/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BAH-4745]: https://bahmni.atlassian.net/browse/BAH-4745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed medication instruction display to prevent undefined text from appearing when instruction components are missing. The instruction field now correctly formats instructions, additional instructions, and route information only when present.

* **Tests**
  * Added test cases for medication instruction formatting across various scenarios, including when individual components or combinations are provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->