### PR TITLE
BAH-4760 | Fix. CSS Bleed Caused By Missing Hash Policy And Scoping

### DIFF
--- a/apps/appointments/vite.config.ts
+++ b/apps/appointments/vite.config.ts
@@ -15,6 +15,11 @@ export default defineConfig(() => ({
     }),
   ],
   publicDir: 'public',
+  css: {
+    modules: process.env['VITEST'] ? {} : {
+      generateScopedName: '[name]_[local]__[hash:base64:5]',
+    },
+  },
   build: {
     outDir: './dist',
     emptyOutDir: true,
@@ -30,7 +35,13 @@ export default defineConfig(() => ({
       formats: ['es' as const],
     },
     rollupOptions: {
-      external: ['react', 'react-dom', 'react/jsx-runtime', 'react-router-dom'],
+      external: [
+        'react',
+        'react-dom',
+        'react/jsx-runtime',
+        'react-router-dom',
+        /^@carbon\/styles/
+      ],
     },
   },
 }));

--- a/apps/appointments/vite.config.ts
+++ b/apps/appointments/vite.config.ts
@@ -40,6 +40,7 @@ export default defineConfig(() => ({
         'react-dom',
         'react/jsx-runtime',
         'react-router-dom',
+        '@tanstack/react-query',
         /^@carbon\/styles/
       ],
     },

--- a/apps/clinical/vite.config.ts
+++ b/apps/clinical/vite.config.ts
@@ -49,6 +49,7 @@ export default defineConfig(() => ({
         'react-dom',
         'react/jsx-runtime',
         'react-router-dom',
+        '@tanstack/react-query',
         /^@carbon\/styles/
       ],
     },

--- a/apps/clinical/vite.config.ts
+++ b/apps/clinical/vite.config.ts
@@ -2,7 +2,7 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import dts from 'vite-plugin-dts';
-import * as path from 'path';
+import * as path from 'node:path';
 
 export default defineConfig(() => ({
   root: __dirname,
@@ -15,6 +15,11 @@ export default defineConfig(() => ({
       tsconfigPath: path.join(__dirname, 'tsconfig.lib.json'),
     }),
   ],
+  css: {
+    modules: process.env['VITEST'] ? {} : {
+      generateScopedName: '[name]_[local]__[hash:base64:5]',
+    },
+  },
   // Uncomment this if you are using workers.
   // worker: {
   //  plugins: [ nxViteTsPaths() ],
@@ -39,8 +44,13 @@ export default defineConfig(() => ({
       formats: ['es' as const],
     },
     rollupOptions: {
-      // External packages that should not be bundled into your library.
-      external: ['react', 'react-dom', 'react/jsx-runtime', 'react-router-dom'],
+      external: [
+        'react',
+        'react-dom',
+        'react/jsx-runtime',
+        'react-router-dom',
+        /^@carbon\/styles/
+      ],
     },
   },
 }));

--- a/apps/home/vite.config.ts
+++ b/apps/home/vite.config.ts
@@ -8,6 +8,11 @@ export default defineConfig(() => ({
   root: __dirname,
   cacheDir: '../../node_modules/.vite/apps/home',
   publicDir: 'public',
+  css: {
+    modules: process.env['VITEST'] ? {} : {
+      generateScopedName: '[name]_[local]__[hash:base64:5]',
+    },
+  },
   plugins: [
     react(),
     dts({
@@ -28,7 +33,14 @@ export default defineConfig(() => ({
       formats: ['es' as const],
     },
     rollupOptions: {
-      external: ['react', 'react-dom', 'react/jsx-runtime', 'react-router-dom', '@tanstack/react-query'],
+      external: [
+        'react',
+        'react-dom',
+        'react/jsx-runtime',
+        'react-router-dom',
+        '@tanstack/react-query',
+        /^@carbon\/styles/
+      ],
     },
   },
 }));

--- a/apps/registration/vite.config.ts
+++ b/apps/registration/vite.config.ts
@@ -2,7 +2,7 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import dts from 'vite-plugin-dts';
-import * as path from 'path';
+import * as path from 'node:path';
 
 export default defineConfig(() => ({
   root: __dirname,
@@ -15,6 +15,11 @@ export default defineConfig(() => ({
       tsconfigPath: path.join(__dirname, 'tsconfig.lib.json'),
     }),
   ],
+  css: {
+    modules: process.env['VITEST'] ? {} : {
+      generateScopedName: '[name]_[local]__[hash:base64:5]',
+    },
+  },
   // Uncomment this if you are using workers.
   // worker: {
   //  plugins: [ nxViteTsPaths() ],
@@ -39,13 +44,13 @@ export default defineConfig(() => ({
       formats: ['es' as const],
     },
     rollupOptions: {
-      // External packages that should not be bundled into your library.
       external: [
         'react',
         'react-dom',
         'react/jsx-runtime',
         'react-router-dom',
         '@tanstack/react-query',
+        /^@carbon\/styles/,
       ],
     },
   },

--- a/packages/bahmni-design-system/src/index.ts
+++ b/packages/bahmni-design-system/src/index.ts
@@ -1,5 +1,3 @@
-import '@carbon/styles/css/styles.css';
-
 export {
   applyBahmniTheme,
   BAHMNI_DEFAULT_THEME,

--- a/packages/bahmni-design-system/src/index.ts
+++ b/packages/bahmni-design-system/src/index.ts
@@ -1,3 +1,5 @@
+import '@carbon/styles/css/styles.css';
+
 export {
   applyBahmniTheme,
   BAHMNI_DEFAULT_THEME,

--- a/packages/bahmni-design-system/vite.config.ts
+++ b/packages/bahmni-design-system/vite.config.ts
@@ -2,7 +2,7 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import dts from 'vite-plugin-dts';
-import * as path from 'path';
+import * as path from 'node:path';
 
 export default defineConfig(() => ({
   root: __dirname,
@@ -37,8 +37,13 @@ export default defineConfig(() => ({
       formats: ['es' as const],
     },
     rollupOptions: {
-      // External packages that should not be bundled into your library.
-      external: ['react', 'react-dom', 'react/jsx-runtime'],
+      external: [
+        'react',
+        'react-dom',
+        'react/jsx-runtime',
+        'react-router-dom',
+        /^@carbon\/styles/
+      ],
     },
   },
 }));

--- a/packages/bahmni-widgets/vite.config.ts
+++ b/packages/bahmni-widgets/vite.config.ts
@@ -2,7 +2,7 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import dts from 'vite-plugin-dts';
-import * as path from 'path';
+import * as path from 'node:path';
 
 export default defineConfig(() => ({
   root: __dirname,
@@ -14,6 +14,11 @@ export default defineConfig(() => ({
       tsconfigPath: path.join(__dirname, 'tsconfig.lib.json'),
     }),
   ],
+  css: {
+    modules: process.env['VITEST'] ? {} : {
+      generateScopedName: '[name]_[local]__[hash:base64:5]',
+    },
+  },
   // Uncomment this if you are using workers.
   // worker: {
   //  plugins: [ nxViteTsPaths() ],
@@ -37,7 +42,6 @@ export default defineConfig(() => ({
       formats: ['es' as const],
     },
     rollupOptions: {
-      // External packages that should not be bundled into your library.
       external: [
         'react',
         'react-dom',
@@ -45,6 +49,7 @@ export default defineConfig(() => ({
         'react-router-dom',
         'react-i18next',
         '@tanstack/react-query',
+        /^@carbon\/styles/,
       ],
     },
   },

--- a/scripts/create-app.js
+++ b/scripts/create-app.js
@@ -283,6 +283,11 @@ export default defineConfig(() => ({
     }),
   ],
   publicDir: 'public',
+  css: {
+    modules: {
+      generateScopedName: '[name]_[local]__[hash:base64:5]',
+    },
+  },
   build: {
     outDir: './dist',
     emptyOutDir: true,
@@ -298,7 +303,13 @@ export default defineConfig(() => ({
       formats: ['es' as const],
     },
     rollupOptions: {
-      external: ['react', 'react-dom', 'react/jsx-runtime', 'react-router-dom'],
+      external: [
+        'react',
+        'react-dom',
+        'react/jsx-runtime',
+        'react-router-dom',
+        /^@carbon\/styles/
+      ],
     },
   },
 }));

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -11,7 +11,7 @@ sonar.javascript.lcov.reportPaths=test-output/jest/coverage/lcov.info
 
 sonar.coverage.exclusions=**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx,**/stories/**,**/__mocks__/**
 
-sonar.exclusions=apps/clinical/setupTests.ts,apps/clinical/setupTests.i18n.ts,apps/home/setupTests.ts,apps/home/setupTests.i18n.ts,apps/appointments/setupTests.ts
+sonar.exclusions=apps/clinical/setupTests.ts,apps/clinical/setupTests.i18n.ts,apps/home/setupTests.ts,apps/home/setupTests.i18n.ts,apps/appointments/setupTests.ts,**/vite.config.ts
 # The getBrowserLocaleDateFormat() function in dateFormatUtils.ts is intentionally duplicated
 # between the design-system and services packages to avoid creating a dependency between them.
 sonar.cpd.exclusions=packages/bahmni-design-system/src/molecules/datePicker/dateFormatUtils.ts


### PR DESCRIPTION
**JIRA** → [BAH-4760](https://bahmni.atlassian.net/browse/BAH-4760)

## **Description**

Fixes CSS bleed between micro-frontends caused by unscoped CSS module class names and Carbon Design System styles being bundled into each package. CSS module class names were colliding at runtime because Vite was not generating hashed, scoped names during library builds. Additionally, `@carbon/styles` was being bundled into each package, causing duplicate and conflicting global style injections.

## **Key Features**

  - CSS module class names are now deterministically scoped with a hash (`[name]_[local]__[hash:base64:5]`) across all apps and packages during library builds.
  - `@carbon/styles` is externalized from all packages and apps so it is loaded once by the host, not duplicated per micro-frontend.

[BAH-4760]: https://bahmni.atlassian.net/browse/BAH-4760?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ