### PR TITLE
Feature/BAH 4744 Rename Action column to Attachments and reorder columns per Figma

### DIFF
--- a/apps/clinical/public/locales/locale_en.json
+++ b/apps/clinical/public/locales/locale_en.json
@@ -134,7 +134,7 @@
   "DIAGNOSIS_LIST_RECORDED_BY": "Recorded By",
   "DIAGNOSIS_RECORDED_DATE": "Recorded Date",
   "DIAGNOSIS_TABLE_NOT_AVAILABLE": "Not available",
-  "DOCUMENTS_ACTION": "Attachments",
+  "DOCUMENTS_ATTACHMENTS": "Attachments",
   "DOCUMENTS_DOCUMENT_IDENTIFIER": "Document Identifier",
   "DOCUMENTS_ERROR_LOADING_ATTACHMENT": "Unable to load attachment. The document URL may be corrupt or not found.",
   "DOCUMENTS_NOT_AVAILABLE": "Not available",

--- a/apps/clinical/public/locales/locale_en.json
+++ b/apps/clinical/public/locales/locale_en.json
@@ -134,7 +134,7 @@
   "DIAGNOSIS_LIST_RECORDED_BY": "Recorded By",
   "DIAGNOSIS_RECORDED_DATE": "Recorded Date",
   "DIAGNOSIS_TABLE_NOT_AVAILABLE": "Not available",
-  "DOCUMENTS_ACTION": "Action",
+  "DOCUMENTS_ACTION": "Attachments",
   "DOCUMENTS_DOCUMENT_IDENTIFIER": "Document Identifier",
   "DOCUMENTS_ERROR_LOADING_ATTACHMENT": "Unable to load attachment. The document URL may be corrupt or not found.",
   "DOCUMENTS_NOT_AVAILABLE": "Not available",

--- a/apps/clinical/public/locales/locale_es.json
+++ b/apps/clinical/public/locales/locale_es.json
@@ -134,7 +134,7 @@
   "DIAGNOSIS_LIST_RECORDED_BY": "Grabado Por",
   "DIAGNOSIS_RECORDED_DATE": "Fecha de grabación",
   "DIAGNOSIS_TABLE_NOT_AVAILABLE": "No disponible",
-  "DOCUMENTS_ACTION": "Acción",
+  "DOCUMENTS_ACTION": "Adjuntos",
   "DOCUMENTS_DOCUMENT_IDENTIFIER": "Identificador de Documento",
   "DOCUMENTS_ERROR_LOADING_ATTACHMENT": "No se puede cargar el adjunto. La URL del documento puede estar dañada o no encontrada.",
   "DOCUMENTS_NOT_AVAILABLE": "No disponible",

--- a/apps/clinical/public/locales/locale_es.json
+++ b/apps/clinical/public/locales/locale_es.json
@@ -134,7 +134,7 @@
   "DIAGNOSIS_LIST_RECORDED_BY": "Grabado Por",
   "DIAGNOSIS_RECORDED_DATE": "Fecha de grabación",
   "DIAGNOSIS_TABLE_NOT_AVAILABLE": "No disponible",
-  "DOCUMENTS_ACTION": "Adjuntos",
+  "DOCUMENTS_ATTACHMENTS": "Adjuntos",
   "DOCUMENTS_DOCUMENT_IDENTIFIER": "Identificador de Documento",
   "DOCUMENTS_ERROR_LOADING_ATTACHMENT": "No se puede cargar el adjunto. La URL del documento puede estar dañada o no encontrada.",
   "DOCUMENTS_NOT_AVAILABLE": "No disponible",

--- a/packages/bahmni-widgets/src/documents/DocumentsTable.tsx
+++ b/packages/bahmni-widgets/src/documents/DocumentsTable.tsx
@@ -16,7 +16,7 @@ import { buildDocumentUrl, createDocumentHeaders } from './utils';
 const DEFAULT_DOCUMENT_FIELDS = [
   'documentIdentifier',
   'documentType',
-  'action',
+  'attachments',
   'uploadedOn',
   'uploadedBy',
 ];
@@ -177,7 +177,7 @@ const DocumentsTable: React.FC<WidgetProps> = ({ config, encounterUuids }) => {
     () =>
       fields.map((field) => ({
         key: field,
-        sortable: field !== 'action',
+        sortable: field !== 'attachments',
       })),
     [fields],
   );
@@ -204,7 +204,7 @@ const DocumentsTable: React.FC<WidgetProps> = ({ config, encounterUuids }) => {
         }
         case 'uploadedBy':
           return doc.uploadedBy ?? t('DOCUMENTS_NOT_AVAILABLE');
-        case 'action': {
+        case 'attachments': {
           const hasAttachments =
             doc.attachments.length > 0 || !!doc.documentUrl;
           if (!hasAttachments) return '--';

--- a/packages/bahmni-widgets/src/documents/DocumentsTable.tsx
+++ b/packages/bahmni-widgets/src/documents/DocumentsTable.tsx
@@ -16,9 +16,9 @@ import { buildDocumentUrl, createDocumentHeaders } from './utils';
 const DEFAULT_DOCUMENT_FIELDS = [
   'documentIdentifier',
   'documentType',
+  'action',
   'uploadedOn',
   'uploadedBy',
-  'action',
 ];
 
 const IMAGE_EXTENSIONS_RE = /\.(jpg|jpeg|png|gif|webp|bmp|svg)$/i;

--- a/packages/bahmni-widgets/src/documents/__tests__/DocumentsTable.integration.test.tsx
+++ b/packages/bahmni-widgets/src/documents/__tests__/DocumentsTable.integration.test.tsx
@@ -104,9 +104,9 @@ describe('DocumentsTable Integration', () => {
     fields: [
       'documentIdentifier',
       'documentType',
+      'action',
       'uploadedOn',
       'uploadedBy',
-      'action',
     ],
   };
 

--- a/packages/bahmni-widgets/src/documents/__tests__/DocumentsTable.integration.test.tsx
+++ b/packages/bahmni-widgets/src/documents/__tests__/DocumentsTable.integration.test.tsx
@@ -104,7 +104,7 @@ describe('DocumentsTable Integration', () => {
     fields: [
       'documentIdentifier',
       'documentType',
-      'action',
+      'attachments',
       'uploadedOn',
       'uploadedBy',
     ],

--- a/packages/bahmni-widgets/src/documents/__tests__/DocumentsTable.test.tsx
+++ b/packages/bahmni-widgets/src/documents/__tests__/DocumentsTable.test.tsx
@@ -132,7 +132,7 @@ const defaultConfig = {
   fields: [
     'documentIdentifier',
     'documentType',
-    'action',
+    'attachments',
     'uploadedOn',
     'uploadedBy',
   ],
@@ -216,7 +216,7 @@ describe('DocumentsTable', () => {
   });
 
   describe('Table Headers and Data Display', () => {
-    it('renders table with configured fields including Action column', () => {
+    it('renders table with configured fields including Attachments column', () => {
       (useQuery as jest.Mock).mockReturnValue(mockQueryData());
       renderComponent({ config: defaultConfig });
 
@@ -230,16 +230,16 @@ describe('DocumentsTable', () => {
       expect(screen.getByText('DOCUMENTS_TYPE')).toBeInTheDocument();
       expect(screen.getByText('DOCUMENTS_UPLOADED_ON')).toBeInTheDocument();
       expect(screen.getByText('DOCUMENTS_UPLOADED_BY')).toBeInTheDocument();
-      expect(screen.getByText('DOCUMENTS_ACTION')).toBeInTheDocument();
+      expect(screen.getByText('DOCUMENTS_ATTACHMENTS')).toBeInTheDocument();
     });
 
-    it('renders the Action column header as 3rd column', () => {
+    it('renders the Attachments column header as 3rd column', () => {
       (useQuery as jest.Mock).mockReturnValue(mockQueryData());
       renderComponent({ config: defaultConfig });
 
       const headers = screen.getAllByRole('columnheader');
       const headerTexts = headers.map((h) => h.textContent?.trim());
-      expect(headerTexts[2]).toBe('DOCUMENTS_ACTION');
+      expect(headerTexts[2]).toBe('DOCUMENTS_ATTACHMENTS');
     });
 
     it('displays document identifier as plain text (no icon, no button)', () => {
@@ -297,7 +297,7 @@ describe('DocumentsTable', () => {
     });
   });
 
-  describe('Action Column', () => {
+  describe('Attachments Column', () => {
     it('renders "View attachment/s" link for documents with attachments', () => {
       (useQuery as jest.Mock).mockReturnValue(mockQueryData([mockPdfDocument]));
       renderComponent({ config: defaultConfig });
@@ -322,7 +322,7 @@ describe('DocumentsTable', () => {
       ).toBeInTheDocument();
     });
 
-    it('renders "--" in action column when document has no attachments and no URL', () => {
+    it('renders "--" in attachments column when document has no attachments and no URL', () => {
       (useQuery as jest.Mock).mockReturnValue(
         mockQueryData([mockDocumentNoUrl]),
       );
@@ -776,7 +776,7 @@ describe('DocumentsTable', () => {
 
     it('renders with custom field configuration', () => {
       const customConfig = {
-        fields: ['documentIdentifier', 'action'],
+        fields: ['documentIdentifier', 'attachments'],
       };
       (useQuery as jest.Mock).mockReturnValue(mockQueryData([mockPdfDocument]));
       renderComponent({ config: customConfig });

--- a/packages/bahmni-widgets/src/documents/__tests__/DocumentsTable.test.tsx
+++ b/packages/bahmni-widgets/src/documents/__tests__/DocumentsTable.test.tsx
@@ -132,9 +132,9 @@ const defaultConfig = {
   fields: [
     'documentIdentifier',
     'documentType',
+    'action',
     'uploadedOn',
     'uploadedBy',
-    'action',
   ],
 };
 
@@ -233,13 +233,13 @@ describe('DocumentsTable', () => {
       expect(screen.getByText('DOCUMENTS_ACTION')).toBeInTheDocument();
     });
 
-    it('renders the Action column header as last column', () => {
+    it('renders the Action column header as 3rd column', () => {
       (useQuery as jest.Mock).mockReturnValue(mockQueryData());
       renderComponent({ config: defaultConfig });
 
       const headers = screen.getAllByRole('columnheader');
       const headerTexts = headers.map((h) => h.textContent?.trim());
-      expect(headerTexts[headerTexts.length - 1]).toBe('DOCUMENTS_ACTION');
+      expect(headerTexts[2]).toBe('DOCUMENTS_ACTION');
     });
 
     it('displays document identifier as plain text (no icon, no button)', () => {

--- a/packages/bahmni-widgets/src/documents/utils.ts
+++ b/packages/bahmni-widgets/src/documents/utils.ts
@@ -3,7 +3,7 @@ const DOCUMENT_FIELD_I18N_KEYS: Record<string, string> = {
   documentType: 'DOCUMENTS_TYPE',
   uploadedOn: 'DOCUMENTS_UPLOADED_ON',
   uploadedBy: 'DOCUMENTS_UPLOADED_BY',
-  action: 'DOCUMENTS_ACTION',
+  attachments: 'DOCUMENTS_ATTACHMENTS',
 };
 
 export function getFileTypeCategory(


### PR DESCRIPTION
                                                                                     
  **Summary**                                                                                          
                                                                                                   
  Aligns the Patient Documents widget with the approved Figma design by:                           
  - Renaming the action field/column to attachments (both internally and in the UI)                
  - Reordering the default columns to: Document Identifier → Document Type → Attachments → Uploaded
   On → Uploaded By                                                                                
                                                                                                   
  **Changes**                                                                                          
                                                                                                   
  - DocumentsTable.tsx — Renamed field key from action to attachments in the default fields array  
  and in the renderCell switch case; updated sortability check to use attachments                
  - utils.ts — Updated DOCUMENT_FIELD_I18N_KEYS to map attachments → DOCUMENTS_ATTACHMENTS         
  - locale_en.json — Replaced DOCUMENTS_ACTION: "Action" with DOCUMENTS_ATTACHMENTS: "Attachments" 
  - locale_es.json — Replaced DOCUMENTS_ACTION: "Acción" with DOCUMENTS_ATTACHMENTS: "Adjuntos"    
  - Tests — Updated unit and integration tests to reflect the renamed field key and new column     
  position (index 2)                                                                               
                                                                                                   
  **Behaviour preserved**                                                                              
                                                                                                 
  - Clicking "View attachment/s" in the Attachments column still opens the attachment modal      
  correctly
  - Documents without attachments still show --
  - Custom fields config overrides continue to work (callers using "action" will need to update    
  their config to "attachments") 
  
  
  
<img width="3012" height="1320" alt="image" src="https://github.com/user-attachments/assets/0ee018ed-71b2-44bc-ad89-d5a297eb9dc8" />

<img width="2516" height="1122" alt="image" src="https://github.com/user-attachments/assets/1e80b556-3600-497d-aebc-e8ce39c7bb26" />

<img width="3020" height="1292" alt="image" src="https://github.com/user-attachments/assets/57fed858-c879-43e6-a3cc-e180e69f1c42" />

<img width="2458" height="858" alt="image" src="https://github.com/user-attachments/assets/58a130ea-4c41-47f9-b501-f6a6e54cfe8b" />





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Documents table now shows an "Attachments" column so users can view available attachments or see a placeholder when none exist.

* **Localization**
  * Added "Attachments" label translations in English ("Attachments") and Spanish ("Adjuntos").
<!-- end of auto-generated comment: release notes by coderabbit.ai -->