### PR TITLE
 BAH-4705 | Kanchi |Fix. Dosage and Duration label alignment in Medic…

### DIFF
--- a/apps/clinical/src/components/forms/medicationRequest/styles/SelectedMedicationRequestItem.module.scss
+++ b/apps/clinical/src/components/forms/medicationRequest/styles/SelectedMedicationRequestItem.module.scss
@@ -41,9 +41,9 @@
 }
 
 .dosageInput {
-  flex: 0 0 calc(50% - 1px) !important;
+  flex: 0 0 calc(50% - $spacing-01) !important;
   min-width: 0;
-  margin-right: 1px;
+  margin-right: $spacing-01;
 
   :global(.cds--number__control-btn.up-icon) {
     order: unset !important;
@@ -65,9 +65,9 @@
 }
 
 .durationInput {
-  flex: 0 0 calc(50% - 1px) !important;
+  flex: 0 0 calc(50% - $spacing-01) !important;
   min-width: 0;
-  margin-right: 1px;
+  margin-right: $spacing-01;
 
   :global(.cds--number__control-btn.up-icon) {
     order: unset !important;

--- a/apps/clinical/src/components/forms/medicationRequest/styles/SelectedMedicationRequestItem.module.scss
+++ b/apps/clinical/src/components/forms/medicationRequest/styles/SelectedMedicationRequestItem.module.scss
@@ -34,13 +34,15 @@
 .dosageControls {
   display: flex !important;
   flex-direction: row !important;
-  align-items: flex-end !important;
+  align-items: baseline !important;
+  flex-wrap: nowrap;
   margin-bottom: $spacing-04;
   margin-left: 0;
 }
 
 .dosageInput {
-  width: 50%;
+  flex: 0 0 calc(50% - 1px) !important;
+  min-width: 0;
   margin-right: 1px;
 
   :global(.cds--number__control-btn.up-icon) {
@@ -49,19 +51,22 @@
 }
 
 .dosageUnit {
-  width: 50%;
+  flex: 0 0 50%;
+  min-width: 0;
 }
 
 .durationControls {
   display: flex !important;
   flex-direction: row !important;
-  align-items: flex-end !important;
+  align-items: baseline !important;
+  flex-wrap: nowrap;
   margin-bottom: $spacing-04;
   margin-left: 0;
 }
 
 .durationInput {
-  width: 50%;
+  flex: 0 0 calc(50% - 1px) !important;
+  min-width: 0;
   margin-right: 1px;
 
   :global(.cds--number__control-btn.up-icon) {
@@ -70,7 +75,8 @@
 }
 
 .durationUnit {
-  width: 50%;
+  flex: 0 0 50%;
+  min-width: 0;
 }
 
 .footerRow {

--- a/packages/bahmni-design-system/src/molecules/textAreaWClose/styles/TextAreaWClose.module.scss
+++ b/packages/bahmni-design-system/src/molecules/textAreaWClose/styles/TextAreaWClose.module.scss
@@ -26,10 +26,10 @@
   position: absolute !important;
   top: $spacing-06;
   right: 2px;
-  background-color: $field-01 !important;
+  background-color: transparent !important;
 
   :global(.cds--btn--icon-only) {
-    background-color: $field-01 !important;
+    background-color: transparent !important;
     color: $icon-primary !important;
   }
 }


### PR DESCRIPTION
 In the Medication request form, the Dosage/Dosage Unit and Duration/Duration Unit control pairs  
  were misaligned — labels at different heights caused the fields to appear visually uneven.
                                                                                                   
**Summary**                                                                                                                                     
                                                                                                                                                
  - Dosage & Duration label alignment: Changed align-items from flex-end to baseline in .dosageControls and .durationControls so that input     
  labels align correctly regardless of helper text or error message differences between the number input and the unit dropdown.
  - Dosage & Duration input sizing: Replaced fixed width: 50% with flex: 0 0 calc(50% - $spacing-01) for inputs and flex: 0 0 50% for unit      
  dropdowns, using the design system spacing token ($spacing-01) instead of a hardcoded 1px gap. Added flex-wrap: nowrap and min-width: 0 to    
  prevent overflow.
  - AddNote close button: Changed background-color of the close button wrapper and icon in TextAreaWClose from $field-01 to transparent, so the 
  button no longer visually blocks the textarea's focus highlight border.                                                                       
  
 **Files Changed**                                                                                                                                 
                                                                                                                                              
  - apps/clinical/src/components/forms/medicationRequest/styles/SelectedMedicationRequestItem.module.scss                                       
  - packages/bahmni-design-system/src/molecules/textAreaWClose/styles/TextAreaWClose.module.scss

<img width="1762" height="746" alt="image" src="https://github.com/user-attachments/assets/b42cfb4b-607e-4e01-81d0-ed3c58af4ace" />

<img width="1720" height="872" alt="image" src="https://github.com/user-attachments/assets/04c85b71-5ad3-4f64-808f-97ca1a9b724a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved layout and alignment of dosage and duration controls in medication request forms — baseline-aligned, prevented wrapping, and adjusted input/unit sizing and spacing for a tighter, more predictable form layout.
  * Updated text-area close button styling to use a transparent background (including the icon-only button state) for a cleaner, less intrusive control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->