### PR TITLE
BAH-4654 | Fix. Dynamic encounter type UUID resolution and encounter …

### DIFF
--- a/apps/clinical/src/components/patientHeader/PatientHeader.tsx
+++ b/apps/clinical/src/components/patientHeader/PatientHeader.tsx
@@ -1,7 +1,6 @@
 import {
   useTranslation,
   useSubscribeConsultationSaved,
-  CONSULTATION_ENCOUNTER_TYPE_UUID,
   setEncounterSessionDecision,
   setEncounterSessionLoading,
   resetEncounterSession,
@@ -14,8 +13,10 @@ import {
   type PrintOption,
 } from '@bahmni/widgets';
 import React, { useEffect, useMemo, useRef } from 'react';
+import { useEncounterConcepts } from '../../hooks/useEncounterConcepts';
 import { useEncounterSession } from '../../hooks/useEncounterSession';
 import { usePatientVisit } from '../../hooks/usePatientVisit';
+import { useClinicalConfig } from '../../providers/clinicalConfig';
 import ConsultationActionButton from './ConsultationActionButton';
 import styles from './styles/PatientHeader.module.scss';
 
@@ -37,12 +38,23 @@ const PatientHeader: React.FC<PatientHeaderProps> = ({
 }) => {
   const { t } = useTranslation();
   const { practitioner } = useActivePractitioner();
+  const { clinicalConfig } = useClinicalConfig();
+  const { encounterConcepts } = useEncounterConcepts();
 
   const patientUUID = usePatientUUID();
 
-  // Single hook call shared with ConsultationActionButton via props to avoid
-  // duplicate FHIR searches. matchReason is exposed on the DOM so downstream
-  // widget consumers can read it without waiting for ConsultationPad to open.
+  const defaultEncounterTypeName =
+    clinicalConfig?.consultationPad?.inputControls?.find(
+      (c) => c.type === 'encounterDetails',
+    )?.metadata?.defaultEncounterType as string | undefined;
+
+  const encounterTypeUUID = useMemo(() => {
+    if (!defaultEncounterTypeName || !encounterConcepts) return undefined;
+    return encounterConcepts.encounterTypes.find(
+      (et) => et.name === defaultEncounterTypeName,
+    )?.uuid;
+  }, [defaultEncounterTypeName, encounterConcepts]);
+
   const {
     matchReason,
     editActiveEncounter,
@@ -51,7 +63,7 @@ const PatientHeader: React.FC<PatientHeaderProps> = ({
     refetch,
   } = useEncounterSession({
     practitioner,
-    encounterTypeUUID: CONSULTATION_ENCOUNTER_TYPE_UUID,
+    encounterTypeUUID,
   });
 
   // Reset the shared store whenever the patient changes so stale data from a

--- a/apps/clinical/src/components/patientHeader/__tests__/PatientHeader.test.tsx
+++ b/apps/clinical/src/components/patientHeader/__tests__/PatientHeader.test.tsx
@@ -52,8 +52,29 @@ jest.mock('../../../hooks/usePatientVisit', () => ({
 
 jest.mock('../../../providers/clinicalConfig', () => ({
   useClinicalConfig: jest.fn(() => ({
-    clinicalConfig: null,
+    clinicalConfig: {
+      consultationPad: {
+        inputControls: [
+          {
+            type: 'encounterDetails',
+            metadata: { defaultEncounterType: 'Consultation' },
+          },
+        ],
+      },
+    },
     isLoading: false,
+    error: null,
+  })),
+}));
+
+jest.mock('../../../hooks/useEncounterConcepts', () => ({
+  useEncounterConcepts: jest.fn(() => ({
+    encounterConcepts: {
+      encounterTypes: [
+        { name: 'Consultation', uuid: 'consultation-encounter-type-uuid' },
+      ],
+    },
+    loading: false,
     error: null,
   })),
 }));

--- a/packages/bahmni-services/src/encounterSessionService/constants.ts
+++ b/packages/bahmni-services/src/encounterSessionService/constants.ts
@@ -4,9 +4,6 @@ export const ENCOUNTER_SEARCH_URL = OPENMRS_FHIR_R4 + '/Encounter';
 //TODO: chnage URL to use bahmni config api
 export const ENCOUNTER_SESSION_DURATION_GP_URL =
   OPENMRS_REST_V1 + '/systemsetting/bahmni.encountersession.duration';
-export const CONSULTATION_ENCOUNTER_TYPE_UUID =
-  'd34fe3ab-5e07-11ef-8f7c-0242ac120002';
-
 export type MatchReasonCode =
   | 'MATCHED'
   | 'NO_ACTIVE_VISIT'

--- a/packages/bahmni-services/src/encounterSessionService/encounterMatchDecisionMapper.ts
+++ b/packages/bahmni-services/src/encounterSessionService/encounterMatchDecisionMapper.ts
@@ -40,6 +40,14 @@ function filterEncountersByVisit(
   );
 }
 
+function sortByMostRecent(encounters: Encounter[]): Encounter[] {
+  return [...encounters].sort((a, b) => {
+    const dateA = new Date(a.period?.start ?? 0).getTime();
+    const dateB = new Date(b.period?.start ?? 0).getTime();
+    return dateB - dateA;
+  });
+}
+
 export async function resolveEncounterMatchDecision(
   patientUUID: string,
   practitionerUUID: string,
@@ -83,9 +91,8 @@ export async function resolveEncounterMatchDecision(
       recentEncounters,
       activeVisit.id,
     );
-    const practitionerEncountersAllTime = filterEncountersByVisit(
-      practitionerAllTimeEncounters,
-      activeVisit.id,
+    const practitionerEncountersAllTime = sortByMostRecent(
+      filterEncountersByVisit(practitionerAllTimeEncounters, activeVisit.id),
     );
 
     // 5. No encounters at all → NO_ACTIVE_ENCOUNTER
@@ -109,22 +116,20 @@ export async function resolveEncounterMatchDecision(
         (p) => getReferenceId(p.individual?.reference) === uuid,
       ) ?? false;
 
-    const currentPractitionerRecentEncounters = recentEncountersInVisit.filter(
-      (e) => hasParticipant(e, practitionerUUID),
+    const currentPractitionerRecentEncounters = sortByMostRecent(
+      recentEncountersInVisit.filter((e) =>
+        hasParticipant(e, practitionerUUID),
+      ),
     );
-    const otherProvidersRecentEncounters = recentEncountersInVisit.filter(
-      (e) => !hasParticipant(e, practitionerUUID),
+    const otherProvidersRecentEncounters = sortByMostRecent(
+      recentEncountersInVisit.filter(
+        (e) => !hasParticipant(e, practitionerUUID),
+      ),
     );
 
     // 7. Recent encounters by this practitioner → MATCHED or LOCATION_MISMATCH
-    //    When multiple exist, pick the first (assumed most recent by FHIR _lastUpdated sort).
+    //    When multiple exist, pick the most recent by period.start.
     if (currentPractitionerRecentEncounters.length >= 1) {
-      if (currentPractitionerRecentEncounters.length > 1) {
-        // eslint-disable-next-line no-console
-        console.warn(
-          `[EncounterMatchDecision] ${currentPractitionerRecentEncounters.length} encounters found for practitioner ${practitionerUUID} within session window; picking first.`,
-        );
-      }
       const encounter = currentPractitionerRecentEncounters[0];
       if (checkLocationMatch(encounter, locationUUID)) {
         return { matched: true, encounter, reasons: ['MATCHED'] };

--- a/packages/bahmni-services/src/encounterSessionService/index.ts
+++ b/packages/bahmni-services/src/encounterSessionService/index.ts
@@ -1,5 +1,4 @@
 export { findActiveEncounterInSession } from './encounterSessionService';
-export { CONSULTATION_ENCOUNTER_TYPE_UUID } from './constants';
 export {
   resolveEncounterMatchDecision,
   canResumeOwnInSessionEncounter,

--- a/packages/bahmni-services/src/index.ts
+++ b/packages/bahmni-services/src/index.ts
@@ -244,7 +244,6 @@ export {
   type EncounterMatchDecision,
   type MatchReasonCode,
   MATCH_REASON_MESSAGES,
-  CONSULTATION_ENCOUNTER_TYPE_UUID,
   useEncounterSessionStore,
   setEncounterSessionDecision,
   setEncounterSessionLoading,


### PR DESCRIPTION
## Summary

Fixes encounter session resolution that was broken on dev-lite and caused edit buttons to be permanently disabled. Also fixes encounter selection when multiple encounters exist in the session window.

## Changes

### Dynamic Encounter Type UUID Resolution
- **Removed** hardcoded `CONSULTATION_ENCOUNTER_TYPE_UUID` (`d34fe3ab-5e07-11ef-8f7c-0242ac120002`) — this UUID was instance-specific and only matched the standard instance
- **PatientHeader** now resolves the encounter type UUID dynamically:
  1. Reads `defaultEncounterType: "Consultation"` from `clinicalConfig.consultationPad.inputControls` (encounterDetails entry)
  2. Looks up the UUID via `useEncounterConcepts()` API (already fetched by clinical-app)
  3. Passes the resolved UUID to `useEncounterSession()`
- Works on any instance regardless of the encounter type UUID
- Fully removed `CONSULTATION_ENCOUNTER_TYPE_UUID` from `constants.ts`, `encounterSessionService/index.ts`, and `@bahmni/services` barrel export

### Encounter Sorting Fix
- When multiple encounters exist in the session window, the resolver previously picked `encounters[0]` assuming FHIR `_lastUpdated` sort — which is unreliable
- Added `sortByMostRecent()` that sorts encounters by `period.start` descending before picking
- Applied to: current practitioner encounters, other provider encounters, and all-time practitioner encounters
- Removed the `console.warn` for multiple encounters (valid scenario, not a warning)

## Impact

| Before | After |
|--------|-------|
| dev-lite: "New Consultation" never changed to "Edit Consultation" | Works — encounter type UUID resolved dynamically |
| dev-lite: All edit/stop buttons permanently disabled | Works — `canEditOrCreate` and `activeEncounterUuid` populated correctly |
| Standard with multiple encounters (e.g., Baby OfPavi): wrong encounter picked | Most recent encounter always selected via `period.start` sort |
| Standard with clean patients: worked | Still works — same UUID, just sourced dynamically |

## Root Cause

The `CONSULTATION_ENCOUNTER_TYPE_UUID` is auto-generated when OpenMRS creates the encounter type. Different instances have different UUIDs:
- Standard: `d34fe3ab-5e07-11ef-8f7c-0242ac120002`
- Dev-lite: `b9ccceaa-f496-11ed-b02c-0242ac150003`

The encounter session resolver searched for encounters matching this UUID. On dev-lite, it found 0 encounters → `canEditOrCreate = false` → all session-dependent features broken.

## Test Plan
- [x] Verify "Edit Consultation" button appears on dev-lite
- [x] Verify edit medication buttons are enabled on dev-lite
- [x] Verify no regression on standard instance
- [x] Verify correct encounter selected when patient has multiple encounters in session window
- [x] All 17 PatientHeader tests pass
- [x] All 21 encounterMatchDecisionMapper tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)