### PR TITLE
BAH-4772 | Fix: AllergyIntolerance PUT/DELETE payload failing with HAPI XHTML parse error  

### DIFF
--- a/apps/clinical/src/services/consultationBundleService.ts
+++ b/apps/clinical/src/services/consultationBundleService.ts
@@ -5,13 +5,17 @@ import {
   post,
   Form2Observation,
 } from '@bahmni/services';
-import { BundleEntry, Reference, Encounter } from 'fhir/r4';
+import { BundleEntry, Reference, Encounter, CodeableConcept } from 'fhir/r4';
 import { CONSULTATION_BUNDLE_URL } from '../constants/app';
 import { CONSULTATION_ERROR_MESSAGES } from '../constants/errors';
 import { AllergyInputEntry } from '../models/allergy';
 import { ConsultationBundle } from '../models/consultationBundle';
 import { ServiceRequestInputEntry } from '../models/serviceRequest';
-import { createEncounterAllergyResource } from '../utils/fhir/allergyResourceCreator';
+import {
+  createDeleteAllergyResource,
+  createEncounterAllergyResource,
+  updateEncounterAllergyResource,
+} from '../utils/fhir/allergyResourceCreator';
 import {
   createEncounterDiagnosisResource,
   createEncounterConditionResource,
@@ -176,10 +180,7 @@ export function createAllergiesBundleEntries({
         !allergyEncounterRef || allergyEncounterRef === encounterReference;
 
       if (isSameSession) {
-        const existingManifestationByCode = new Map<
-          string,
-          import('fhir/r4').CodeableConcept
-        >();
+        const existingManifestationByCode = new Map<string, CodeableConcept>();
         for (const r of allergy.rawFhirResource.reaction ?? []) {
           for (const m of r.manifestation ?? []) {
             const primaryCode = m.coding?.find((c) => !c.system)?.code;
@@ -201,17 +202,13 @@ export function createAllergiesBundleEntries({
               existingManifestationByCode.get(code) ?? { coding: [{ code }] },
           );
 
-        const putResource: import('fhir/r4').AllergyIntolerance = {
-          ...allergy.rawFhirResource,
-          encounter: createEncounterReferenceFromString(encounterReference),
-          reaction: [
-            {
-              substance: allergy.rawFhirResource.code,
-              manifestation: manifestations,
-              severity,
-            },
-          ],
-        };
+        const putResource = updateEncounterAllergyResource(
+          allergy.rawFhirResource,
+          manifestations,
+          severity,
+          createEncounterReferenceFromString(encounterReference),
+          allergy.note,
+        );
         const putURL = `AllergyIntolerance/${allergy.resourceId}`;
         allergyEntries.push(
           createBundleEntry(putURL, putResource, 'PUT', putURL),
@@ -221,7 +218,7 @@ export function createAllergiesBundleEntries({
         allergyEntries.push(
           createBundleEntry(
             deleteURL,
-            allergy.rawFhirResource,
+            createDeleteAllergyResource(allergy.resourceId!),
             'DELETE',
             deleteURL,
           ),

--- a/apps/clinical/src/utils/fhir/allergyResourceCreator.ts
+++ b/apps/clinical/src/utils/fhir/allergyResourceCreator.ts
@@ -1,4 +1,4 @@
-import { AllergyIntolerance, Reference } from 'fhir/r4';
+import { AllergyIntolerance, CodeableConcept, Reference } from 'fhir/r4';
 import { createCodeableConcept, createCoding } from './codeableConceptCreator';
 
 interface AllergyReaction {
@@ -52,3 +52,41 @@ export const createEncounterAllergyResource = (
 
   return resource;
 };
+
+/**
+ * Builds a PUT AllergyIntolerance resource for updating an existing allergy.
+ * Explicitly picks only the fields needed — never spreads the raw server
+ * response so server-generated fields (text.div narrative, etc.) are excluded.
+ */
+export const createDeleteAllergyResource = (id: string): AllergyIntolerance =>
+  ({ resourceType: 'AllergyIntolerance', id }) as AllergyIntolerance;
+
+export const updateEncounterAllergyResource = (
+  existing: AllergyIntolerance,
+  manifestations: CodeableConcept[],
+  severity: 'mild' | 'moderate' | 'severe',
+  encounterReference: Reference,
+  note?: string,
+): AllergyIntolerance => ({
+  resourceType: 'AllergyIntolerance',
+  id: existing.id,
+  meta: existing.meta,
+  clinicalStatus: existing.clinicalStatus,
+  verificationStatus: existing.verificationStatus,
+  type: existing.type,
+  category: existing.category,
+  criticality: existing.criticality,
+  code: existing.code,
+  patient: existing.patient,
+  recordedDate: existing.recordedDate,
+  recorder: existing.recorder,
+  note: note?.trim() ? [{ text: note.trim() }] : undefined,
+  encounter: encounterReference,
+  reaction: [
+    {
+      substance: existing.code,
+      manifestation: manifestations,
+      severity,
+    },
+  ],
+});


### PR DESCRIPTION
BAH-4772 | Fix: AllergyIntolerance PUT/DELETE payload failing with HAPI XHTML parse error                                                                                    
                                                                                                                                                                               
                                                                                                                                                                               
  Updating an existing allergy severity via the ConsultationBundle was failing with HTTP 400:                                                                                  
                                                                                                                                                                               
  HAPI-1755: String does not appear to be valid XML/XHTML —                                                                                                                    
  The entity name must immediately follow the '&' in the entity reference.                                                                                                     
                                                                                                                                                                               
  Root cause: HAPI FHIR appends a text.div XHTML narrative to every resource it returns. When a patient's allergy note contains & (e.g. "Common Types & Triggers"), that       
  character is embedded unescaped in the XHTML. The frontend was round-tripping this server-generated field back in the PUT/DELETE bundle entries, causing HAPI to reject its  
  own narrative as invalid XML.                                                                                                                                                
                                                                                                                                                                               
  This affected two flows:                                                                                                                                                   
  - Same-session PUT — editing severity of an allergy recorded in the current visit
  - Cross-session DELETE+POST — editing an allergy recorded in a previous visit (the DELETE entry carried the full raw resource including text.div)
                                                                                                                                                                               
  Fix
                                                                                                                                                                               
  Rather than patching text.div at the point of sending, the PUT resource is now constructed explicitly — only the fields that belong in an update request are included. No  
  spreading of the raw server response, so server-generated fields (text.div, etc.) can never be accidentally round-tripped.      
Note edits were silently lost on same-session PUT                                                                                                                
                                                                                                                                                                               
  Previously the PUT payload spread rawFhirResource wholesale, which meant note always reflected the original server value — any edits the user made in the form were          
  discarded. 

Minor: Cleaned up inline import('fhir/r4') type annotation                                                                                                                   
                                                                                                                                                                               
  CodeableConcept was previously imported inline as import('fhir/r4').CodeableConcept inside the function body in consultationBundleService.ts. It is now imported at the top  
  of the file alongside the other fhir/r4 imports, consistent with the rest of the codebase.                                                  
                                                                                                                                                                             
  Two new functions added to allergyResourceCreator.ts:                                                                                                                        
                                                                                                                                                                             
  - updateEncounterAllergyResource — builds the PUT payload by explicitly listing each field (id, meta, clinicalStatus, verificationStatus, type, category, criticality, code,
  patient, recordedDate, recorder, note, encounter, reaction). Accepts the edited note and new severity/manifestations from the form.                                          
  - createDeleteAllergyResource — returns a minimal { resourceType, id } resource for the DELETE entry. HAPI uses the request.url for deletion; the body only needs to satisfy
  bundle validation.                                                                                                                                                           
                                                                                                                                                                               
  Why note[].text with & is fine but text.div is not
                                                                                                                                                                               
  note[].text is a plain JSON string — & is valid there. text.div is XHTML and must be valid XML, so & requires escaping as &amp;. Since we now never send text.div, this class
   of error is structurally prevented regardless of note content.  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced allergy management in clinical consultations with improved handling of allergy record updates and deletions across different patient encounters, ensuring more consistent and reliable allergy data management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->