### PR TITLE
BAH-4784 | Kanchi | Fix. Reactions multiselect stays open after selec…

### DIFF
--- a/apps/clinical/src/components/forms/allergies/SelectedAllergyItem.tsx
+++ b/apps/clinical/src/components/forms/allergies/SelectedAllergyItem.tsx
@@ -119,7 +119,7 @@ const SelectedAllergyItem: React.FC<SelectedAllergyItemProps> = React.memo(
             className={styles.selectedAllergyReactions}
           >
             <FilterableMultiSelect
-              key={`${id}-${selectedReactions.length}`}
+              key={id}
               id={`allergy-reactions-multiselect-${id}`}
               data-testid={`allergy-reactions-multiselect-${id}`}
               type="default"

--- a/apps/clinical/src/components/forms/allergies/__tests__/SelectedAllergyItem.test.tsx
+++ b/apps/clinical/src/components/forms/allergies/__tests__/SelectedAllergyItem.test.tsx
@@ -605,7 +605,6 @@ describe('SelectedAllergyItem', () => {
         );
       });
 
-      // The key prop change should trigger a remount, effectively clearing the input
       // We verify this by checking that the component still renders correctly
       expect(multiselect).toBeInTheDocument();
     });

--- a/apps/clinical/src/components/forms/allergies/__tests__/__snapshots__/SelectedAllergyItem.test.tsx.snap
+++ b/apps/clinical/src/components/forms/allergies/__tests__/__snapshots__/SelectedAllergyItem.test.tsx.snap
@@ -34,8 +34,8 @@ exports[`SelectedAllergyItem Snapshot Tests default rendering matches snapshot 1
       >
         <label
           class="cds--label"
-          for="downshift-_r_7p_-toggle-button"
-          id="downshift-_r_7p_-label"
+          for="downshift-_r_7m_-toggle-button"
+          id="downshift-_r_7m_-label"
         >
           Severity
         </label>
@@ -45,12 +45,12 @@ exports[`SelectedAllergyItem Snapshot Tests default rendering matches snapshot 1
         >
           <button
             aria-activedescendant=""
-            aria-controls="downshift-_r_7p_-menu"
+            aria-controls="downshift-_r_7m_-menu"
             aria-expanded="false"
             aria-haspopup="listbox"
             aria-label="Select severity for this allergy"
             class="cds--list-box__field"
-            id="downshift-_r_7p_-toggle-button"
+            id="downshift-_r_7m_-toggle-button"
             role="combobox"
             tabindex="0"
             title="Mild"
@@ -86,9 +86,9 @@ exports[`SelectedAllergyItem Snapshot Tests default rendering matches snapshot 1
             </div>
           </button>
           <ul
-            aria-labelledby="downshift-_r_7p_-label"
+            aria-labelledby="downshift-_r_7m_-label"
             class="cds--list-box__menu"
-            id="downshift-_r_7p_-menu"
+            id="downshift-_r_7m_-menu"
             role="listbox"
             style="position: fixed; left: 0px; top: 0px; visibility: visible; transform: translate(0px, 0px);"
           />
@@ -238,8 +238,8 @@ exports[`SelectedAllergyItem Snapshot Tests rendering with validation errors mat
       >
         <label
           class="cds--label"
-          for="downshift-_r_7v_-toggle-button"
-          id="downshift-_r_7v_-label"
+          for="downshift-_r_7s_-toggle-button"
+          id="downshift-_r_7s_-label"
         >
           Severity
         </label>
@@ -270,12 +270,12 @@ exports[`SelectedAllergyItem Snapshot Tests rendering with validation errors mat
           </svg>
           <button
             aria-activedescendant=""
-            aria-controls="downshift-_r_7v_-menu"
+            aria-controls="downshift-_r_7s_-menu"
             aria-expanded="false"
             aria-haspopup="listbox"
             aria-label="Select severity for this allergy"
             class="cds--list-box__field"
-            id="downshift-_r_7v_-toggle-button"
+            id="downshift-_r_7s_-toggle-button"
             role="combobox"
             tabindex="0"
             title="Select Severity"
@@ -311,9 +311,9 @@ exports[`SelectedAllergyItem Snapshot Tests rendering with validation errors mat
             </div>
           </button>
           <ul
-            aria-labelledby="downshift-_r_7v_-label"
+            aria-labelledby="downshift-_r_7s_-label"
             class="cds--list-box__menu"
-            id="downshift-_r_7v_-menu"
+            id="downshift-_r_7s_-menu"
             role="listbox"
             style="position: fixed; left: 0px; top: 0px; visibility: visible; transform: translate(0px, 0px);"
           />


### PR DESCRIPTION
Removed the dynamic key prop from the FilterableMultiSelect (reactions dropdown) in SelectedAllergyItem.tsx.                                  
   
  **Before**: key={${id}-${selectedReactions.length}}                                                                                               
  **After**: key={id}                                                                                                                             
                                                                                                                                                
  **Why**                                                                                                                                         

The reactions dropdown was behaving like a single-select — it closed every time a reaction was picked. This happened because the key prop included selectedReactions.length, which changed on every selection. React treats a key change as a signal to destroy and recreate the component, resetting the dropdown to its default closed state.                                                                                
                                                                                                                                              
Using a stable key={id} keeps the component alive across selections, allowing Carbon's built-in multi-select behavior to work as intended —   the dropdown stays open until the user clicks outside.

<img width="1806" height="1214" alt="image" src="https://github.com/user-attachments/assets/8967192b-9a7e-45bf-bc9e-f345ada3ddd3" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented the multi-select allergy input from being unnecessarily cleared during reaction selection, preserving user input and selections.

* **Tests**
  * Cleaned up test comments relating to selection-clearing behavior to reflect updated component behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->