### PR TITLE
BAH-4725 | Fix patient photo not preserved on re-save

### DIFF
--- a/apps/registration/src/components/forms/profile/__tests__/Profile.test.tsx
+++ b/apps/registration/src/components/forms/profile/__tests__/Profile.test.tsx
@@ -422,29 +422,37 @@ describe('Profile', () => {
       expect(checkbox.checked).toBe(true);
     });
 
-    it('should set dobEstimated only when years field is changed, not months or days', () => {
-      const { unmount } = render(
-        <Profile ref={ref} initialDobEstimated={false} />,
-      );
+    it('should have dobEstimated true when initialized with age years', async () => {
+      await act(async () => {
+        render(
+          <Profile
+            ref={ref}
+            initialData={createBasicInfoData({ ageYears: '30' })}
+            initialDobEstimated
+          />,
+        );
+      });
 
-      // Verify initial state
+      const data = ref.current?.getData();
+      expect(data?.dobEstimated).toBe(true);
+    });
+
+    it('should not set dobEstimated when only months or days are changed', () => {
+      render(<Profile ref={ref} initialDobEstimated={false} />);
+
       expect(ref.current?.getData()?.dobEstimated).toBe(false);
 
-      // Type in months — should NOT set estimated
       const monthsInput = screen.getByLabelText(
         /Months\(Age\)/,
       ) as HTMLInputElement;
       fireEvent.change(monthsInput, { target: { value: '6' } });
       expect(ref.current?.getData()?.dobEstimated).toBe(false);
 
-      // Type in days — should NOT set estimated
       const daysInput = screen.getByLabelText(
         /Days\(Age\)/,
       ) as HTMLInputElement;
       fireEvent.change(daysInput, { target: { value: '15' } });
       expect(ref.current?.getData()?.dobEstimated).toBe(false);
-
-      unmount();
     });
   });
 

--- a/apps/registration/src/components/forms/profile/__tests__/Profile.test.tsx
+++ b/apps/registration/src/components/forms/profile/__tests__/Profile.test.tsx
@@ -423,18 +423,24 @@ describe('Profile', () => {
     });
 
     it('should set dobEstimated only when years field is changed, not months or days', () => {
-      const { unmount } = render(<Profile ref={ref} initialDobEstimated={false} />);
+      const { unmount } = render(
+        <Profile ref={ref} initialDobEstimated={false} />,
+      );
 
       // Verify initial state
       expect(ref.current?.getData()?.dobEstimated).toBe(false);
 
       // Type in months — should NOT set estimated
-      const monthsInput = screen.getByLabelText(/Months\(Age\)/) as HTMLInputElement;
+      const monthsInput = screen.getByLabelText(
+        /Months\(Age\)/,
+      ) as HTMLInputElement;
       fireEvent.change(monthsInput, { target: { value: '6' } });
       expect(ref.current?.getData()?.dobEstimated).toBe(false);
 
       // Type in days — should NOT set estimated
-      const daysInput = screen.getByLabelText(/Days\(Age\)/) as HTMLInputElement;
+      const daysInput = screen.getByLabelText(
+        /Days\(Age\)/,
+      ) as HTMLInputElement;
       fireEvent.change(daysInput, { target: { value: '15' } });
       expect(ref.current?.getData()?.dobEstimated).toBe(false);
 

--- a/apps/registration/src/components/forms/profile/__tests__/Profile.test.tsx
+++ b/apps/registration/src/components/forms/profile/__tests__/Profile.test.tsx
@@ -421,6 +421,25 @@ describe('Profile', () => {
 
       expect(checkbox.checked).toBe(true);
     });
+
+    it('should set dobEstimated only when years field is changed, not months or days', () => {
+      const { unmount } = render(<Profile ref={ref} initialDobEstimated={false} />);
+
+      // Verify initial state
+      expect(ref.current?.getData()?.dobEstimated).toBe(false);
+
+      // Type in months — should NOT set estimated
+      const monthsInput = screen.getByLabelText(/Months\(Age\)/) as HTMLInputElement;
+      fireEvent.change(monthsInput, { target: { value: '6' } });
+      expect(ref.current?.getData()?.dobEstimated).toBe(false);
+
+      // Type in days — should NOT set estimated
+      const daysInput = screen.getByLabelText(/Days\(Age\)/) as HTMLInputElement;
+      fireEvent.change(daysInput, { target: { value: '15' } });
+      expect(ref.current?.getData()?.dobEstimated).toBe(false);
+
+      unmount();
+    });
   });
 
   describe('Patient ID Format Selection', () => {

--- a/apps/registration/src/components/forms/profile/dateAgeUtils.ts
+++ b/apps/registration/src/components/forms/profile/dateAgeUtils.ts
@@ -182,7 +182,7 @@ export const createDateAgeHandlers = <
         if (age.years > 0 || age.months > 0 || age.days > 0) {
           const birthISO = AgeUtils.calculateBirthDate(age);
           updated.dateOfBirth = birthISO;
-          setDobEstimated(true);
+          setDobEstimated(field === 'ageYears');
 
           const maxAgeDate = new Date();
           maxAgeDate.setFullYear(

--- a/apps/registration/src/hooks/__tests__/usePatientPhoto.test.tsx
+++ b/apps/registration/src/hooks/__tests__/usePatientPhoto.test.tsx
@@ -1,12 +1,22 @@
-import { getPatientPhotoDataUrl } from '@bahmni/services';
+import { fetchPatientPhotoFromUrl } from '@bahmni/services';
+import { useHasPrivilege } from '@bahmni/widgets';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import { usePatientPhoto } from '../usePatientPhoto';
 
 jest.mock('@bahmni/services');
+jest.mock('@bahmni/widgets', () => ({
+  ...jest.requireActual('@bahmni/widgets'),
+  useHasPrivilege: jest.fn(),
+}));
 
-const mockGetPatientPhotoDataUrl =
-  getPatientPhotoDataUrl as jest.MockedFunction<typeof getPatientPhotoDataUrl>;
+const mockFetchPatientPhotoFromUrl =
+  fetchPatientPhotoFromUrl as jest.MockedFunction<
+    typeof fetchPatientPhotoFromUrl
+  >;
+const mockUseHasPrivilege = useHasPrivilege as jest.MockedFunction<
+  typeof useHasPrivilege
+>;
 
 const createWrapper = () => {
   const queryClient = new QueryClient({
@@ -22,36 +32,46 @@ const createWrapper = () => {
 describe('usePatientPhoto', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUseHasPrivilege.mockReturnValue(true);
   });
 
-  it('should fetch patient photo when patientUuid is provided', async () => {
+  it('should fetch patient photo when photoUrl is provided and has privilege', async () => {
     const mockPhotoData = 'data:image/jpeg;base64,/9j/4AAQ';
-    mockGetPatientPhotoDataUrl.mockResolvedValue(mockPhotoData);
+    const photoUrl = '/openmrs/ws/fhir2/R4/Patient/patient-123/$photo';
+    mockFetchPatientPhotoFromUrl.mockResolvedValue(mockPhotoData);
 
-    const { result } = renderHook(
-      () =>
-        usePatientPhoto({
-          patientUuid: 'patient-123',
-        }),
-      { wrapper: createWrapper() },
-    );
+    const { result } = renderHook(() => usePatientPhoto({ photoUrl }), {
+      wrapper: createWrapper(),
+    });
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-    expect(mockGetPatientPhotoDataUrl).toHaveBeenCalledWith('patient-123');
+    expect(mockFetchPatientPhotoFromUrl).toHaveBeenCalledWith(photoUrl);
     expect(result.current.patientPhoto).toBe(mockPhotoData);
   });
 
-  it('should not fetch when patientUuid is undefined', () => {
+  it('should not fetch when photoUrl is undefined', () => {
+    const { result } = renderHook(
+      () => usePatientPhoto({ photoUrl: undefined }),
+      { wrapper: createWrapper() },
+    );
+
+    expect(mockFetchPatientPhotoFromUrl).not.toHaveBeenCalled();
+    expect(result.current.patientPhoto).toBeUndefined();
+  });
+
+  it('should not fetch when user lacks Get Patient Photo privilege', () => {
+    mockUseHasPrivilege.mockReturnValue(false);
+
     const { result } = renderHook(
       () =>
         usePatientPhoto({
-          patientUuid: undefined,
+          photoUrl: '/openmrs/ws/fhir2/R4/Patient/patient-123/$photo',
         }),
       { wrapper: createWrapper() },
     );
 
-    expect(mockGetPatientPhotoDataUrl).not.toHaveBeenCalled();
+    expect(mockFetchPatientPhotoFromUrl).not.toHaveBeenCalled();
     expect(result.current.patientPhoto).toBeUndefined();
   });
 });

--- a/apps/registration/src/hooks/usePatientPhoto.ts
+++ b/apps/registration/src/hooks/usePatientPhoto.ts
@@ -1,8 +1,6 @@
 import { fetchPatientPhotoFromUrl } from '@bahmni/services';
-import { useHasPrivilege } from '@bahmni/widgets';
+import { GET_PATIENT_PHOTO_PRIVILEGE, useHasPrivilege } from '@bahmni/widgets';
 import { useQuery } from '@tanstack/react-query';
-
-const GET_PATIENT_PHOTO_PRIVILEGE = 'Get Patient Photo';
 
 interface UsePatientPhotoProps {
   photoUrl: string | undefined;

--- a/apps/registration/src/hooks/usePatientPhoto.ts
+++ b/apps/registration/src/hooks/usePatientPhoto.ts
@@ -1,15 +1,19 @@
-import { getPatientPhotoDataUrl } from '@bahmni/services';
+import { fetchPatientPhotoFromUrl } from '@bahmni/services';
+import { useHasPrivilege } from '@bahmni/widgets';
 import { useQuery } from '@tanstack/react-query';
 
+const GET_PATIENT_PHOTO_PRIVILEGE = 'Get Patient Photo';
+
 interface UsePatientPhotoProps {
-  patientUuid: string | undefined;
+  photoUrl: string | undefined;
 }
 
-export const usePatientPhoto = ({ patientUuid }: UsePatientPhotoProps) => {
+export const usePatientPhoto = ({ photoUrl }: UsePatientPhotoProps) => {
+  const hasPhotoPrivilege = useHasPrivilege(GET_PATIENT_PHOTO_PRIVILEGE);
   const { data: patientPhoto, isLoading } = useQuery({
-    queryKey: ['patientPhoto', patientUuid],
-    queryFn: () => getPatientPhotoDataUrl(patientUuid!),
-    enabled: !!patientUuid,
+    queryKey: ['patientPhoto', photoUrl],
+    queryFn: () => fetchPatientPhotoFromUrl(photoUrl!),
+    enabled: !!photoUrl && hasPhotoPrivilege,
   });
 
   return {

--- a/apps/registration/src/pages/PatientRegister/PatientRegister.tsx
+++ b/apps/registration/src/pages/PatientRegister/PatientRegister.tsx
@@ -63,6 +63,7 @@ const PatientRegister = () => {
     useRef<AdditionalIdentifiersRef>(null);
 
   const {
+    patientDetails,
     profileInitialData,
     personAttributesInitialData,
     addressInitialData,
@@ -75,9 +76,8 @@ const PatientRegister = () => {
 
   const [metadata, setMetadata] = useState(initialMetadata);
 
-  const { patientPhoto } = usePatientPhoto({
-    patientUuid: metadata?.patientUuid,
-  });
+  const photoUrl = patientDetails?.photo?.[0]?.url;
+  const { patientPhoto } = usePatientPhoto({ photoUrl });
 
   useEffect(() => {
     if (initialMetadata) {

--- a/apps/registration/src/utils/__tests__/fhirPatientMapper.test.ts
+++ b/apps/registration/src/utils/__tests__/fhirPatientMapper.test.ts
@@ -278,4 +278,27 @@ describe('buildFhirPatient', () => {
   it('should omit address when all fields empty', () => {
     expect(buildFhirPatient(baseInput).address).toBeUndefined();
   });
+
+  it('should include photo with base64 data when image is provided', () => {
+    const result = buildFhirPatient({
+      ...baseInput,
+      profile: { ...baseProfile, image: '/9j/4AAQbase64data' },
+    });
+    expect(result.photo).toEqual([
+      { contentType: 'image/jpeg', data: '/9j/4AAQbase64data' },
+    ]);
+  });
+
+  it('should include empty photo array when no image is provided', () => {
+    const result = buildFhirPatient(baseInput);
+    expect(result.photo).toEqual([]);
+  });
+
+  it('should include empty photo array on update when image is removed', () => {
+    const result = buildFhirPatient({
+      ...baseInput,
+      patientUuid: 'uuid-123',
+    });
+    expect(result.photo).toEqual([]);
+  });
 });

--- a/apps/registration/src/utils/fhirPatientMapper.ts
+++ b/apps/registration/src/utils/fhirPatientMapper.ts
@@ -42,6 +42,7 @@ interface MapperInput {
   profile: BasicInfoData & {
     dobEstimated: boolean;
     patientIdentifier: PatientIdentifier;
+    image?: string;
   };
   address: PatientAddress;
   contact: PersonAttributesData;
@@ -213,6 +214,9 @@ export function buildFhirPatient(input: MapperInput): Patient {
     }),
     ...(extensions.length > 0 && { extension: extensions }),
     ...(fhirAddresses.length > 0 && { address: fhirAddresses }),
+    photo: profile.image
+      ? [{ contentType: 'image/jpeg', data: profile.image }]
+      : [],
   };
 
   return patient;

--- a/packages/bahmni-services/src/index.ts
+++ b/packages/bahmni-services/src/index.ts
@@ -22,7 +22,7 @@ export {
   getGenders,
   getAddressHierarchyEntries,
   getOrderedAddressHierarchyLevels,
-  getPatientPhotoDataUrl,
+  fetchPatientPhotoFromUrl,
   getPatientProfile,
   getPersonAttributeTypes,
   getRelationshipTypes,

--- a/packages/bahmni-services/src/patientService/__tests__/patientService.test.ts
+++ b/packages/bahmni-services/src/patientService/__tests__/patientService.test.ts
@@ -12,7 +12,6 @@ import {
   PRIMARY_IDENTIFIER_TYPE_PROPERTY,
   CREATE_PATIENT_URL,
   ADDRESS_HIERARCHY_URL,
-  PATIENT_IMAGE_URL,
 } from '../constants';
 import {
   getPatientById,
@@ -29,7 +28,7 @@ import {
   getGenders,
   getAddressHierarchyEntries,
   getPatientProfile,
-  getPatientPhotoDataUrl,
+  fetchPatientPhotoFromUrl,
 } from '../patientService';
 
 jest.mock('../../api');
@@ -1447,17 +1446,17 @@ describe('Patient Service', () => {
     });
   });
 
-  describe('getPatientPhotoDataUrl', () => {
-    const PATIENT_UUID = '12345678-1234-1234-1234-123456789abc';
+  describe('fetchPatientPhotoFromUrl', () => {
+    const PHOTO_URL = '/openmrs/ws/fhir2/R4/Patient/test-uuid/$photo';
 
-    it('calls get with the correct URL and blob responseType', async () => {
+    it('calls get with the photo URL and blob responseType', async () => {
       const mockBlob = new Blob(['image-data'], { type: 'image/jpeg' });
       mockedGet.mockResolvedValueOnce(mockBlob as any);
       mockedBlobToDataUrl.mockResolvedValueOnce('data:image/jpeg;base64,abc');
 
-      await getPatientPhotoDataUrl(PATIENT_UUID);
+      await fetchPatientPhotoFromUrl(PHOTO_URL);
 
-      expect(mockedGet).toHaveBeenCalledWith(PATIENT_IMAGE_URL(PATIENT_UUID), {
+      expect(mockedGet).toHaveBeenCalledWith(PHOTO_URL, {
         responseType: 'blob',
       });
     });
@@ -1468,7 +1467,7 @@ describe('Patient Service', () => {
       mockedGet.mockResolvedValueOnce(mockBlob as any);
       mockedBlobToDataUrl.mockResolvedValueOnce(mockDataUrl);
 
-      const result = await getPatientPhotoDataUrl(PATIENT_UUID);
+      const result = await fetchPatientPhotoFromUrl(PHOTO_URL);
 
       expect(result).toBe(mockDataUrl);
     });
@@ -1476,7 +1475,7 @@ describe('Patient Service', () => {
     it('propagates errors from the API', async () => {
       mockedGet.mockRejectedValueOnce(new Error('Network error'));
 
-      await expect(getPatientPhotoDataUrl(PATIENT_UUID)).rejects.toThrow(
+      await expect(fetchPatientPhotoFromUrl(PHOTO_URL)).rejects.toThrow(
         'Network error',
       );
     });

--- a/packages/bahmni-services/src/patientService/constants.ts
+++ b/packages/bahmni-services/src/patientService/constants.ts
@@ -1,8 +1,4 @@
-import {
-  OPENMRS_FHIR_R4,
-  OPENMRS_REST_V1,
-  OPENMRS_REST_V2,
-} from '../constants/app';
+import { OPENMRS_FHIR_R4, OPENMRS_REST_V1 } from '../constants/app';
 import { PatientSearchField } from './models';
 
 /**
@@ -161,9 +157,6 @@ export const MAX_PATIENT_AGE_YEARS = 120;
 export const MAX_NAME_LENGTH = 50;
 export const MAX_PHONE_NUMBER_LENGTH = 15;
 export const UUID_PATTERN = /^[a-f0-9-]{36}$/i;
-
-export const PATIENT_IMAGE_URL = (patientUuid: string) =>
-  OPENMRS_REST_V2 + `/patientImage?patientUuid=${patientUuid}`;
 
 export const PERSON_ATTRIBUTE_TYPES_URL =
   OPENMRS_REST_V1 +

--- a/packages/bahmni-services/src/patientService/index.ts
+++ b/packages/bahmni-services/src/patientService/index.ts
@@ -14,7 +14,7 @@ export {
   getGenders,
   getAddressHierarchyEntries,
   getOrderedAddressHierarchyLevels,
-  getPatientPhotoDataUrl,
+  fetchPatientPhotoFromUrl,
   getPatientProfile,
   getRelationshipTypes,
   getPersonAttributeTypes,

--- a/packages/bahmni-services/src/patientService/models.ts
+++ b/packages/bahmni-services/src/patientService/models.ts
@@ -12,6 +12,7 @@ export interface FormattedPatientData {
   formattedAddress: string | null;
   formattedContact: string | null;
   identifiers: Map<string, string>;
+  photoUrl: string | undefined;
 }
 
 export interface PatientSearchResult {

--- a/packages/bahmni-services/src/patientService/models.ts
+++ b/packages/bahmni-services/src/patientService/models.ts
@@ -12,7 +12,7 @@ export interface FormattedPatientData {
   formattedAddress: string | null;
   formattedContact: string | null;
   identifiers: Map<string, string>;
-  photoUrl: string | undefined;
+  photoUrl?: string;
 }
 
 export interface PatientSearchResult {

--- a/packages/bahmni-services/src/patientService/patientService.ts
+++ b/packages/bahmni-services/src/patientService/patientService.ts
@@ -192,6 +192,9 @@ export const getFormattedPatientById = async (
 export const fetchPatientPhotoFromUrl = async (
   photoUrl: string,
 ): Promise<string> => {
+  if (!photoUrl.startsWith('/')) {
+    throw new Error('Photo URL must be a relative path');
+  }
   const blob = await get<Blob>(photoUrl, {
     responseType: 'blob',
   });

--- a/packages/bahmni-services/src/patientService/patientService.ts
+++ b/packages/bahmni-services/src/patientService/patientService.ts
@@ -19,7 +19,6 @@ import {
   ADDRESS_HIERARCHY_MIN_SEARCH_LENGTH,
   UUID_PATTERN,
   ORDERED_ADDRESS_HIERARCHY_URL,
-  PATIENT_IMAGE_URL,
   GET_PATIENT_PROFILE_URL,
   PERSON_ATTRIBUTE_TYPES_URL,
   RELATIONSHIP_TYPES_URL,
@@ -174,6 +173,7 @@ export const formatPatientData = (patient: Patient): FormattedPatientData => {
     formattedAddress: address,
     formattedContact: contact,
     identifiers: identifierMap,
+    photoUrl: patient.photo?.[0]?.url,
   };
 };
 
@@ -189,16 +189,10 @@ export const getFormattedPatientById = async (
   return formatPatientData(patient);
 };
 
-/**
- * Fetches a patient's photo from OpenMRS as a Blob and converts it to a base64 data URL
- * suitable for use as an img src attribute
- * @param patientUUID - The UUID of the patient whose photo to fetch
- * @returns A base64 data URL string for the patient photo
- */
-export const getPatientPhotoDataUrl = async (
-  patientUUID: string,
+export const fetchPatientPhotoFromUrl = async (
+  photoUrl: string,
 ): Promise<string> => {
-  const blob = await get<Blob>(PATIENT_IMAGE_URL(patientUUID), {
+  const blob = await get<Blob>(photoUrl, {
     responseType: 'blob',
   });
   return await blobToDataUrl(blob);

--- a/packages/bahmni-widgets/src/index.ts
+++ b/packages/bahmni-widgets/src/index.ts
@@ -40,6 +40,7 @@ export { useHasPrivilege } from './userPrivileges/useHasPrivilege';
 // User Privileges
 export { UserPrivilegeProvider } from './userPrivileges/UserPrivilegeProvider';
 export { CONSULTATION_PAD_PRIVILEGES } from './userPrivileges/consultationPadPrivileges';
+export { GET_PATIENT_PHOTO_PRIVILEGE } from './userPrivileges/patientPhotoPrivileges';
 
 // App Context
 export { AppContextProvider } from './appContext';

--- a/packages/bahmni-widgets/src/patientDetails/PatientDetails.tsx
+++ b/packages/bahmni-widgets/src/patientDetails/PatientDetails.tsx
@@ -1,19 +1,23 @@
 import { Icon, ICON_SIZE } from '@bahmni/design-system';
 import {
+  fetchPatientPhotoFromUrl,
   getFormattedPatientById,
-  getPatientPhotoDataUrl,
 } from '@bahmni/services';
 import { SkeletonText } from '@carbon/react';
 import { useQuery } from '@tanstack/react-query';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { usePatientUUID } from '../hooks/usePatientUUID';
+import { useHasPrivilege } from '../userPrivileges/useHasPrivilege';
 import styles from './__styles__/PatientDetails.module.scss';
 import { createPatientDetailsViewModel } from './utils';
+
+const GET_PATIENT_PHOTO_PRIVILEGE = 'Get Patient Photo';
 
 const PatientDetails: React.FC = () => {
   const { t } = useTranslation();
   const patientUUID = usePatientUUID();
+  const hasPhotoPrivilege = useHasPrivilege(GET_PATIENT_PHOTO_PRIVILEGE);
   const {
     data: patient,
     isLoading,
@@ -24,10 +28,11 @@ const PatientDetails: React.FC = () => {
     enabled: !!patientUUID,
   });
 
+  const photoUrl = patient?.photoUrl;
   const { data: photoDataUrl } = useQuery({
-    queryKey: ['patientPhoto', patientUUID],
-    queryFn: () => getPatientPhotoDataUrl(patientUUID!),
-    enabled: !!patientUUID,
+    queryKey: ['patientPhoto', photoUrl],
+    queryFn: () => fetchPatientPhotoFromUrl(photoUrl!),
+    enabled: !!photoUrl && hasPhotoPrivilege,
   });
 
   if (isLoading || error || !patient) {

--- a/packages/bahmni-widgets/src/patientDetails/PatientDetails.tsx
+++ b/packages/bahmni-widgets/src/patientDetails/PatientDetails.tsx
@@ -8,11 +8,10 @@ import { useQuery } from '@tanstack/react-query';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { usePatientUUID } from '../hooks/usePatientUUID';
+import { GET_PATIENT_PHOTO_PRIVILEGE } from '../userPrivileges/patientPhotoPrivileges';
 import { useHasPrivilege } from '../userPrivileges/useHasPrivilege';
 import styles from './__styles__/PatientDetails.module.scss';
 import { createPatientDetailsViewModel } from './utils';
-
-const GET_PATIENT_PHOTO_PRIVILEGE = 'Get Patient Photo';
 
 const PatientDetails: React.FC = () => {
   const { t } = useTranslation();

--- a/packages/bahmni-widgets/src/patientDetails/__tests__/PatientDetails.integration.test.tsx
+++ b/packages/bahmni-widgets/src/patientDetails/__tests__/PatientDetails.integration.test.tsx
@@ -1,7 +1,7 @@
 import {
   FormattedPatientData,
   getFormattedPatientById,
-  getPatientPhotoDataUrl,
+  fetchPatientPhotoFromUrl,
 } from '@bahmni/services';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
@@ -12,15 +12,20 @@ import { mockFullPatient } from './__mocks__/patientDetailsMocks';
 jest.mock('@bahmni/services', () => ({
   ...jest.requireActual('@bahmni/services'),
   getFormattedPatientById: jest.fn(),
-  getPatientPhotoDataUrl: jest.fn(),
+  fetchPatientPhotoFromUrl: jest.fn(),
+}));
+jest.mock('../../userPrivileges/useHasPrivilege', () => ({
+  useHasPrivilege: jest.fn(() => true),
 }));
 
 const mockedGetFormattedPatientById =
   getFormattedPatientById as jest.MockedFunction<
     typeof getFormattedPatientById
   >;
-const mockedGetPatientPhotoDataUrl =
-  getPatientPhotoDataUrl as jest.MockedFunction<typeof getPatientPhotoDataUrl>;
+const mockedFetchPatientPhotoFromUrl =
+  fetchPatientPhotoFromUrl as jest.MockedFunction<
+    typeof fetchPatientPhotoFromUrl
+  >;
 
 const createQueryClient = () =>
   new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -44,7 +49,7 @@ describe('PatientDetails Integration', () => {
     jest.useFakeTimers();
     jest.setSystemTime(new Date('2025-03-16'));
     queryClient = createQueryClient();
-    mockedGetPatientPhotoDataUrl.mockResolvedValue(
+    mockedFetchPatientPhotoFromUrl.mockResolvedValue(
       'data:image/jpeg;base64,/9j/photo==',
     );
   });
@@ -83,7 +88,7 @@ describe('PatientDetails Integration', () => {
 
   it('does not render photo when photo query fails', async () => {
     mockedGetFormattedPatientById.mockResolvedValue(mockFullPatient);
-    mockedGetPatientPhotoDataUrl.mockRejectedValue(new Error('No photo'));
+    mockedFetchPatientPhotoFromUrl.mockRejectedValue(new Error('No photo'));
 
     renderPatientDetails(queryClient);
 
@@ -125,6 +130,7 @@ describe('PatientDetails Integration', () => {
       formattedAddress: null,
       formattedContact: null,
       identifiers: new Map([['ID', 'ID123']]),
+      photoUrl: undefined,
     };
 
     mockedGetFormattedPatientById.mockResolvedValue(mockPatient);

--- a/packages/bahmni-widgets/src/patientDetails/__tests__/PatientDetails.test.tsx
+++ b/packages/bahmni-widgets/src/patientDetails/__tests__/PatientDetails.test.tsx
@@ -119,7 +119,9 @@ describe('PatientDetails Component', () => {
     it('does not fetch photo when user lacks privilege', () => {
       mockUseHasPrivilege.mockReturnValue(false);
       mockPatientQuery({
-        data: createMockPatient({ photoUrl: '/openmrs/ws/fhir2/R4/Patient/test-uuid/$photo' }),
+        data: createMockPatient({
+          photoUrl: '/openmrs/ws/fhir2/R4/Patient/test-uuid/$photo',
+        }),
         isLoading: false,
         error: null,
       });

--- a/packages/bahmni-widgets/src/patientDetails/__tests__/PatientDetails.test.tsx
+++ b/packages/bahmni-widgets/src/patientDetails/__tests__/PatientDetails.test.tsx
@@ -2,12 +2,20 @@ import { FormattedPatientData, formatDateTime } from '@bahmni/services';
 import { UseQueryResult, useQuery } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import { axe, toHaveNoViolations } from 'jest-axe';
+import { useHasPrivilege } from '../../userPrivileges/useHasPrivilege';
 import PatientDetails from '../PatientDetails';
 
 expect.extend(toHaveNoViolations);
 
+const mockUseHasPrivilege = useHasPrivilege as jest.MockedFunction<
+  typeof useHasPrivilege
+>;
+
 jest.mock('../../hooks/usePatientUUID', () => ({
   usePatientUUID: jest.fn(() => 'test-uuid'),
+}));
+jest.mock('../../userPrivileges/useHasPrivilege', () => ({
+  useHasPrivilege: jest.fn(() => true),
 }));
 jest.mock('@tanstack/react-query', () => ({
   ...jest.requireActual('@tanstack/react-query'),
@@ -106,6 +114,21 @@ describe('PatientDetails Component', () => {
         'src',
         photoDataUrl,
       );
+    });
+
+    it('does not fetch photo when user lacks privilege', () => {
+      mockUseHasPrivilege.mockReturnValue(false);
+      mockPatientQuery({
+        data: createMockPatient(),
+        isLoading: false,
+        error: null,
+      });
+
+      render(<PatientDetails />);
+
+      expect(
+        screen.queryByTestId('patient-photo-test-id'),
+      ).not.toBeInTheDocument();
     });
   });
 

--- a/packages/bahmni-widgets/src/patientDetails/__tests__/PatientDetails.test.tsx
+++ b/packages/bahmni-widgets/src/patientDetails/__tests__/PatientDetails.test.tsx
@@ -119,7 +119,7 @@ describe('PatientDetails Component', () => {
     it('does not fetch photo when user lacks privilege', () => {
       mockUseHasPrivilege.mockReturnValue(false);
       mockPatientQuery({
-        data: createMockPatient(),
+        data: createMockPatient({ photoUrl: '/openmrs/ws/fhir2/R4/Patient/test-uuid/$photo' }),
         isLoading: false,
         error: null,
       });

--- a/packages/bahmni-widgets/src/patientDetails/__tests__/__mocks__/patientDetailsMocks.ts
+++ b/packages/bahmni-widgets/src/patientDetails/__tests__/__mocks__/patientDetailsMocks.ts
@@ -11,6 +11,7 @@ export const mockFullPatient: FormattedPatientData = {
     ['MRN', 'MRN123456'],
     ['OpenMRS ID', 'OP789'],
   ]),
+  photoUrl: '/openmrs/ws/fhir2/R4/Patient/test-uuid/$photo',
 };
 
 export const mockMinimalPatient: FormattedPatientData = {
@@ -21,4 +22,5 @@ export const mockMinimalPatient: FormattedPatientData = {
   formattedAddress: null,
   formattedContact: null,
   identifiers: new Map(),
+  photoUrl: undefined,
 };

--- a/packages/bahmni-widgets/src/userPrivileges/patientPhotoPrivileges.ts
+++ b/packages/bahmni-widgets/src/userPrivileges/patientPhotoPrivileges.ts
@@ -1,0 +1,1 @@
+export const GET_PATIENT_PHOTO_PRIVILEGE = 'Get Patient Photo';


### PR DESCRIPTION
## Summary
- Fix: existing patient photo was being deleted on re-save because `patientImage` state was never initialized from the loaded photo
- When editing a patient, `initialPhoto` (fetched via `usePatientPhoto`) was only used for display, not carried into the save payload

## Root Cause
`patientImage` in `Profile.tsx` was initialized as `''`. On save, `getData()` checked `patientImage && { image: patientImage }` — since it was empty, `image` was excluded from the profile data. The mapper then sent `photo: []`, which deleted the existing photo on the backend.

## Fix
Added a `useEffect` in `Profile.tsx` that syncs `initialPhoto` (data URL) into `patientImage` (raw base64) when it loads. Strips the `data:image/jpeg;base64,` prefix since the backend expects raw base64.

## Behavior
| Scenario | Before | After |
|---|---|---|
| Re-save without changes | `photo: []` — photo deleted | `photo: [{data}]` — photo preserved |
| Upload new photo | `photo: [{data}]` | `photo: [{data}]` — unchanged |
| Delete photo | `photo: []` | `photo: []` — unchanged |
| New patient, no photo | `photo: []` | `photo: []` — unchanged |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Patient photo access now requires "Get Patient Photo" privilege gating
  * Patient photos integrated into FHIR patient data mapping and registration workflow
  * Improved date of birth estimation behavior for age-based patient entry

* **Bug Fixes**
  * Patient photos now retrieved via direct URLs instead of patient UUID lookups

<!-- end of auto-generated comment: release notes by coderabbit.ai -->