### PR TITLE
BAH-4725 | Fix patient photo not preserved on re-save

### DIFF
--- a/apps/registration/src/components/forms/profile/Profile.tsx
+++ b/apps/registration/src/components/forms/profile/Profile.tsx
@@ -108,6 +108,15 @@ export const Profile = ({
   const [patientImage, setPatientImage] = useState<string>('');
 
   useEffect(() => {
+    if (initialPhoto && !patientImage) {
+      const base64 = initialPhoto.includes(',')
+        ? initialPhoto.split(',')[1]
+        : initialPhoto;
+      setPatientImage(base64);
+    }
+  }, [initialPhoto]);
+
+  useEffect(() => {
     if (initialData) {
       setFormData({
         patientIdFormat:


### PR DESCRIPTION
## Summary
- Fix: existing patient photo was being deleted on re-save because `patientImage` state was never initialized from the loaded photo
- When editing a patient, `initialPhoto` (fetched via `usePatientPhoto`) was only used for display, not carried into the save payload

## Root Cause
`patientImage` in `Profile.tsx` was initialized as `''`. On save, `getData()` checked `patientImage && { image: patientImage }` — since it was empty, `image` was excluded from the profile data. The mapper then sent `photo: []`, which deleted the existing photo on the backend.

## Fix
Added a `useEffect` in `Profile.tsx` that syncs `initialPhoto` (data URL) into `patientImage` (raw base64) when it loads. Strips the `data:image/jpeg;base64,` prefix since the backend expects raw base64.

## Behavior
| Scenario | Before | After |
|---|---|---|
| Re-save without changes | `photo: []` — photo deleted | `photo: [{data}]` — photo preserved |
| Upload new photo | `photo: [{data}]` | `photo: [{data}]` — unchanged |
| Delete photo | `photo: []` | `photo: []` — unchanged |
| New patient, no photo | `photo: []` | `photo: []` — unchanged |