### PR TITLE
Fix. Use DELETE+POST for same-session allergy reaction rem…

### DIFF
--- a/apps/clinical/src/constants/allergy.ts
+++ b/apps/clinical/src/constants/allergy.ts
@@ -1,6 +1,8 @@
 import { Coding } from 'fhir/r4';
 import { AllergenType } from '../models/allergy';
 
+export const ALLERGY_INTOLERANCE_RESOURCE_TYPE = 'AllergyIntolerance';
+
 export const ALLERGY_SEVERITY_CONCEPTS: Coding[] = [
   {
     code: 'mild',

--- a/apps/clinical/src/services/__tests__/consultationBundleService.test.ts
+++ b/apps/clinical/src/services/__tests__/consultationBundleService.test.ts
@@ -737,6 +737,62 @@ describe('consultationBundleService', () => {
         expect(result[0].fullUrl).toBe('AllergyIntolerance/uuid-B');
       });
 
+      it('should not include server-generated text field in PUT body', () => {
+        const allergyWithText: AllergyInputEntry = {
+          ...mockExistingAllergy,
+          rawFhirResource: {
+            ...mockRawFhirResource,
+            text: {
+              status: 'generated',
+              div: '<div xmlns="http://www.w3.org/1999/xhtml">Common Types &amp; Triggers</div>',
+            },
+          },
+        };
+
+        const result = createAllergiesBundleEntries({
+          selectedAllergies: [allergyWithText],
+          encounterSubject: mockEncounterSubject,
+          encounterReference: mockEncounterReference,
+          practitionerUUID: mockPractitionerUUID,
+        });
+
+        expect((result[0].resource as AllergyIntolerance).text).toBeUndefined();
+      });
+
+      it('should use note from form state in PUT body', () => {
+        const allergyWithNote: AllergyInputEntry = {
+          ...mockExistingAllergy,
+          note: 'Updated note from form',
+        };
+
+        const result = createAllergiesBundleEntries({
+          selectedAllergies: [allergyWithNote],
+          encounterSubject: mockEncounterSubject,
+          encounterReference: mockEncounterReference,
+          practitionerUUID: mockPractitionerUUID,
+        });
+
+        expect((result[0].resource as AllergyIntolerance).note).toEqual([
+          { text: 'Updated note from form' },
+        ]);
+      });
+
+      it('should clear note in PUT body when form note is empty', () => {
+        const allergyWithClearedNote: AllergyInputEntry = {
+          ...mockExistingAllergy,
+          note: '',
+        };
+
+        const result = createAllergiesBundleEntries({
+          selectedAllergies: [allergyWithClearedNote],
+          encounterSubject: mockEncounterSubject,
+          encounterReference: mockEncounterReference,
+          practitionerUUID: mockPractitionerUUID,
+        });
+
+        expect((result[0].resource as AllergyIntolerance).note).toBeUndefined();
+      });
+
       it('should POST (not PUT) for new allergy without resourceId', () => {
         const newAllergy: AllergyInputEntry = {
           ...mockValidAllergy,
@@ -875,6 +931,24 @@ describe('consultationBundleService', () => {
 
         const postResource = result[1].resource as AllergyIntolerance;
         expect(postResource.reaction?.[0].severity).toBe('mild');
+      });
+
+      it('POST resource carries the note from the allergy entry', () => {
+        const allergyWithNote: AllergyInputEntry = {
+          ...mockCrossSessionAllergy,
+          note: 'Cross-session allergy note',
+        };
+
+        const result = createAllergiesBundleEntries({
+          selectedAllergies: [allergyWithNote],
+          encounterSubject: mockEncounterSubject,
+          encounterReference: mockEncounterReference,
+          practitionerUUID: mockPractitionerUUID,
+        });
+
+        expect((result[1].resource as AllergyIntolerance).note).toEqual([
+          { text: 'Cross-session allergy note' },
+        ]);
       });
 
       it('skips cross-session allergy when isModified is false', () => {
@@ -1090,6 +1164,36 @@ describe('consultationBundleService', () => {
         });
 
         expect(result[1].fullUrl).toMatch(/^urn:uuid:/);
+      });
+
+      it('POST entry carries the current encounter reference', () => {
+        const result = createAllergiesBundleEntries({
+          selectedAllergies: [mockSameSessionAllergyWithReactionRemoved],
+          encounterSubject: mockEncounterSubject,
+          encounterReference: mockEncounterReference,
+          practitionerUUID: mockPractitionerUUID,
+        });
+
+        const postResource = result[1].resource as AllergyIntolerance;
+        expect(postResource.encounter?.reference).toBe(mockEncounterReference);
+      });
+
+      it('POST entry carries the note from the allergy entry', () => {
+        const allergyWithNote: AllergyInputEntry = {
+          ...mockSameSessionAllergyWithReactionRemoved,
+          note: 'Reaction note for same session',
+        };
+
+        const result = createAllergiesBundleEntries({
+          selectedAllergies: [allergyWithNote],
+          encounterSubject: mockEncounterSubject,
+          encounterReference: mockEncounterReference,
+          practitionerUUID: mockPractitionerUUID,
+        });
+
+        expect((result[1].resource as AllergyIntolerance).note).toEqual([
+          { text: 'Reaction note for same session' },
+        ]);
       });
 
       it('uses PUT when reactions are only added or unchanged in same session', () => {

--- a/apps/clinical/src/services/__tests__/consultationBundleService.test.ts
+++ b/apps/clinical/src/services/__tests__/consultationBundleService.test.ts
@@ -947,6 +947,176 @@ describe('consultationBundleService', () => {
       });
     });
 
+    describe('Same-session reaction removal (DELETE+POST) paths', () => {
+      const mockRawFhirWithTwoReactions: AllergyIntolerance = {
+        resourceType: 'AllergyIntolerance',
+        id: 'allergy-same-session',
+        clinicalStatus: {
+          coding: [
+            {
+              system:
+                'http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical',
+              code: 'active',
+            },
+          ],
+        },
+        code: {
+          coding: [
+            {
+              code: '162536AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+              display: 'Penicillin',
+            },
+          ],
+          text: 'Penicillin',
+        },
+        patient: { reference: 'Patient/patient-123' },
+        encounter: { reference: mockEncounterReference },
+        reaction: [
+          {
+            manifestation: [
+              {
+                coding: [
+                  {
+                    code: '121677AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+                    display: 'Rash',
+                  },
+                ],
+                text: 'Rash',
+              },
+            ],
+            severity: 'moderate' as const,
+          },
+          {
+            manifestation: [
+              {
+                coding: [
+                  {
+                    code: '121629AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+                    display: 'Anaemia',
+                  },
+                ],
+                text: 'Anaemia',
+              },
+            ],
+            severity: 'moderate' as const,
+          },
+        ],
+      };
+
+      const mockSameSessionAllergyWithReactionRemoved: AllergyInputEntry = {
+        id: '162536AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+        display: 'Penicillin',
+        type: 'medication',
+        selectedSeverity: { code: 'mild', display: 'Mild' },
+        selectedReactions: [
+          { code: '121677AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', display: 'Rash' },
+        ],
+        errors: {},
+        hasBeenValidated: true,
+        resourceId: 'allergy-same-session',
+        isModified: true,
+        rawFhirResource: mockRawFhirWithTwoReactions,
+      };
+
+      it('produces DELETE+POST when a reaction is removed in same session', () => {
+        const result = createAllergiesBundleEntries({
+          selectedAllergies: [mockSameSessionAllergyWithReactionRemoved],
+          encounterSubject: mockEncounterSubject,
+          encounterReference: mockEncounterReference,
+          practitionerUUID: mockPractitionerUUID,
+        });
+
+        expect(result).toHaveLength(2);
+        expect((result[0].request as { method: string }).method).toBe('DELETE');
+        expect((result[1].request as { method: string }).method).toBe('POST');
+      });
+
+      it('DELETE entry targets the existing allergy UUID', () => {
+        const result = createAllergiesBundleEntries({
+          selectedAllergies: [mockSameSessionAllergyWithReactionRemoved],
+          encounterSubject: mockEncounterSubject,
+          encounterReference: mockEncounterReference,
+          practitionerUUID: mockPractitionerUUID,
+        });
+
+        expect((result[0].request as { url: string }).url).toBe(
+          'AllergyIntolerance/allergy-same-session',
+        );
+        expect(result[0].fullUrl).toBe(
+          'AllergyIntolerance/allergy-same-session',
+        );
+      });
+
+      it('POST entry has only the remaining reaction, not the removed one', () => {
+        const result = createAllergiesBundleEntries({
+          selectedAllergies: [mockSameSessionAllergyWithReactionRemoved],
+          encounterSubject: mockEncounterSubject,
+          encounterReference: mockEncounterReference,
+          practitionerUUID: mockPractitionerUUID,
+        });
+
+        const postResource = result[1].resource as AllergyIntolerance;
+        const manifestationCodes =
+          postResource.reaction?.[0].manifestation.flatMap(
+            (m) => m.coding?.map((c) => c.code) ?? [],
+          );
+        expect(manifestationCodes).toContain(
+          '121677AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+        );
+        expect(manifestationCodes).not.toContain(
+          '121629AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+        );
+      });
+
+      it('POST entry carries the updated severity', () => {
+        const result = createAllergiesBundleEntries({
+          selectedAllergies: [mockSameSessionAllergyWithReactionRemoved],
+          encounterSubject: mockEncounterSubject,
+          encounterReference: mockEncounterReference,
+          practitionerUUID: mockPractitionerUUID,
+        });
+
+        expect(
+          (result[1].resource as AllergyIntolerance).reaction?.[0].severity,
+        ).toBe('mild');
+      });
+
+      it('POST entry has a new urn:uuid URL', () => {
+        const result = createAllergiesBundleEntries({
+          selectedAllergies: [mockSameSessionAllergyWithReactionRemoved],
+          encounterSubject: mockEncounterSubject,
+          encounterReference: mockEncounterReference,
+          practitionerUUID: mockPractitionerUUID,
+        });
+
+        expect(result[1].fullUrl).toMatch(/^urn:uuid:/);
+      });
+
+      it('uses PUT when reactions are only added or unchanged in same session', () => {
+        const allergyWithReactionAdded: AllergyInputEntry = {
+          ...mockSameSessionAllergyWithReactionRemoved,
+          selectedReactions: [
+            { code: '121677AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', display: 'Rash' },
+            {
+              code: '121629AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+              display: 'Anaemia',
+            },
+            { code: '143264AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', display: 'Cough' },
+          ],
+        };
+
+        const result = createAllergiesBundleEntries({
+          selectedAllergies: [allergyWithReactionAdded],
+          encounterSubject: mockEncounterSubject,
+          encounterReference: mockEncounterReference,
+          practitionerUUID: mockPractitionerUUID,
+        });
+
+        expect(result).toHaveLength(1);
+        expect((result[0].request as { method: string }).method).toBe('PUT');
+      });
+    });
+
     describe('createEncounterBundleEntry', () => {
       const mockEncounterResource = {
         resourceType: 'Encounter',

--- a/apps/clinical/src/services/consultationBundleService.ts
+++ b/apps/clinical/src/services/consultationBundleService.ts
@@ -124,6 +124,35 @@ export function createDiagnosisBundleEntries({
   return diagnosisEntries;
 }
 
+function createDeleteAndPostAllergyEntries(
+  allergy: AllergyInputEntry,
+  manifestationUUIDs: string[],
+  severity: 'mild' | 'moderate' | 'severe',
+  encounterSubject: Reference,
+  encounterReference: string,
+  practitionerUUID: string,
+): BundleEntry[] {
+  const deleteURL = `${ALLERGY_INTOLERANCE_RESOURCE_TYPE}/${allergy.resourceId}`;
+  const newResource = createEncounterAllergyResource(
+    allergy.id,
+    [allergy.type] as Array<'food' | 'medication' | 'environment' | 'biologic'>,
+    [{ manifestationUUIDs, severity }],
+    encounterSubject,
+    createEncounterReferenceFromString(encounterReference),
+    createPractitionerReference(practitionerUUID),
+    allergy.note,
+  );
+  return [
+    createBundleEntry(
+      deleteURL,
+      createDeleteAllergyResource(allergy.resourceId!),
+      'DELETE',
+      deleteURL,
+    ),
+    createBundleEntry(`urn:uuid:${crypto.randomUUID()}`, newResource, 'POST'),
+  ];
+}
+
 /**
  * Creates bundle entries for allergies as part of consultation bundle
  * @param params - Parameters required for creating allergy bundle entries
@@ -224,61 +253,26 @@ export function createAllergiesBundleEntries({
             createBundleEntry(putURL, putResource, 'PUT', putURL),
           );
         } else {
-          const deleteURL = `${ALLERGY_INTOLERANCE_RESOURCE_TYPE}/${allergy.resourceId}`;
           allergyEntries.push(
-            createBundleEntry(
-              deleteURL,
-              createDeleteAllergyResource(allergy.resourceId!),
-              'DELETE',
-              deleteURL,
-            ),
-          );
-          const newResource = createEncounterAllergyResource(
-            allergy.id,
-            [allergy.type] as Array<
-              'food' | 'medication' | 'environment' | 'biologic'
-            >,
-            [{ manifestationUUIDs, severity }],
-            encounterSubject,
-            createEncounterReferenceFromString(encounterReference),
-            createPractitionerReference(practitionerUUID),
-            allergy.note,
-          );
-          allergyEntries.push(
-            createBundleEntry(
-              `urn:uuid:${crypto.randomUUID()}`,
-              newResource,
-              'POST',
+            ...createDeleteAndPostAllergyEntries(
+              allergy,
+              manifestationUUIDs,
+              severity,
+              encounterSubject,
+              encounterReference,
+              practitionerUUID,
             ),
           );
         }
       } else {
-        const deleteURL = `${ALLERGY_INTOLERANCE_RESOURCE_TYPE}/${allergy.resourceId}`;
         allergyEntries.push(
-          createBundleEntry(
-            deleteURL,
-            createDeleteAllergyResource(allergy.resourceId!),
-            'DELETE',
-            deleteURL,
-          ),
-        );
-
-        const newResource = createEncounterAllergyResource(
-          allergy.id,
-          [allergy.type] as Array<
-            'food' | 'medication' | 'environment' | 'biologic'
-          >,
-          [{ manifestationUUIDs, severity }],
-          encounterSubject,
-          createEncounterReferenceFromString(encounterReference),
-          createPractitionerReference(practitionerUUID),
-          allergy.note,
-        );
-        allergyEntries.push(
-          createBundleEntry(
-            `urn:uuid:${crypto.randomUUID()}`,
-            newResource,
-            'POST',
+          ...createDeleteAndPostAllergyEntries(
+            allergy,
+            manifestationUUIDs,
+            severity,
+            encounterSubject,
+            encounterReference,
+            practitionerUUID,
           ),
         );
       }

--- a/apps/clinical/src/services/consultationBundleService.ts
+++ b/apps/clinical/src/services/consultationBundleService.ts
@@ -6,6 +6,7 @@ import {
   Form2Observation,
 } from '@bahmni/services';
 import { BundleEntry, Reference, Encounter, CodeableConcept } from 'fhir/r4';
+import { ALLERGY_INTOLERANCE_RESOURCE_TYPE } from '../constants/allergy';
 import { CONSULTATION_BUNDLE_URL } from '../constants/app';
 import { CONSULTATION_ERROR_MESSAGES } from '../constants/errors';
 import { AllergyInputEntry } from '../models/allergy';
@@ -218,12 +219,12 @@ export function createAllergiesBundleEntries({
             createEncounterReferenceFromString(encounterReference),
             allergy.note,
           );
-          const putURL = `AllergyIntolerance/${allergy.resourceId}`;
+          const putURL = `${ALLERGY_INTOLERANCE_RESOURCE_TYPE}/${allergy.resourceId}`;
           allergyEntries.push(
             createBundleEntry(putURL, putResource, 'PUT', putURL),
           );
         } else {
-          const deleteURL = `AllergyIntolerance/${allergy.resourceId}`;
+          const deleteURL = `${ALLERGY_INTOLERANCE_RESOURCE_TYPE}/${allergy.resourceId}`;
           allergyEntries.push(
             createBundleEntry(
               deleteURL,
@@ -252,7 +253,7 @@ export function createAllergiesBundleEntries({
           );
         }
       } else {
-        const deleteURL = `AllergyIntolerance/${allergy.resourceId}`;
+        const deleteURL = `${ALLERGY_INTOLERANCE_RESOURCE_TYPE}/${allergy.resourceId}`;
         allergyEntries.push(
           createBundleEntry(
             deleteURL,

--- a/apps/clinical/src/services/consultationBundleService.ts
+++ b/apps/clinical/src/services/consultationBundleService.ts
@@ -202,17 +202,55 @@ export function createAllergiesBundleEntries({
               existingManifestationByCode.get(code) ?? { coding: [{ code }] },
           );
 
-        const putResource = updateEncounterAllergyResource(
-          allergy.rawFhirResource,
-          manifestations,
-          severity,
-          createEncounterReferenceFromString(encounterReference),
-          allergy.note,
+        // OpenMRS FHIR2 appends reactions on PUT rather than replacing them,
+        // so PUT cannot remove a reaction. Fall through to DELETE+POST when
+        // the user has removed one or more reactions.
+        const manifestationUUIDSet = new Set(manifestationUUIDs);
+        const reactionsRemoved = [...existingManifestationByCode.keys()].some(
+          (code) => !manifestationUUIDSet.has(code),
         );
-        const putURL = `AllergyIntolerance/${allergy.resourceId}`;
-        allergyEntries.push(
-          createBundleEntry(putURL, putResource, 'PUT', putURL),
-        );
+
+        if (!reactionsRemoved) {
+          const putResource = updateEncounterAllergyResource(
+            allergy.rawFhirResource,
+            manifestations,
+            severity,
+            createEncounterReferenceFromString(encounterReference),
+            allergy.note,
+          );
+          const putURL = `AllergyIntolerance/${allergy.resourceId}`;
+          allergyEntries.push(
+            createBundleEntry(putURL, putResource, 'PUT', putURL),
+          );
+        } else {
+          const deleteURL = `AllergyIntolerance/${allergy.resourceId}`;
+          allergyEntries.push(
+            createBundleEntry(
+              deleteURL,
+              createDeleteAllergyResource(allergy.resourceId!),
+              'DELETE',
+              deleteURL,
+            ),
+          );
+          const newResource = createEncounterAllergyResource(
+            allergy.id,
+            [allergy.type] as Array<
+              'food' | 'medication' | 'environment' | 'biologic'
+            >,
+            [{ manifestationUUIDs, severity }],
+            encounterSubject,
+            createEncounterReferenceFromString(encounterReference),
+            createPractitionerReference(practitionerUUID),
+            allergy.note,
+          );
+          allergyEntries.push(
+            createBundleEntry(
+              `urn:uuid:${crypto.randomUUID()}`,
+              newResource,
+              'POST',
+            ),
+          );
+        }
       } else {
         const deleteURL = `AllergyIntolerance/${allergy.resourceId}`;
         allergyEntries.push(

--- a/apps/clinical/src/utils/fhir/__tests__/allergyResourceCreator.test.ts
+++ b/apps/clinical/src/utils/fhir/__tests__/allergyResourceCreator.test.ts
@@ -1,5 +1,9 @@
-import { Reference } from 'fhir/r4';
-import { createEncounterAllergyResource } from '../allergyResourceCreator';
+import { AllergyIntolerance, Reference } from 'fhir/r4';
+import {
+  createDeleteAllergyResource,
+  createEncounterAllergyResource,
+  updateEncounterAllergyResource,
+} from '../allergyResourceCreator';
 
 describe('allergyResourceCreator', () => {
   const mockPatientReference: Reference = {
@@ -360,5 +364,203 @@ describe('allergyResourceCreator', () => {
     );
 
     expect(allergyResource).not.toHaveProperty('note');
+  });
+});
+
+describe('createDeleteAllergyResource', () => {
+  it('returns a minimal resource with only resourceType and id', () => {
+    const result = createDeleteAllergyResource('allergy-uuid-123');
+
+    expect(result.resourceType).toBe('AllergyIntolerance');
+    expect(result.id).toBe('allergy-uuid-123');
+  });
+
+  it('does not include text, meta, or any other server-generated fields', () => {
+    const result = createDeleteAllergyResource('allergy-uuid-123');
+
+    expect(result).not.toHaveProperty('text');
+    expect(result).not.toHaveProperty('meta');
+    expect(result).not.toHaveProperty('clinicalStatus');
+    expect(result).not.toHaveProperty('reaction');
+  });
+});
+
+describe('updateEncounterAllergyResource', () => {
+  const mockExisting: AllergyIntolerance = {
+    resourceType: 'AllergyIntolerance',
+    id: 'allergy-uuid-123',
+    meta: { versionId: '1', lastUpdated: '2026-06-04T09:31:25.000+00:00' },
+    text: {
+      status: 'generated',
+      div: '<div xmlns="http://www.w3.org/1999/xhtml">Common Types &amp; Triggers</div>',
+    },
+    clinicalStatus: {
+      coding: [
+        {
+          system:
+            'http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical',
+          code: 'active',
+          display: 'Active',
+        },
+      ],
+    },
+    verificationStatus: {
+      coding: [
+        {
+          system:
+            'http://terminology.hl7.org/CodeSystem/allergyintolerance-verification',
+          code: 'confirmed',
+        },
+      ],
+    },
+    type: 'allergy',
+    category: ['medication'],
+    criticality: 'high',
+    code: {
+      coding: [
+        { code: '162536AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', display: 'Penicillin' },
+        { system: 'http://snomed.info/sct', code: '372687004' },
+      ],
+      text: 'Penicillin',
+    },
+    patient: { reference: 'Patient/patient-123' },
+    recordedDate: '2026-06-04T09:31:25+00:00',
+    recorder: {
+      reference: 'Practitioner/practitioner-123',
+      display: 'Dr. Smith',
+    },
+    note: [{ text: 'Original note' }],
+    reaction: [
+      {
+        manifestation: [
+          {
+            coding: [
+              { code: '121677AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', display: 'Rash' },
+              { system: 'http://snomed.info/sct', code: '271807003' },
+            ],
+            text: 'Rash',
+          },
+        ],
+        severity: 'moderate',
+      },
+    ],
+  };
+
+  const mockEncounterRef: Reference = {
+    reference: 'Encounter/enc-uuid-456',
+  };
+
+  const mockManifestations = [
+    {
+      coding: [
+        { code: '121677AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', display: 'Rash' },
+        { system: 'http://snomed.info/sct', code: '271807003' },
+      ],
+      text: 'Rash',
+    },
+  ];
+
+  it('does not include server-generated text.div in the output', () => {
+    const result = updateEncounterAllergyResource(
+      mockExisting,
+      mockManifestations,
+      'severe',
+      mockEncounterRef,
+    );
+
+    expect(result).not.toHaveProperty('text');
+  });
+
+  it('preserves identity and metadata fields from existing resource', () => {
+    const result = updateEncounterAllergyResource(
+      mockExisting,
+      mockManifestations,
+      'severe',
+      mockEncounterRef,
+    );
+
+    expect(result.id).toBe('allergy-uuid-123');
+    expect(result.meta).toEqual(mockExisting.meta);
+    expect(result.clinicalStatus).toEqual(mockExisting.clinicalStatus);
+    expect(result.verificationStatus).toEqual(mockExisting.verificationStatus);
+    expect(result.type).toBe('allergy');
+    expect(result.category).toEqual(['medication']);
+    expect(result.criticality).toBe('high');
+    expect(result.code).toEqual(mockExisting.code);
+    expect(result.patient).toEqual(mockExisting.patient);
+    expect(result.recordedDate).toBe('2026-06-04T09:31:25+00:00');
+    expect(result.recorder).toEqual(mockExisting.recorder);
+  });
+
+  it('updates reaction with new severity and manifestations', () => {
+    const result = updateEncounterAllergyResource(
+      mockExisting,
+      mockManifestations,
+      'severe',
+      mockEncounterRef,
+    );
+
+    expect(result.reaction).toHaveLength(1);
+    expect(result.reaction?.[0].severity).toBe('severe');
+    expect(result.reaction?.[0].manifestation).toEqual(mockManifestations);
+    expect(result.reaction?.[0].substance).toEqual(mockExisting.code);
+  });
+
+  it('sets encounter to the new encounter reference', () => {
+    const result = updateEncounterAllergyResource(
+      mockExisting,
+      mockManifestations,
+      'moderate',
+      mockEncounterRef,
+    );
+
+    expect(result.encounter).toEqual(mockEncounterRef);
+  });
+
+  it('uses note from parameter, not from existing resource', () => {
+    const result = updateEncounterAllergyResource(
+      mockExisting,
+      mockManifestations,
+      'moderate',
+      mockEncounterRef,
+      'Updated note from form',
+    );
+
+    expect(result.note).toEqual([{ text: 'Updated note from form' }]);
+  });
+
+  it('trims whitespace from note', () => {
+    const result = updateEncounterAllergyResource(
+      mockExisting,
+      mockManifestations,
+      'moderate',
+      mockEncounterRef,
+      '  trimmed note  ',
+    );
+
+    expect(result.note).toEqual([{ text: 'trimmed note' }]);
+  });
+
+  it('sets note to undefined when note parameter is empty', () => {
+    const result = updateEncounterAllergyResource(
+      mockExisting,
+      mockManifestations,
+      'moderate',
+      mockEncounterRef,
+      '',
+    );
+
+    expect(result.note).toBeUndefined();
+  });
+
+  it('sets note to undefined when note parameter is not provided', () => {
+    const result = updateEncounterAllergyResource(
+      mockExisting,
+      mockManifestations,
+      'moderate',
+      mockEncounterRef,
+    );
+
+    expect(result.note).toBeUndefined();
   });
 });


### PR DESCRIPTION
Fix: Reaction removal not working for same-session allergy edits                                                     
                                                                                                                                                                               
  Problem                                                                                                                                                                      
                                                                                                                                                                               
  When editing an allergy that was recorded in the current consultation (same encounter), removing a reaction had no effect — the removed reaction persisted after save.       
                                                                                                                                                                               
  The same-session edit path used a PUT request. OpenMRS FHIR2 does not replace reactions on PUT — it appends to existing reactions. This means sending fewer reactions in the 
  PUT body does not remove the ones left off. Confirmed via direct Bruno test against the FHIR endpoint.                                                                     
                                                                                                                                                                               
  The cross-session path (allergy from a previous visit) already worked correctly because it uses DELETE+POST, which wipes the old resource and creates a fresh one with only  
  the selected reactions.
                                                                                                                                                                               
  Fix                                                                                                                                                                        

  In createAllergiesBundleEntries, before issuing a same-session PUT, compare the original reaction codes from rawFhirResource against the user's current selection:           
   
  const manifestationUUIDSet = new Set(manifestationUUIDs);                                                                                                                    
  const reactionsRemoved = [...existingManifestationByCode.keys()].some(                                                                                                     
    (code) => !manifestationUUIDSet.has(code),                                                                                                                                 
  );
                                                                                                                                                                               
  - No reactions removed → PUT (safe, OpenMRS append behaviour doesn't matter when nothing is being removed)                                                                   
  - Reactions removed → DELETE+POST, identical to the cross-session path — DELETE removes the existing resource, POST creates a clean one with only the selected reactions
                                                                                                                                                                               
  Decision: why not always DELETE+POST?                                                                                                                                        
                                                                                                                                                                               
  PUT is preferred when no reactions are removed because it preserves the existing resource UUID, criticality, recordedDate, recorder attribution, and FHIR version history.   
  DELETE+POST creates a new resource with a new server-assigned UUID, losing those fields. Falling through to DELETE+POST only when necessary keeps the impact minimal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed allergy reaction management during clinical consultations. The system now correctly processes the removal of allergy reactions within the same encounter, ensuring patient allergy records accurately reflect current selections and completely remove unwanted reactions. This prevents data inconsistencies and improves clinical safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->