### PR TITLE
BAH-4655. Refactor: Use encounter Type instead of encounter uuid

### DIFF
--- a/apps/registration/src/hooks/__tests__/useCreatePatient.test.tsx
+++ b/apps/registration/src/hooks/__tests__/useCreatePatient.test.tsx
@@ -10,9 +10,10 @@ import { ReactNode } from 'react';
 import { PersonAttributesProvider } from '../../providers/PersonAttributesProvider';
 import { useCreatePatient } from '../useCreatePatient';
 
-const mockUseRegistrationConfig = jest.fn();
-jest.mock('../../providers/registrationConfig', () => ({
-  useRegistrationConfig: () => mockUseRegistrationConfig(),
+const mockUseRegistrationEncounterTypeUuid = jest.fn();
+jest.mock('../useRegistrationEncounterTypeUuid', () => ({
+  useRegistrationEncounterTypeUuid: () =>
+    mockUseRegistrationEncounterTypeUuid(),
 }));
 
 jest.mock('@bahmni/services', () => ({
@@ -134,7 +135,7 @@ describe('useCreatePatient', () => {
     mockUseNotification.mockReturnValue({
       addNotification: mockAddNotification,
     });
-    mockUseRegistrationConfig.mockReturnValue({ registrationConfig: null });
+    mockUseRegistrationEncounterTypeUuid.mockReturnValue(undefined);
     mockCreateRegistrationEncounterForPatient.mockResolvedValue(undefined);
     window.history.replaceState = jest.fn();
   });
@@ -264,11 +265,9 @@ describe('useCreatePatient', () => {
 
   it('should create a registration encounter after patient is saved when encounter type is configured', async () => {
     mockCreateFhirPatient.mockResolvedValue(mockFhirResponse);
-    mockUseRegistrationConfig.mockReturnValue({
-      registrationConfig: {
-        registrationEncounterTypeUuid: 'reg-encounter-type-uuid',
-      },
-    });
+    mockUseRegistrationEncounterTypeUuid.mockReturnValue(
+      'reg-encounter-type-uuid',
+    );
 
     const { result } = renderHook(() => useCreatePatient(), {
       wrapper: createWrapper(),
@@ -285,11 +284,7 @@ describe('useCreatePatient', () => {
 
   it('should not create a registration encounter when encounter type is not configured', async () => {
     mockCreateFhirPatient.mockResolvedValue(mockFhirResponse);
-    mockUseRegistrationConfig.mockReturnValue({
-      registrationConfig: {
-        registrationEncounterTypeUuid: undefined,
-      },
-    });
+    mockUseRegistrationEncounterTypeUuid.mockReturnValue(undefined);
 
     const { result } = renderHook(() => useCreatePatient(), {
       wrapper: createWrapper(),
@@ -308,11 +303,9 @@ describe('useCreatePatient', () => {
 
   it('should show error notification and not block patient save when encounter creation fails', async () => {
     mockCreateFhirPatient.mockResolvedValue(mockFhirResponse);
-    mockUseRegistrationConfig.mockReturnValue({
-      registrationConfig: {
-        registrationEncounterTypeUuid: 'reg-encounter-type-uuid',
-      },
-    });
+    mockUseRegistrationEncounterTypeUuid.mockReturnValue(
+      'reg-encounter-type-uuid',
+    );
     mockCreateRegistrationEncounterForPatient.mockRejectedValue(
       new Error('Encounter creation failed'),
     );

--- a/apps/registration/src/hooks/__tests__/useRegistrationEncounterTypeUuid.test.tsx
+++ b/apps/registration/src/hooks/__tests__/useRegistrationEncounterTypeUuid.test.tsx
@@ -1,0 +1,90 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+import { useRegistrationEncounterTypeUuid } from '../useRegistrationEncounterTypeUuid';
+
+const mockGetEncounterTypeUuidByName = jest.fn();
+jest.mock('../../services/registrationEncounterService', () => ({
+  getEncounterTypeUuidByName: (...args: unknown[]) =>
+    mockGetEncounterTypeUuidByName(...args),
+}));
+
+const mockUseRegistrationConfig = jest.fn();
+jest.mock('../../providers/registrationConfig', () => ({
+  useRegistrationConfig: () => mockUseRegistrationConfig(),
+}));
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return Wrapper;
+};
+
+describe('useRegistrationEncounterTypeUuid', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return the encounter type uuid when config and lookup succeed', async () => {
+    mockUseRegistrationConfig.mockReturnValue({
+      registrationConfig: { registrationEncounterType: 'Registration' },
+    });
+    mockGetEncounterTypeUuidByName.mockResolvedValue('enc-type-uuid-123');
+
+    const { result } = renderHook(() => useRegistrationEncounterTypeUuid(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current).toBe('enc-type-uuid-123');
+    });
+    expect(mockGetEncounterTypeUuidByName).toHaveBeenCalledWith('Registration');
+  });
+
+  it('should return undefined when registrationEncounterType is not configured', async () => {
+    mockUseRegistrationConfig.mockReturnValue({
+      registrationConfig: {},
+    });
+
+    const { result } = renderHook(() => useRegistrationEncounterTypeUuid(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current).toBeUndefined();
+    });
+    expect(mockGetEncounterTypeUuidByName).not.toHaveBeenCalled();
+  });
+
+  it('should return undefined when registrationConfig is not yet loaded', async () => {
+    mockUseRegistrationConfig.mockReturnValue({ registrationConfig: null });
+
+    const { result } = renderHook(() => useRegistrationEncounterTypeUuid(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current).toBeUndefined();
+    });
+    expect(mockGetEncounterTypeUuidByName).not.toHaveBeenCalled();
+  });
+
+  it('should return undefined when the encounter type name is not found in OpenMRS', async () => {
+    mockUseRegistrationConfig.mockReturnValue({
+      registrationConfig: { registrationEncounterType: 'Unknown Type' },
+    });
+    mockGetEncounterTypeUuidByName.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useRegistrationEncounterTypeUuid(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current).toBeUndefined();
+    });
+  });
+});

--- a/apps/registration/src/hooks/__tests__/useVisit.test.tsx
+++ b/apps/registration/src/hooks/__tests__/useVisit.test.tsx
@@ -11,9 +11,10 @@ const mockAddNotification = jest.fn();
 const mockFindValidRegistrationEncounterInSession = jest.fn();
 const mockCreateRegistrationEncounterForPatient = jest.fn();
 
-const mockUseRegistrationConfig = jest.fn();
-jest.mock('../../providers/registrationConfig', () => ({
-  useRegistrationConfig: () => mockUseRegistrationConfig(),
+const mockUseRegistrationEncounterTypeUuid = jest.fn();
+jest.mock('../useRegistrationEncounterTypeUuid', () => ({
+  useRegistrationEncounterTypeUuid: () =>
+    mockUseRegistrationEncounterTypeUuid(),
 }));
 
 const mockLinkRegistrationEncounterToVisit = jest.fn();
@@ -57,7 +58,7 @@ describe('useVisit', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockUseRegistrationConfig.mockReturnValue({ registrationConfig: null });
+    mockUseRegistrationEncounterTypeUuid.mockReturnValue(undefined);
     queryClient = new QueryClient({
       defaultOptions: {
         queries: {
@@ -109,7 +110,7 @@ describe('useVisit', () => {
     beforeEach(() => {
       mockCheckIfActiveVisitExists.mockResolvedValue(false);
       mockCreateVisitForPatient.mockResolvedValue({});
-      mockUseRegistrationConfig.mockReturnValue({ registrationConfig: null });
+      mockUseRegistrationEncounterTypeUuid.mockReturnValue(undefined);
       mockLinkRegistrationEncounterToVisit.mockResolvedValue(undefined);
     });
 
@@ -145,11 +146,9 @@ describe('useVisit', () => {
     });
 
     it('should link registration encounter to visit after visit creation when encounter type is configured', async () => {
-      mockUseRegistrationConfig.mockReturnValue({
-        registrationConfig: {
-          registrationEncounterTypeUuid: 'reg-encounter-type-uuid',
-        },
-      });
+      mockUseRegistrationEncounterTypeUuid.mockReturnValue(
+        'reg-encounter-type-uuid',
+      );
 
       mockFindValidRegistrationEncounterInSession.mockResolvedValue({
         id: 'enc-123',
@@ -171,11 +170,9 @@ describe('useVisit', () => {
     });
 
     it('should create a registration encounter when none exists and link it to visit', async () => {
-      mockUseRegistrationConfig.mockReturnValue({
-        registrationConfig: {
-          registrationEncounterTypeUuid: 'reg-encounter-type-uuid',
-        },
-      });
+      mockUseRegistrationEncounterTypeUuid.mockReturnValue(
+        'reg-encounter-type-uuid',
+      );
 
       mockFindValidRegistrationEncounterInSession.mockResolvedValue(null);
       mockCreateRegistrationEncounterForPatient.mockResolvedValue({
@@ -197,11 +194,9 @@ describe('useVisit', () => {
 
     it('should show error notification when encounter linkage fails', async () => {
       const error = new Error('Failed to link encounter');
-      mockUseRegistrationConfig.mockReturnValue({
-        registrationConfig: {
-          registrationEncounterTypeUuid: 'reg-encounter-type-uuid',
-        },
-      });
+      mockUseRegistrationEncounterTypeUuid.mockReturnValue(
+        'reg-encounter-type-uuid',
+      );
       mockLinkRegistrationEncounterToVisit.mockRejectedValue(error);
 
       const { result } = renderHook(() => useCreateVisit(), { wrapper });
@@ -218,10 +213,8 @@ describe('useVisit', () => {
       });
     });
 
-    it('should skip encounter linkage when registrationEncounterTypeUuid is not configured', async () => {
-      mockUseRegistrationConfig.mockReturnValue({
-        registrationConfig: {},
-      });
+    it('should skip encounter linkage when registrationEncounterType is not configured', async () => {
+      mockUseRegistrationEncounterTypeUuid.mockReturnValue(undefined);
 
       const { result } = renderHook(() => useCreateVisit(), { wrapper });
 

--- a/apps/registration/src/hooks/useCreatePatient.ts
+++ b/apps/registration/src/hooks/useCreatePatient.ts
@@ -19,11 +19,11 @@ import {
   PersonAttributesData,
   AdditionalIdentifiersData,
 } from '../models/patient';
-import { useRegistrationConfig } from '../providers/registrationConfig';
 import { createRegistrationEncounterForPatient } from '../services/registrationEncounterService';
 import { buildFhirPatient } from '../utils/fhirPatientMapper';
 import { useIdentifierTypes } from './useAdditionalIdentifiers';
 import { usePersonAttributes } from './usePersonAttributes';
+import { useRegistrationEncounterTypeUuid } from './useRegistrationEncounterTypeUuid';
 
 interface CreatePatientFormData {
   profile: BasicInfoData & {
@@ -54,10 +54,9 @@ export const useCreatePatient = () => {
   const navigate = useNavigate();
   const { personAttributes } = usePersonAttributes();
   const { data: identifierTypes } = useIdentifierTypes();
-  const { registrationConfig } = useRegistrationConfig();
+  const encounterTypeUuid = useRegistrationEncounterTypeUuid();
 
   const createRegistrationEncounter = async (patientUuid: string) => {
-    const encounterTypeUuid = registrationConfig?.registrationEncounterTypeUuid;
     if (!encounterTypeUuid) return;
 
     try {

--- a/apps/registration/src/hooks/useRegistrationEncounterTypeUuid.ts
+++ b/apps/registration/src/hooks/useRegistrationEncounterTypeUuid.ts
@@ -1,0 +1,17 @@
+import { useQuery } from '@tanstack/react-query';
+import { useRegistrationConfig } from '../providers/registrationConfig';
+import { getEncounterTypeUuidByName } from '../services/registrationEncounterService';
+
+export const useRegistrationEncounterTypeUuid = (): string | undefined => {
+  const { registrationConfig } = useRegistrationConfig();
+  const encounterTypeName = registrationConfig?.registrationEncounterType;
+
+  const { data: encounterTypeUuid } = useQuery({
+    queryKey: ['encounterType', encounterTypeName],
+    queryFn: () => getEncounterTypeUuidByName(encounterTypeName!),
+    enabled: !!encounterTypeName,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  return encounterTypeUuid;
+};

--- a/apps/registration/src/hooks/useVisit.ts
+++ b/apps/registration/src/hooks/useVisit.ts
@@ -8,12 +8,12 @@ import {
 import { useNotification } from '@bahmni/widgets';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useParams } from 'react-router-dom';
-import { useRegistrationConfig } from '../providers/registrationConfig';
 import {
   linkRegistrationEncounterToVisit,
   findValidRegistrationEncounterInSession,
   createRegistrationEncounterForPatient,
 } from '../services/registrationEncounterService';
+import { useRegistrationEncounterTypeUuid } from './useRegistrationEncounterTypeUuid';
 
 export const useVisitTypes = () => {
   const { data: visitTypes, isLoading } = useQuery({
@@ -47,7 +47,7 @@ export const useCreateVisit = () => {
   const { patientUuid } = useParams<{ patientUuid: string }>();
   const { hasActiveVisit } = useActiveVisit(patientUuid);
   const queryClient = useQueryClient();
-  const { registrationConfig } = useRegistrationConfig();
+  const encounterTypeUuid = useRegistrationEncounterTypeUuid();
 
   const createVisit = async (patientUuid: string, visitType: VisitType) => {
     try {
@@ -57,8 +57,6 @@ export const useCreateVisit = () => {
       await createVisitForPatient(patientUuid, visitType);
       queryClient.setQueryData(['hasActiveVisit', patientUuid], true);
 
-      const encounterTypeUuid =
-        registrationConfig?.registrationEncounterTypeUuid;
       if (encounterTypeUuid) {
         try {
           const existingEncounter =

--- a/apps/registration/src/providers/registrationConfig/models.ts
+++ b/apps/registration/src/providers/registrationConfig/models.ts
@@ -104,7 +104,7 @@ export interface RegistrationFormConfig {
 export interface RegistrationConfig {
   patientSearch: PatientSearchConfig;
   defaultVisitType?: string;
-  registrationEncounterTypeUuid?: string;
+  registrationEncounterType?: string;
   patientInformation?: PatientInformationConfig;
   fieldValidation?: FieldValidationConfig;
   registrationForm?: RegistrationFormConfig;

--- a/apps/registration/src/providers/registrationConfig/schema.json
+++ b/apps/registration/src/providers/registrationConfig/schema.json
@@ -193,9 +193,9 @@
       "type": "string",
       "description": "Default visit type for patient registration"
     },
-    "registrationEncounterTypeUuid": {
+    "registrationEncounterType": {
       "type": "string",
-      "description": "UUID of the encounter type to create automatically on patient registration"
+      "description": "Name of the encounter type to create automatically on patient registration"
     },
     "patientInformation": {
       "type": "object",

--- a/apps/registration/src/services/__tests__/registrationEncounterService.test.ts
+++ b/apps/registration/src/services/__tests__/registrationEncounterService.test.ts
@@ -7,11 +7,13 @@ import {
   getUserLoginLocation,
   getCurrentUser,
   getCurrentProvider,
+  get,
 } from '@bahmni/services';
 import type { Encounter } from 'fhir/r4';
 import {
   createRegistrationEncounterForPatient,
   findValidRegistrationEncounterInSession,
+  getEncounterTypeUuidByName,
   linkRegistrationEncounterToVisit,
 } from '../registrationEncounterService';
 
@@ -25,6 +27,7 @@ jest.mock('@bahmni/services', () => ({
   getUserLoginLocation: jest.fn(),
   getCurrentUser: jest.fn(),
   getCurrentProvider: jest.fn(),
+  get: jest.fn(),
   dispatchAuditEvent: jest.fn(),
   AUDIT_LOG_EVENT_DETAILS: {
     CREATE_ENCOUNTER: { eventType: 'CREATE_ENCOUNTER', module: 'registration' },
@@ -64,6 +67,7 @@ const mockGetCurrentUser = getCurrentUser as jest.MockedFunction<
 const mockGetCurrentProvider = getCurrentProvider as jest.MockedFunction<
   typeof getCurrentProvider
 >;
+const mockGet = get as jest.MockedFunction<typeof get>;
 
 const PATIENT_UUID = 'patient-uuid-123';
 const ENCOUNTER_TYPE_UUID = 'enc-type-uuid-456';
@@ -403,5 +407,55 @@ describe('linkRegistrationEncounterToVisit', () => {
     expect(mockSearchEncounters).not.toHaveBeenCalled();
     expect(mockUpdateFhirEncounter).not.toHaveBeenCalled();
     expect(mockCreateFhirEncounter).not.toHaveBeenCalled();
+  });
+});
+
+describe('getEncounterTypeUuidByName', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return the uuid when the encounter type name matches', async () => {
+    mockGet.mockResolvedValue({
+      results: [
+        { uuid: 'uuid-001', name: 'Registration' },
+        { uuid: 'uuid-002', name: 'OPD' },
+      ],
+    });
+
+    const result = await getEncounterTypeUuidByName('Registration');
+
+    expect(result).toBe('uuid-001');
+    expect(mockGet).toHaveBeenCalledWith(
+      expect.stringContaining('q=Registration'),
+    );
+  });
+
+  it('should return undefined when no encounter type matches the name', async () => {
+    mockGet.mockResolvedValue({
+      results: [{ uuid: 'uuid-001', name: 'OPD' }],
+    });
+
+    const result = await getEncounterTypeUuidByName('Registration');
+
+    expect(result).toBeUndefined();
+  });
+
+  it('should return undefined when results are empty', async () => {
+    mockGet.mockResolvedValue({ results: [] });
+
+    const result = await getEncounterTypeUuidByName('Registration');
+
+    expect(result).toBeUndefined();
+  });
+
+  it('should URL-encode the name in the query', async () => {
+    mockGet.mockResolvedValue({ results: [] });
+
+    await getEncounterTypeUuidByName('Clinic Visit Type');
+
+    expect(mockGet).toHaveBeenCalledWith(
+      expect.stringContaining('q=Clinic%20Visit%20Type'),
+    );
   });
 });

--- a/apps/registration/src/services/registrationEncounterService.ts
+++ b/apps/registration/src/services/registrationEncounterService.ts
@@ -9,10 +9,14 @@ import {
   getUserLoginLocation,
   searchEncounters,
   updateFhirEncounter,
+  get,
+  OPENMRS_REST_V1,
   type AuditEventType,
 } from '@bahmni/services';
 import type { Encounter } from 'fhir/r4';
 import { buildRegistrationEncounterPayload } from '../utils/fhirEncounterMapper';
+
+const ENCOUNTER_TYPE_URL = `${OPENMRS_REST_V1}/encountertype`;
 
 /**
  * Creates a registration encounter for patient.
@@ -136,4 +140,13 @@ export async function linkRegistrationEncounterToVisit(
   }
 
   if (validEncounters.length === 0) return;
+}
+
+export async function getEncounterTypeUuidByName(
+  name: string,
+): Promise<string | undefined> {
+  const response = await get<{ results: { uuid: string; name: string }[] }>(
+    `${ENCOUNTER_TYPE_URL}?q=${encodeURIComponent(name)}&v=default`,
+  );
+  return response.results.find((r) => r.name === name)?.uuid;
 }


### PR DESCRIPTION
**JIRA** → [BAH-4655](https://bahmni.atlassian.net/browse/BAH-4655?atlOrigin=eyJpIjoiNWIwOGM5MWJhZmEwNDU3ZDg4YTVkNWYxZWQ5ZjA4ZWIiLCJwIjoiaiJ9)

### **Problem**

registrationEncounterTypeUuid` in `clinic-config/openmrs/apps/registration/v2/app.json` was hardcoded to a specific UUID:
UUIDs are installation-specific. This breaks on any OpenMRS instance where the Registration encounter type has a different UUID.

## **Solution**

Store the encounter type **name** in config instead of UUID. Resolve the UUID at runtime by calling the OpenMRS REST API, the same way the clinical app resolves encounter types via `bahmnicore/config/bahmniencounter`.


[BAH-4655]: https://bahmni.atlassian.net/browse/BAH-4655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Registration now selects encounter types by name (config key renamed) instead of storing UUIDs directly.
* **New Features**
  * Automatic lookup of encounter type UUIDs by name during patient registration and visit creation.
* **Tests**
  * Updated and added tests to validate encounter-type name configuration, lookup behavior, and error handling during registration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->