### PR TITLE
BAH-4582 | Fix. Send browser timeZone in print render context

### DIFF
--- a/apps/clinical/src/components/patientHeader/PatientHeader.tsx
+++ b/apps/clinical/src/components/patientHeader/PatientHeader.tsx
@@ -112,6 +112,7 @@ const PatientHeader: React.FC<PatientHeaderProps> = ({
     () => ({
       ...(patientUUID && { patientUUID }),
       ...(visitUuid && { visitUuid }),
+      timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
     }),
     [patientUUID, visitUuid],
   );


### PR DESCRIPTION
## Summary
- Pass the browser's timezone (`Intl.DateTimeFormat().resolvedOptions().timeZone`) in `renderContext` from `PatientHeader` so the template service can format dates in the user's local timezone instead of UTC.

## Test plan
- [ ] Open a patient's clinical dashboard
- [ ] Click "Print Prescription"
- [ ] Verify the start date, stopped date, and visit date on the printed PDF show the correct local date (not shifted by timezone offset)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Print previews of patient clinical documents now automatically include timezone information, ensuring timestamps are accurately displayed according to the user's local timezone when generating patient records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->