### PR TITLE
BAH-4754 Fix <dialog> element's UA stylesheet sets margin: auto for c…

### DIFF
--- a/apps/appointments/src/App.tsx
+++ b/apps/appointments/src/App.tsx
@@ -1,4 +1,4 @@
-import { CommandPaletteProvider } from '@bahmni/command-palette';
+import { CommandPaletteProvider } from '@bahmni/command-palette-app';
 import { Content, Loading, initFontAwesome } from '@bahmni/design-system';
 import { initAppI18n } from '@bahmni/services';
 import {

--- a/apps/clinical/src/App.tsx
+++ b/apps/clinical/src/App.tsx
@@ -1,4 +1,4 @@
-import { CommandPaletteProvider } from '@bahmni/command-palette';
+import { CommandPaletteProvider } from '@bahmni/command-palette-app';
 import { Content, initFontAwesome, Loading } from '@bahmni/design-system';
 import { initAppI18n, initializeAuditListener } from '@bahmni/services';
 import {

--- a/apps/command-palette/jest.config.ts
+++ b/apps/command-palette/jest.config.ts
@@ -1,5 +1,5 @@
 export default {
-  displayName: '@bahmni/command-palette',
+  displayName: '@bahmni/command-palette-app',
   preset: '../../jest.preset.js',
   setupFilesAfterEnv: ['<rootDir>/setupTests.ts'],
   transformIgnorePatterns: [

--- a/apps/command-palette/package.json
+++ b/apps/command-palette/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@bahmni/command-palette",
+  "name": "@bahmni/command-palette-app",
   "version": "0.0.1",
   "type": "module",
   "main": "./dist/index.js",

--- a/apps/command-palette/vite.config.ts
+++ b/apps/command-palette/vite.config.ts
@@ -30,7 +30,7 @@ export default defineConfig(() => ({
     },
     lib: {
       entry: 'src/index.ts',
-      name: '@bahmni/command-palette',
+      name: '@bahmni/command-palette-app',
       fileName: 'index',
       formats: ['es' as const],
     },

--- a/apps/home/src/App.tsx
+++ b/apps/home/src/App.tsx
@@ -1,4 +1,4 @@
-import { CommandPaletteProvider } from '@bahmni/command-palette';
+import { CommandPaletteProvider } from '@bahmni/command-palette-app';
 import { initFontAwesome, Loading } from '@bahmni/design-system';
 import { initAppI18n } from '@bahmni/services';
 import {

--- a/apps/registration/src/App.tsx
+++ b/apps/registration/src/App.tsx
@@ -1,4 +1,4 @@
-import { CommandPaletteProvider } from '@bahmni/command-palette';
+import { CommandPaletteProvider } from '@bahmni/command-palette-app';
 import { Content, initFontAwesome, Loading } from '@bahmni/design-system';
 import { initAppI18n, initializeAuditListener } from '@bahmni/services';
 import {

--- a/distro/webpack.config.js
+++ b/distro/webpack.config.js
@@ -22,7 +22,7 @@ module.exports = (env, argv) => {
         '@bahmni/clinical-app': join(__dirname, '../apps/clinical/src'),
         '@bahmni/registration-app': join(__dirname, '../apps/registration/src'),
         '@bahmni/appointments-app': join(__dirname, '../apps/appointments/src'),
-        '@bahmni/command-palette': join(__dirname, '../apps/command-palette/src'),
+        '@bahmni/command-palette-app': join(__dirname, '../apps/command-palette/src'),
       } : {},
     },
     devServer: {

--- a/packages/bahmni-widgets/src/commandPalette/styles/CommandPalette.module.scss
+++ b/packages/bahmni-widgets/src/commandPalette/styles/CommandPalette.module.scss
@@ -14,6 +14,7 @@
 
 .dialog {
   padding: 0;
+  margin: 0;
   position: fixed;
   top: 15%;
   left: 50%;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Removed default spacing around the Command Palette dialog to keep it consistently aligned across the interface.
* **Maintenance**
  * Updated Command Palette integration so all affected apps resolve the Command Palette module consistently.
  * Adjusted build/test packaging configuration to match the updated Command Palette distribution name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->