### PR TITLE
BAH-4704 | Fix. Observation Forms to check fields with conditional mandatory fields onHidden

### DIFF
--- a/apps/clinical/src/components/forms/observations/ObservationFormsContainer.tsx
+++ b/apps/clinical/src/components/forms/observations/ObservationFormsContainer.tsx
@@ -272,15 +272,6 @@ const ObservationFormsContainer: React.FC<ObservationFormsContainerProps> = ({
       const isEmpty = !hasAnyValue; // Empty if no values (including empty strings), even if there are notes
       const hasErrors = errors && errors.length > 0;
 
-      if (isEmpty) {
-        setValidationErrorType(VALIDATION_STATE_EMPTY);
-        return;
-      }
-
-      // form2-controls does not propagate mandatory errors to getValue().errors for
-      // fields that were never interacted with — including always-visible mandatory
-      // fields and fields revealed via isHidden scripting. Check the Container data
-      // directly to catch these violations.
       const containerStateData = (
         formContainerRef.current as {
           state?: { data?: Record<string, unknown> | { toJS?: () => unknown } };
@@ -291,6 +282,11 @@ const ObservationFormsContainer: React.FC<ObservationFormsContainerProps> = ({
           | Record<string, unknown>
           | undefined,
       );
+
+      if (isEmpty && !hasMissingMandatory) {
+        setValidationErrorType(VALIDATION_STATE_EMPTY);
+        return;
+      }
 
       if (hasErrors || hasMissingMandatory) {
         const hasMandatoryError =

--- a/apps/clinical/src/components/forms/observations/ObservationFormsContainer.tsx
+++ b/apps/clinical/src/components/forms/observations/ObservationFormsContainer.tsx
@@ -23,6 +23,7 @@ import {
   extractNotesFromFormData,
   type AgeDetails,
   computeAgeDetails,
+  hasMissingMandatoryVisibleField,
 } from '@bahmni/services';
 import { useActivePractitioner, usePatientUUID } from '@bahmni/widgets';
 import { useQuery } from '@tanstack/react-query';
@@ -276,14 +277,31 @@ const ObservationFormsContainer: React.FC<ObservationFormsContainerProps> = ({
         return;
       }
 
-      if (hasErrors) {
-        const hasMandatoryError = errors
-          .flat()
-          .some(
-            (err: { get?: (key: string) => string; message?: string }) =>
-              (err.get?.('message') ?? err.message) ===
-              VALIDATION_STATE_MANDATORY,
-          );
+      // form2-controls does not propagate mandatory errors to getValue().errors for
+      // fields that were never interacted with — including always-visible mandatory
+      // fields and fields revealed via isHidden scripting. Check the Container data
+      // directly to catch these violations.
+      const containerStateData = (
+        formContainerRef.current as {
+          state?: { data?: Record<string, unknown> | { toJS?: () => unknown } };
+        } | null
+      )?.state?.data;
+      const hasMissingMandatory = hasMissingMandatoryVisibleField(
+        convertImmutableToPlainObject(containerStateData) as
+          | Record<string, unknown>
+          | undefined,
+      );
+
+      if (hasErrors || hasMissingMandatory) {
+        const hasMandatoryError =
+          hasMissingMandatory ||
+          errors
+            .flat()
+            .some(
+              (err: { get?: (key: string) => string; message?: string }) =>
+                (err.get?.('message') ?? err.message) ===
+                VALIDATION_STATE_MANDATORY,
+            );
         const errorType = hasMandatoryError
           ? VALIDATION_STATE_MANDATORY
           : VALIDATION_STATE_INVALID;

--- a/apps/clinical/src/components/forms/observations/__tests__/ObservationFormsContainer.test.tsx
+++ b/apps/clinical/src/components/forms/observations/__tests__/ObservationFormsContainer.test.tsx
@@ -1521,5 +1521,44 @@ describe('ObservationFormsContainer', () => {
         );
       });
     });
+
+    it('should show mandatory error when a visible mandatory field has no value but getValue returns no errors (isHidden scenario)', async () => {
+      // Simulate a field that was hidden via isHidden scripting and became visible,
+      // but form2-controls did not propagate the mandatory error to getValue().errors.
+      // Also covers always-visible mandatory fields never touched by the user.
+      mockGetValue.mockReturnValue({
+        observations: [
+          { concept: { uuid: 'other-field' }, value: 'some value' },
+        ],
+        errors: [],
+      });
+
+      mockContainerState.data = {
+        children: [
+          {
+            control: { properties: { mandatory: true } },
+            hidden: false,
+            voided: false,
+            value: { value: undefined },
+            children: [],
+          },
+        ],
+      };
+
+      render(
+        <ObservationFormsContainer {...defaultProps} viewingForm={mockForm} />,
+      );
+
+      fireEvent.click(screen.getByTestId('primary-button'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('inline-notification')).toBeInTheDocument();
+        expect(screen.getByTestId('notification-title')).toHaveTextContent(
+          'translated_OBSERVATION_FORM_VALIDATION_ERROR_TITLE_MANDATORY',
+        );
+      });
+
+      mockContainerState.data = {};
+    });
   });
 });

--- a/packages/bahmni-services/src/index.ts
+++ b/packages/bahmni-services/src/index.ts
@@ -327,6 +327,7 @@ export {
   transformContainerObservationsToForm2Observations,
   convertImmutableToPlainObject,
   extractNotesFromFormData,
+  hasMissingMandatoryVisibleField,
   getPatientFormData,
   type ObservationForm,
   type FormApiResponse,

--- a/packages/bahmni-services/src/observationFormsService/__tests__/observationFormsTransformer.test.ts
+++ b/packages/bahmni-services/src/observationFormsService/__tests__/observationFormsTransformer.test.ts
@@ -1160,6 +1160,42 @@ describe('hasMissingMandatoryVisibleField', () => {
     expect(hasMissingMandatoryVisibleField(data)).toBe(false);
   });
 
+  it('returns false for a hidden group node containing a visible mandatory empty child', () => {
+    const data = {
+      control: mandatoryControl,
+      hidden: true,
+      voided: false,
+      value: null,
+      children: [
+        {
+          control: mandatoryControl,
+          hidden: false,
+          voided: false,
+          value: { value: null },
+        },
+      ],
+    };
+    expect(hasMissingMandatoryVisibleField(data)).toBe(false);
+  });
+
+  it('returns false for a voided group node containing a visible mandatory empty child', () => {
+    const data = {
+      control: mandatoryControl,
+      hidden: false,
+      voided: true,
+      value: null,
+      children: [
+        {
+          control: mandatoryControl,
+          hidden: false,
+          voided: false,
+          value: { value: null },
+        },
+      ],
+    };
+    expect(hasMissingMandatoryVisibleField(data)).toBe(false);
+  });
+
   it('returns false for a mandatory group node whose children are all filled', () => {
     const data = {
       control: mandatoryControl,

--- a/packages/bahmni-services/src/observationFormsService/__tests__/observationFormsTransformer.test.ts
+++ b/packages/bahmni-services/src/observationFormsService/__tests__/observationFormsTransformer.test.ts
@@ -5,6 +5,7 @@ import {
   transformContainerObservationsToForm2Observations,
   convertImmutableToPlainObject,
   extractNotesFromFormData,
+  hasMissingMandatoryVisibleField,
   FormData,
   ConceptValue,
   Form2Observation,
@@ -1027,5 +1028,111 @@ describe('observationFormsTransformer', () => {
       expect(result).toHaveLength(1);
       expect(result[0].concept.uuid).toBe('text-concept-uuid');
     });
+  });
+});
+
+describe('hasMissingMandatoryVisibleField', () => {
+  const mandatoryControl = { properties: { mandatory: true } };
+  const optionalControl = { properties: { mandatory: false } };
+
+  it('returns true when a visible mandatory field has no value', () => {
+    const data = {
+      control: mandatoryControl,
+      hidden: false,
+      voided: false,
+      value: { value: undefined },
+    };
+    expect(hasMissingMandatoryVisibleField(data)).toBe(true);
+  });
+
+  it('returns false when a visible mandatory field has a value', () => {
+    const data = {
+      control: mandatoryControl,
+      hidden: false,
+      voided: false,
+      value: { value: 'Dr. Smith' },
+    };
+    expect(hasMissingMandatoryVisibleField(data)).toBe(false);
+  });
+
+  it('returns false when a mandatory field is hidden', () => {
+    const data = {
+      control: mandatoryControl,
+      hidden: true,
+      voided: false,
+      value: { value: undefined },
+    };
+    expect(hasMissingMandatoryVisibleField(data)).toBe(false);
+  });
+
+  it('returns false when a mandatory field is voided', () => {
+    const data = {
+      control: mandatoryControl,
+      hidden: false,
+      voided: true,
+      value: { value: undefined },
+    };
+    expect(hasMissingMandatoryVisibleField(data)).toBe(false);
+  });
+
+  it('returns false for a visible optional field with no value', () => {
+    const data = {
+      control: optionalControl,
+      hidden: false,
+      voided: false,
+      value: { value: undefined },
+    };
+    expect(hasMissingMandatoryVisibleField(data)).toBe(false);
+  });
+
+  it('returns true when a nested mandatory field has no value', () => {
+    const data = {
+      control: {},
+      hidden: false,
+      children: [
+        {
+          control: mandatoryControl,
+          hidden: false,
+          voided: false,
+          value: { value: null },
+        },
+      ],
+    };
+    expect(hasMissingMandatoryVisibleField(data)).toBe(true);
+  });
+
+  it('returns false when nested mandatory field is hidden', () => {
+    const data = {
+      control: {},
+      hidden: false,
+      children: [
+        {
+          control: mandatoryControl,
+          hidden: true,
+          voided: false,
+          value: { value: null },
+        },
+      ],
+    };
+    expect(hasMissingMandatoryVisibleField(data)).toBe(false);
+  });
+
+  it('returns false for undefined or null input', () => {
+    expect(hasMissingMandatoryVisibleField(undefined)).toBe(false);
+    expect(
+      hasMissingMandatoryVisibleField(
+        null as unknown as Record<string, unknown>,
+      ),
+    ).toBe(false);
+  });
+
+  it('returns true when value is an empty string', () => {
+    const data = {
+      control: mandatoryControl,
+      hidden: false,
+      voided: false,
+      value: { value: '' },
+    };
+    expect(hasMissingMandatoryVisibleField(data)).toBe(true);
   });
 });

--- a/packages/bahmni-services/src/observationFormsService/__tests__/observationFormsTransformer.test.ts
+++ b/packages/bahmni-services/src/observationFormsService/__tests__/observationFormsTransformer.test.ts
@@ -1045,7 +1045,7 @@ describe('hasMissingMandatoryVisibleField', () => {
     expect(hasMissingMandatoryVisibleField(data)).toBe(true);
   });
 
-  it('returns false when a visible mandatory field has a value', () => {
+  it('returns false when a visible mandatory field has a text value', () => {
     const data = {
       control: mandatoryControl,
       hidden: false,
@@ -1053,6 +1053,49 @@ describe('hasMissingMandatoryVisibleField', () => {
       value: { value: 'Dr. Smith' },
     };
     expect(hasMissingMandatoryVisibleField(data)).toBe(false);
+  });
+
+  it('returns false when a mandatory coded field has a concept answer', () => {
+    const data = {
+      control: mandatoryControl,
+      hidden: false,
+      voided: false,
+      value: { value: null, concept: { uuid: 'abc-123', name: 'True' } },
+    };
+    expect(hasMissingMandatoryVisibleField(data)).toBe(false);
+  });
+
+  it('returns true when a mandatory coded field has no concept answer', () => {
+    const data = {
+      control: mandatoryControl,
+      hidden: false,
+      voided: false,
+      value: { value: null, concept: null },
+    };
+    expect(hasMissingMandatoryVisibleField(data)).toBe(true);
+  });
+
+  it('returns false when a mandatory multi-select field has selected items', () => {
+    const data = {
+      control: mandatoryControl,
+      hidden: false,
+      voided: false,
+      value: {
+        value: null,
+        concept: [{ uuid: 'abc-123', name: 'Option A' }],
+      },
+    };
+    expect(hasMissingMandatoryVisibleField(data)).toBe(false);
+  });
+
+  it('returns true when a mandatory multi-select field has no selected items', () => {
+    const data = {
+      control: mandatoryControl,
+      hidden: false,
+      voided: false,
+      value: { value: null, concept: [] },
+    };
+    expect(hasMissingMandatoryVisibleField(data)).toBe(true);
   });
 
   it('returns false when a mandatory field is hidden', () => {
@@ -1115,6 +1158,42 @@ describe('hasMissingMandatoryVisibleField', () => {
       ],
     };
     expect(hasMissingMandatoryVisibleField(data)).toBe(false);
+  });
+
+  it('returns false for a mandatory group node whose children are all filled', () => {
+    const data = {
+      control: mandatoryControl,
+      hidden: false,
+      voided: false,
+      value: null,
+      children: [
+        {
+          control: mandatoryControl,
+          hidden: false,
+          voided: false,
+          value: { value: 'filled' },
+        },
+      ],
+    };
+    expect(hasMissingMandatoryVisibleField(data)).toBe(false);
+  });
+
+  it('returns true for a mandatory group node with an empty mandatory child', () => {
+    const data = {
+      control: mandatoryControl,
+      hidden: false,
+      voided: false,
+      value: null,
+      children: [
+        {
+          control: mandatoryControl,
+          hidden: false,
+          voided: false,
+          value: { value: null },
+        },
+      ],
+    };
+    expect(hasMissingMandatoryVisibleField(data)).toBe(true);
   });
 
   it('returns false for undefined or null input', () => {

--- a/packages/bahmni-services/src/observationFormsService/index.ts
+++ b/packages/bahmni-services/src/observationFormsService/index.ts
@@ -23,6 +23,7 @@ export {
   transformContainerObservationsToForm2Observations,
   convertImmutableToPlainObject,
   extractNotesFromFormData,
+  hasMissingMandatoryVisibleField,
   type FormData,
   type FormControlData,
   type Form2Observation,

--- a/packages/bahmni-services/src/observationFormsService/observationFormsTransformer.ts
+++ b/packages/bahmni-services/src/observationFormsService/observationFormsTransformer.ts
@@ -524,7 +524,45 @@ function processControlForNotesExtraction(
 }
 
 /**
- * Checks if any visible, non-voided mandatory fields in the Container data have no values.
+ * Returns true when a leaf control's value is considered empty.
+ *
+ * form2-controls serializes values differently per control type:
+ * - Free-text / numeric / date: { value: "abc" | 123 | null }
+ * - Coded / select:             { value: null, concept: { uuid, name } }
+ * - Multi-select:               { value: null, concept: [{ uuid, name }] }
+ *
+ * A field is empty only when both `value.value` AND `value.concept` are absent.
+ */
+function isLeafValueEmpty(data: Record<string, unknown>): boolean {
+  const valueObj =
+    data.value && typeof data.value === 'object'
+      ? (data.value as Record<string, unknown>)
+      : null;
+
+  if (!valueObj) {
+    return data.value === null || data.value === undefined || data.value === '';
+  }
+
+  // Direct value (text, number, date)
+  const directValue = valueObj.value;
+  if (directValue !== null && directValue !== undefined && directValue !== '') {
+    return false;
+  }
+
+  // Coded / select answer lives under value.concept
+  const concept = valueObj.concept;
+  if (concept !== null && concept !== undefined) {
+    // multi-select returns an array
+    if (Array.isArray(concept)) return concept.length === 0;
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Checks if any visible, non-voided mandatory leaf fields in the Container data
+ * have no values.
  *
  * form2-controls does not propagate mandatory errors back to the Container's internal
  * data structure when a field has never been interacted with by the user — this includes
@@ -534,33 +572,37 @@ function processControlForNotesExtraction(
  *
  * This function traverses the Container's Immutable data (converted to plain JS via toJS())
  * to detect these missed violations directly.
+ *
+ * Only leaf nodes (no children) are checked for emptiness. Group/section controls
+ * carry value: null themselves while the real data lives in their children — checking
+ * the group node's own value would produce false positives.
  */
 export function hasMissingMandatoryVisibleField(
   data: Record<string, unknown> | undefined,
 ): boolean {
   if (!data || typeof data !== 'object') return false;
 
+  const children = data.children;
+  const hasChildren = Array.isArray(children) && children.length > 0;
+
   const control = data.control as Record<string, unknown> | undefined;
   const properties = control?.properties as Record<string, unknown> | undefined;
 
-  if (properties?.mandatory === true && !data.hidden && !data.voided) {
-    const valueObj =
-      data.value && typeof data.value === 'object'
-        ? (data.value as Record<string, unknown>)
-        : null;
-    const actualValue = valueObj ? valueObj.value : data.value;
-    if (
-      actualValue === null ||
-      actualValue === undefined ||
-      actualValue === ''
-    ) {
+  // Only validate leaf nodes — group/section controls have no value of their own
+  if (
+    !hasChildren &&
+    properties?.mandatory === true &&
+    !data.hidden &&
+    !data.voided
+  ) {
+    if (isLeafValueEmpty(data)) {
       return true;
     }
   }
 
-  const children = data.children;
-  if (Array.isArray(children)) {
-    return children.some(
+  // Recurse into children regardless of this node's mandatory flag
+  if (hasChildren) {
+    return (children as unknown[]).some(
       (child) =>
         child &&
         typeof child === 'object' &&

--- a/packages/bahmni-services/src/observationFormsService/observationFormsTransformer.ts
+++ b/packages/bahmni-services/src/observationFormsService/observationFormsTransformer.ts
@@ -522,3 +522,51 @@ function processControlForNotesExtraction(
     });
   }
 }
+
+/**
+ * Checks if any visible, non-voided mandatory fields in the Container data have no values.
+ *
+ * form2-controls does not propagate mandatory errors back to the Container's internal
+ * data structure when a field has never been interacted with by the user — this includes
+ * always-visible mandatory fields that were never touched, and fields that transition
+ * from hidden to visible via isHidden scripting without user interaction.
+ * As a result, getValue().errors is empty for such fields even when they are required.
+ *
+ * This function traverses the Container's Immutable data (converted to plain JS via toJS())
+ * to detect these missed violations directly.
+ */
+export function hasMissingMandatoryVisibleField(
+  data: Record<string, unknown> | undefined,
+): boolean {
+  if (!data || typeof data !== 'object') return false;
+
+  const control = data.control as Record<string, unknown> | undefined;
+  const properties = control?.properties as Record<string, unknown> | undefined;
+
+  if (properties?.mandatory === true && !data.hidden && !data.voided) {
+    const valueObj =
+      data.value && typeof data.value === 'object'
+        ? (data.value as Record<string, unknown>)
+        : null;
+    const actualValue = valueObj ? valueObj.value : data.value;
+    if (
+      actualValue === null ||
+      actualValue === undefined ||
+      actualValue === ''
+    ) {
+      return true;
+    }
+  }
+
+  const children = data.children;
+  if (Array.isArray(children)) {
+    return children.some(
+      (child) =>
+        child &&
+        typeof child === 'object' &&
+        hasMissingMandatoryVisibleField(child as Record<string, unknown>),
+    );
+  }
+
+  return false;
+}

--- a/packages/bahmni-services/src/observationFormsService/observationFormsTransformer.ts
+++ b/packages/bahmni-services/src/observationFormsService/observationFormsTransformer.ts
@@ -600,7 +600,10 @@ export function hasMissingMandatoryVisibleField(
     }
   }
 
-  // Recurse into children regardless of this node's mandatory flag
+  // Skip hidden/voided subtrees entirely — their children are not visible
+  if (data.hidden || data.voided) return false;
+
+  // Recurse into children
   if (hasChildren) {
     return (children as unknown[]).some(
       (child) =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6960,7 +6960,7 @@ clone@^1.0.2:
 
 cmdk@^1.1.1:
   version "1.1.1"
-  resolved "https://registry.npmjs.org/cmdk/-/cmdk-1.1.1.tgz#b8524272699ccaa37aaf07f36850b376bf3d58e5"
+  resolved "https://registry.yarnpkg.com/cmdk/-/cmdk-1.1.1.tgz#b8524272699ccaa37aaf07f36850b376bf3d58e5"
   integrity sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==
   dependencies:
     "@radix-ui/react-compose-refs" "^1.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6960,7 +6960,7 @@ clone@^1.0.2:
 
 cmdk@^1.1.1:
   version "1.1.1"
-  resolved "https://registry.yarnpkg.com/cmdk/-/cmdk-1.1.1.tgz#b8524272699ccaa37aaf07f36850b376bf3d58e5"
+  resolved "https://registry.npmjs.org/cmdk/-/cmdk-1.1.1.tgz#b8524272699ccaa37aaf07f36850b376bf3d58e5"
   integrity sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==
   dependencies:
     "@radix-ui/react-compose-refs" "^1.1.1"


### PR DESCRIPTION
## JIRA
[BAH-4704](https://bahmni.atlassian.net/browse/BAH-4704)

## Description

Observation forms were silently saving when a mandatory field was hidden via `isHidden` scripting and then became visible again — `form2-controls` does not propagate mandatory errors to `getValue().errors` for fields that were never interacted with after becoming visible. The same gap affected always-visible mandatory fields that the user never touched.

## Key Changes

- **`hasMissingMandatoryVisibleField`** — new recursive helper in `bahmni-services` that walks the Container's Immutable state data (via `toJS()`) to detect visible, non-voided mandatory leaf fields with no value. Handles text/number/date (`value.value`), coded/select (`value.concept`), and multi-select (array concept).
- **`ObservationFormsContainer.validateAndSave`** — integrates the helper alongside `getValue().errors`. The `isEmpty` guard now runs _after_ `hasMissingMandatory` is computed so a form with only untouched mandatory fields shows "mandatory field missing" rather than "empty form".
- **Hidden subtree fix** — the recursive traversal now skips the entire subtree when a group node is `hidden` or `voided`, preventing false positives on sections that form2-controls has hidden.

## Acceptance Criteria

| # | Criteria | Status |
|---|---|---|
| AC1 | Mandatory field that was hidden and revealed via `isHidden` scripting blocks save | ✅ |
| AC2 | Always-visible mandatory field never touched blocks save with correct error message | ✅ |
| AC3 | Filled mandatory fields (text, coded, multi-select) do not false-positive | ✅ |
| AC4 | Hidden/voided fields and hidden group subtrees are not flagged | ✅ |

## Testing

- Observation form with a mandatory field hidden by default via `isHidden` — reveal it without filling, click Save → blocked with mandatory error
- Observation form with an always-visible mandatory field never touched → blocked with mandatory error  
- Fill all mandatory fields → saves successfully
- Coded (select) mandatory field — answered → saves, unanswered → blocked
- Group/section with `isHidden` hiding it → mandatory child inside is not flagged

[BAH-4704]: https://bahmni.atlassian.net/browse/BAH-4704?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ