### PR TITLE
BAH-4826 |  Appointment Search: Show toast notifications on action button success and failure

### DIFF
--- a/apps/registration/public/locales/locale_en.json
+++ b/apps/registration/public/locales/locale_en.json
@@ -159,6 +159,7 @@
   "NOTIFICATION_UNABLE_TO_GET_CONTACT_DATA": "Unable to get patient contact data",
   "NOTIFICATION_UNABLE_TO_GET_ADDITIONAL_DATA": "Unable to get patient additional data",
   "REGISTRATION_PATIENT_SEARCH_APPOINTMENT": "Search by Appointment",
+  "REGISTRATION_ACTION_BUTTON_GENERIC_ERROR": "Something went wrong. Please try again.",
   "SUCCESS": "Success",
   "VIEWED_REGISTRATION_PATIENT_SEARCH_MESSAGE": "User {{username}} accessed patient search screen in registration app",
   "YEARS_one": " year",

--- a/apps/registration/public/locales/locale_es.json
+++ b/apps/registration/public/locales/locale_es.json
@@ -159,6 +159,7 @@
   "NOTIFICATION_UNABLE_TO_GET_CONTACT_DATA": "No se pueden obtener los datos de contacto del paciente",
   "NOTIFICATION_UNABLE_TO_GET_ADDITIONAL_DATA": "No se pueden obtener los datos adicionales del paciente",
   "REGISTRATION_PATIENT_SEARCH_APPOINTMENT": "Búsqueda por cita",
+  "REGISTRATION_ACTION_BUTTON_GENERIC_ERROR": "Algo salió mal. Por favor, inténtelo de nuevo.",
   "SUCCESS": "Éxito",
   "VIEWED_REGISTRATION_PATIENT_SEARCH_MESSAGE": "El usuario {{username}} accedió a la pantalla de búsqueda de pacientes en la aplicación de registro",
   "YEARS_one": " año",

--- a/apps/registration/src/pages/patientSearchPage/__tests__/appointmentSearchResultActionHandler.test.ts
+++ b/apps/registration/src/pages/patientSearchPage/__tests__/appointmentSearchResultActionHandler.test.ts
@@ -466,8 +466,7 @@ describe('appointmentSearchResultActionHandler', () => {
         type: 'checkInAndStartVisit',
         translationKey: 'Check In',
         onAction: {
-          submit:
-            '/openmrs/ws/rest/v1/iom/appointment/checkin?visitType=Follow+Up',
+          submit: '/bahmni/appointment/checkin',
         },
         enabledRule: [],
         onSuccess: {
@@ -576,8 +575,7 @@ describe('appointmentSearchResultActionHandler', () => {
     });
 
     it('should call checkInAppointment with submit URL and appointmentUuid for checkInAndStartVisit action', async () => {
-      const submitUrl =
-        '/openmrs/ws/rest/v1/iom/appointment/checkin?visitType=Follow+Up';
+      const submitUrl = '/bahmni/appointment/checkin';
       const action: SearchActionConfig = {
         type: 'checkInAndStartVisit',
         translationKey: 'Check In',
@@ -610,8 +608,7 @@ describe('appointmentSearchResultActionHandler', () => {
         type: 'checkInAndStartVisit',
         translationKey: 'Check In',
         onAction: {
-          submit:
-            '/openmrs/ws/rest/v1/iom/appointment/checkin?visitType=Follow+Up',
+          submit: '/bahmni/appointment/checkin',
         },
         enabledRule: [],
       };
@@ -675,8 +672,7 @@ describe('appointmentSearchResultActionHandler', () => {
         type: 'checkInAndStartVisit',
         translationKey: 'Check In',
         onAction: {
-          submit:
-            '/openmrs/ws/rest/v1/iom/appointment/checkin?visitType=Follow+Up',
+          submit: '/bahmni/appointment/checkin',
         },
         enabledRule: [],
       };

--- a/apps/registration/src/pages/patientSearchPage/__tests__/appointmentSearchResultActionHandler.test.ts
+++ b/apps/registration/src/pages/patientSearchPage/__tests__/appointmentSearchResultActionHandler.test.ts
@@ -315,6 +315,8 @@ describe('appointmentSearchResultActionHandler', () => {
   describe('handleActionButtonClick', () => {
     let mockNavigate: jest.MockedFunction<NavigateFunction>;
     let mockSetPatientSearchData: jest.Mock;
+    let mockAddNotification: jest.Mock;
+    const mockT = (key: string) => key;
 
     const mockRow: PatientSearchViewModel<AppointmentSearchResult> = {
       uuid: 'patient-uuid-1',
@@ -351,6 +353,7 @@ describe('appointmentSearchResultActionHandler', () => {
     beforeEach(() => {
       mockNavigate = jest.fn();
       mockSetPatientSearchData = jest.fn();
+      mockAddNotification = jest.fn();
       jest.clearAllMocks();
     });
 
@@ -375,6 +378,8 @@ describe('appointmentSearchResultActionHandler', () => {
         mockPatientSearchData,
         mockSetPatientSearchData,
         mockNavigate,
+        mockAddNotification,
+        mockT,
       );
 
       expect(updateAppointmentStatus).toHaveBeenCalledWith(
@@ -405,6 +410,8 @@ describe('appointmentSearchResultActionHandler', () => {
         mockPatientSearchData,
         mockSetPatientSearchData,
         mockNavigate,
+        mockAddNotification,
+        mockT,
       );
 
       expect(mockSetPatientSearchData).toHaveBeenCalledWith({
@@ -416,6 +423,107 @@ describe('appointmentSearchResultActionHandler', () => {
           }),
         ]),
       });
+    });
+
+    it('should show success notification after changeStatus action when onSuccess is configured', async () => {
+      const action: SearchActionConfig = {
+        type: 'changeStatus',
+        translationKey: 'Mark Arrived',
+        onAction: { status: 'Arrived' },
+        enabledRule: [],
+        onSuccess: {
+          notification:
+            'REGISTRATION_APPOINTMENT_MARKED_AS_ARRIVED_SUCCESS_NOTIFICATION',
+        },
+      };
+
+      (updateAppointmentStatus as jest.Mock).mockResolvedValue({
+        uuid: 'appt-uuid-1',
+        status: 'Arrived',
+      });
+
+      await handleActionButtonClick(
+        action,
+        mockRow,
+        mockPatientSearchData,
+        mockSetPatientSearchData,
+        mockNavigate,
+        mockAddNotification,
+        mockT,
+      );
+
+      expect(mockAddNotification).toHaveBeenCalledWith({
+        title:
+          'REGISTRATION_APPOINTMENT_MARKED_AS_ARRIVED_SUCCESS_NOTIFICATION',
+        message: '',
+        type: 'success',
+        timeout: 5000,
+      });
+    });
+
+    it('should show success notification after checkInAndStartVisit action when onSuccess is configured', async () => {
+      const action: SearchActionConfig = {
+        type: 'checkInAndStartVisit',
+        translationKey: 'Check In',
+        onAction: {
+          submit:
+            '/openmrs/ws/rest/v1/iom/appointment/checkin?visitType=Follow+Up',
+        },
+        enabledRule: [],
+        onSuccess: {
+          notification:
+            'REGISTRATION_APPOINTMENT_MARKED_AS_ARRIVED_SUCCESS_NOTIFICATION',
+        },
+      };
+
+      (checkInAppointment as jest.Mock).mockResolvedValue({
+        appointmentUuid: 'appt-uuid-1',
+        status: 'Arrived',
+      });
+
+      await handleActionButtonClick(
+        action,
+        mockRow,
+        mockPatientSearchData,
+        mockSetPatientSearchData,
+        mockNavigate,
+        mockAddNotification,
+        mockT,
+      );
+
+      expect(mockAddNotification).toHaveBeenCalledWith({
+        title:
+          'REGISTRATION_APPOINTMENT_MARKED_AS_ARRIVED_SUCCESS_NOTIFICATION',
+        message: '',
+        type: 'success',
+        timeout: 5000,
+      });
+    });
+
+    it('should not show success notification when onSuccess is not configured', async () => {
+      const action: SearchActionConfig = {
+        type: 'changeStatus',
+        translationKey: 'Mark Arrived',
+        onAction: { status: 'Arrived' },
+        enabledRule: [],
+      };
+
+      (updateAppointmentStatus as jest.Mock).mockResolvedValue({
+        uuid: 'appt-uuid-1',
+        status: 'Arrived',
+      });
+
+      await handleActionButtonClick(
+        action,
+        mockRow,
+        mockPatientSearchData,
+        mockSetPatientSearchData,
+        mockNavigate,
+        mockAddNotification,
+        mockT,
+      );
+
+      expect(mockAddNotification).not.toHaveBeenCalled();
     });
 
     it('should navigate for navigate action', async () => {
@@ -434,6 +542,8 @@ describe('appointmentSearchResultActionHandler', () => {
         mockPatientSearchData,
         mockSetPatientSearchData,
         mockNavigate,
+        mockAddNotification,
+        mockT,
       );
 
       expect(mockNavigate).toHaveBeenCalledWith(
@@ -458,6 +568,8 @@ describe('appointmentSearchResultActionHandler', () => {
         mockPatientSearchData,
         mockSetPatientSearchData,
         mockNavigate,
+        mockAddNotification,
+        mockT,
       );
 
       expect(mockNavigate).toHaveBeenCalledWith('/appointment/APT-001');
@@ -484,6 +596,8 @@ describe('appointmentSearchResultActionHandler', () => {
         mockPatientSearchData,
         mockSetPatientSearchData,
         mockNavigate,
+        mockAddNotification,
+        mockT,
       );
 
       expect(checkInAppointment).toHaveBeenCalledWith(submitUrl, 'appt-uuid-1');
@@ -513,6 +627,8 @@ describe('appointmentSearchResultActionHandler', () => {
         mockPatientSearchData,
         mockSetPatientSearchData,
         mockNavigate,
+        mockAddNotification,
+        mockT,
       );
 
       expect(mockSetPatientSearchData).toHaveBeenCalledWith({
@@ -524,6 +640,65 @@ describe('appointmentSearchResultActionHandler', () => {
           }),
         ]),
       });
+    });
+
+    it('should show error notification when changeStatus API fails', async () => {
+      const action: SearchActionConfig = {
+        type: 'changeStatus',
+        translationKey: 'Mark Arrived',
+        onAction: { status: 'Arrived' },
+        enabledRule: [],
+      };
+
+      (updateAppointmentStatus as jest.Mock).mockRejectedValue(
+        new Error('API error'),
+      );
+
+      await handleActionButtonClick(
+        action,
+        mockRow,
+        mockPatientSearchData,
+        mockSetPatientSearchData,
+        mockNavigate,
+        mockAddNotification,
+        mockT,
+      );
+
+      expect(mockAddNotification).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'error' }),
+      );
+      expect(mockSetPatientSearchData).not.toHaveBeenCalled();
+    });
+
+    it('should show error notification when checkInAndStartVisit API fails', async () => {
+      const action: SearchActionConfig = {
+        type: 'checkInAndStartVisit',
+        translationKey: 'Check In',
+        onAction: {
+          submit:
+            '/openmrs/ws/rest/v1/iom/appointment/checkin?visitType=Follow+Up',
+        },
+        enabledRule: [],
+      };
+
+      (checkInAppointment as jest.Mock).mockRejectedValue(
+        new Error('API error'),
+      );
+
+      await handleActionButtonClick(
+        action,
+        mockRow,
+        mockPatientSearchData,
+        mockSetPatientSearchData,
+        mockNavigate,
+        mockAddNotification,
+        mockT,
+      );
+
+      expect(mockAddNotification).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'error' }),
+      );
+      expect(mockSetPatientSearchData).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/registration/src/pages/patientSearchPage/appointmentSearchResultActionHandler.ts
+++ b/apps/registration/src/pages/patientSearchPage/appointmentSearchResultActionHandler.ts
@@ -7,6 +7,7 @@ import {
   formatUrl,
   PatientSearchResultBundle,
   hasPrivilege,
+  type Notification,
 } from '@bahmni/services';
 import { isSameDay, isBefore, isAfter } from 'date-fns';
 import { NavigateFunction } from 'react-router-dom';
@@ -66,24 +67,53 @@ export const handleActionButtonClick = async (
   patientSearchData: PatientSearchResultBundle,
   setPatientSearchData: (data: PatientSearchResultBundle) => void,
   navigate: NavigateFunction,
+  addNotification: (notification: Omit<Notification, 'id'>) => void,
+  t: (key: string) => string,
 ) => {
   const { status, navigation, submit } = action.onAction;
+
+  const showSuccessNotification = () => {
+    if (action.onSuccess?.notification) {
+      addNotification({
+        title: t(action.onSuccess.notification),
+        message: '',
+        type: 'success',
+        timeout: 5000,
+      });
+    }
+  };
+
+  const showErrorNotification = () => {
+    addNotification({
+      title: t('REGISTRATION_ACTION_BUTTON_GENERIC_ERROR'),
+      message: '',
+      type: 'error',
+      timeout: 5000,
+    });
+  };
 
   if (action.type === 'changeStatus') {
     await updateAppointmentStatus(
       row.appointmentUuid as string,
       status as string,
-    ).then((response) => {
-      const updatedPatientSearchData = {
-        totalCount: patientSearchData.totalCount,
-        pageOfResults: updateAppointmentStatusInResults(
-          patientSearchData.pageOfResults,
-          response.uuid,
-          response.status,
-        ),
-      };
-      setPatientSearchData(updatedPatientSearchData);
-    });
+    )
+      .then((response) => {
+        const { uuid, status: updatedStatus } = response as {
+          uuid: string;
+          status: string;
+        };
+        const updatedPatientSearchData = {
+          totalCount: patientSearchData.totalCount,
+          pageOfResults: updateAppointmentStatusInResults(
+            patientSearchData.pageOfResults,
+            uuid,
+            updatedStatus,
+          ),
+        };
+        setPatientSearchData(updatedPatientSearchData);
+        showSuccessNotification();
+      })
+      .catch(showErrorNotification);
   } else if (action.type === 'navigate') {
     const options: Record<string, string> = {};
     options['patientUuid'] = row.uuid;
@@ -91,17 +121,20 @@ export const handleActionButtonClick = async (
     options['appointmentUuid'] = row.appointmentUuid!;
     handleActionNavigation(navigation ?? '', options, navigate);
   } else if (action.type === 'checkInAndStartVisit') {
-    await checkInAppointment(submit!, row.appointmentUuid!).then((response) => {
-      const updatedPatientSearchData = {
-        totalCount: patientSearchData.totalCount,
-        pageOfResults: updateAppointmentStatusInResults(
-          patientSearchData.pageOfResults,
-          response.appointmentUuid,
-          response.status,
-        ),
-      };
-      setPatientSearchData(updatedPatientSearchData);
-    });
+    await checkInAppointment(submit!, row.appointmentUuid!)
+      .then((response) => {
+        const updatedPatientSearchData = {
+          totalCount: patientSearchData.totalCount,
+          pageOfResults: updateAppointmentStatusInResults(
+            patientSearchData.pageOfResults,
+            response.appointmentUuid,
+            response.status,
+          ),
+        };
+        setPatientSearchData(updatedPatientSearchData);
+        showSuccessNotification();
+      })
+      .catch(showErrorNotification);
   }
 };
 

--- a/apps/registration/src/pages/patientSearchPage/appointmentSearchResultActionHandler.ts
+++ b/apps/registration/src/pages/patientSearchPage/appointmentSearchResultActionHandler.ts
@@ -92,28 +92,35 @@ export const handleActionButtonClick = async (
     });
   };
 
+  const handleResponse = async (
+    promise: Promise<{ appointmentUuid: string; status: string }>,
+  ) => {
+    try {
+      const { appointmentUuid, status: updatedStatus } = await promise;
+      setPatientSearchData({
+        totalCount: patientSearchData.totalCount,
+        pageOfResults: updateAppointmentStatusInResults(
+          patientSearchData.pageOfResults,
+          appointmentUuid,
+          updatedStatus,
+        ),
+      });
+      showSuccessNotification();
+    } catch {
+      showErrorNotification();
+    }
+  };
+
   if (action.type === 'changeStatus') {
-    await updateAppointmentStatus(
-      row.appointmentUuid as string,
-      status as string,
-    )
-      .then((response) => {
-        const { uuid, status: updatedStatus } = response as {
+    await handleResponse(
+      updateAppointmentStatus(row.appointmentUuid!, status!).then((res) => {
+        const { uuid, status: updatedStatus } = res as {
           uuid: string;
           status: string;
         };
-        const updatedPatientSearchData = {
-          totalCount: patientSearchData.totalCount,
-          pageOfResults: updateAppointmentStatusInResults(
-            patientSearchData.pageOfResults,
-            uuid,
-            updatedStatus,
-          ),
-        };
-        setPatientSearchData(updatedPatientSearchData);
-        showSuccessNotification();
-      })
-      .catch(showErrorNotification);
+        return { appointmentUuid: uuid, status: updatedStatus };
+      }),
+    );
   } else if (action.type === 'navigate') {
     const options: Record<string, string> = {};
     options['patientUuid'] = row.uuid;
@@ -121,20 +128,7 @@ export const handleActionButtonClick = async (
     options['appointmentUuid'] = row.appointmentUuid!;
     handleActionNavigation(navigation ?? '', options, navigate);
   } else if (action.type === 'checkInAndStartVisit') {
-    await checkInAppointment(submit!, row.appointmentUuid!)
-      .then((response) => {
-        const updatedPatientSearchData = {
-          totalCount: patientSearchData.totalCount,
-          pageOfResults: updateAppointmentStatusInResults(
-            patientSearchData.pageOfResults,
-            response.appointmentUuid,
-            response.status,
-          ),
-        };
-        setPatientSearchData(updatedPatientSearchData);
-        showSuccessNotification();
-      })
-      .catch(showErrorNotification);
+    await handleResponse(checkInAppointment(submit!, row.appointmentUuid!));
   }
 };
 

--- a/apps/registration/src/pages/patientSearchPage/index.tsx
+++ b/apps/registration/src/pages/patientSearchPage/index.tsx
@@ -23,7 +23,11 @@ import {
   PatientSearchResultBundle,
   useTranslation,
 } from '@bahmni/services';
-import { SearchPatient, useUserPrivilege } from '@bahmni/widgets';
+import {
+  SearchPatient,
+  useNotification,
+  useUserPrivilege,
+} from '@bahmni/widgets';
 import { useCallback, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useRegistrationConfig } from '../../providers/registrationConfig';
@@ -61,6 +65,7 @@ const PatientSearchPage: React.FC = () => {
   const navigate = useNavigate();
   const [selectedFieldType, setSelectedFieldType] = useState<string>('');
   const { userPrivileges } = useUserPrivilege();
+  const { addNotification } = useNotification();
   const { registrationConfig } = useRegistrationConfig();
 
   const handleCreateNewPatient = () => {
@@ -222,6 +227,8 @@ const PatientSearchPage: React.FC = () => {
                     patientSearchData!,
                     setPatientSearchData,
                     navigate,
+                    addNotification,
+                    t,
                   )
                 }
               >


### PR DESCRIPTION
 -After a successful changeStatus or checkInAndStartVisit action, shows a success toast using the translation key configured in onSuccess.notification
- If either API call fails, shows a generic error toast (REGISTRATION_ACTION_BUTTON_GENERIC_ERROR)
- No notification is shown for the navigate action type (no API call involved)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Patient search actions (`changeStatus`, `checkInAndStartVisit`) now display success notifications when configured, and a generic error notification on failure.
  * Added new English and Spanish locale text for generic registration errors.

* **Bug Fixes**
  * Patient search results are no longer updated when an action request fails.

* **Tests**
  * Expanded coverage for notification behavior on both success and failure paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->