### PR TITLE
BAH-4754 command palette as configurable

### DIFF
--- a/apps/command-palette/src/components/CommandPaletteProvider/CommandPaletteProvider.tsx
+++ b/apps/command-palette/src/components/CommandPaletteProvider/CommandPaletteProvider.tsx
@@ -1,19 +1,36 @@
 import { CommandPaletteProvider as WidgetCommandPaletteProvider } from '@bahmni/widgets';
 import React, { type ReactNode } from 'react';
+import { COMMAND_PALETTE_ENABLED_STORAGE_KEY } from '../../constants/app';
 import { useCommandPaletteConfig } from '../../hooks/useCommandPaletteConfig';
 
 interface CommandPaletteProviderProps {
   children?: ReactNode;
 }
 
-export const CommandPaletteProvider: React.FC<CommandPaletteProviderProps> = ({
+const EnabledCommandPaletteProvider: React.FC<CommandPaletteProviderProps> = ({
   children,
 }) => {
   const config = useCommandPaletteConfig();
+
   return (
     <WidgetCommandPaletteProvider {...config}>
       {children}
     </WidgetCommandPaletteProvider>
+  );
+};
+
+export const CommandPaletteProvider: React.FC<CommandPaletteProviderProps> = ({
+  children,
+}) => {
+  const isCommandPaletteEnabled =
+    localStorage.getItem(COMMAND_PALETTE_ENABLED_STORAGE_KEY) === 'true';
+
+  if (!isCommandPaletteEnabled) {
+    return children;
+  }
+
+  return (
+    <EnabledCommandPaletteProvider>{children}</EnabledCommandPaletteProvider>
   );
 };
 

--- a/apps/command-palette/src/components/CommandPaletteProvider/__tests__/CommandPaletteProvider.test.tsx
+++ b/apps/command-palette/src/components/CommandPaletteProvider/__tests__/CommandPaletteProvider.test.tsx
@@ -29,7 +29,11 @@ const defaultConfig = {
 
 describe('CommandPaletteProvider', () => {
   beforeEach(() => {
+    localStorage.setItem('enableCommandPalette', 'true');
     mockUseCommandPaletteConfig.mockReturnValue(defaultConfig);
+  });
+  afterEach(() => {
+    localStorage.clear();
   });
 
   it('renders children inside the widget provider', () => {
@@ -43,8 +47,16 @@ describe('CommandPaletteProvider', () => {
     expect(screen.getByText('child content')).toBeInTheDocument();
   });
 
-  it('renders without children', () => {
-    render(<CommandPaletteProvider />);
-    expect(screen.getByTestId('widget-provider')).toBeInTheDocument();
+  it('does not render the widget provider when command palette is disabled', () => {
+    localStorage.setItem('enableCommandPalette', 'false');
+
+    render(
+      <CommandPaletteProvider>
+        <span>child content</span>
+      </CommandPaletteProvider>,
+    );
+
+    expect(screen.queryByTestId('widget-provider')).not.toBeInTheDocument();
+    expect(screen.getByText('child content')).toBeInTheDocument();
   });
 });

--- a/apps/command-palette/src/constants/app.ts
+++ b/apps/command-palette/src/constants/app.ts
@@ -2,6 +2,8 @@ import type { PatientFieldsConfig, TriggerConfig } from '@bahmni/widgets';
 
 export const BAHMNI_COMMAND_PALETTE_NAMESPACE = 'command-palette';
 
+export const COMMAND_PALETTE_ENABLED_STORAGE_KEY = 'enableCommandPalette';
+
 export const COMMAND_PALETTE_APP_CONFIG_URL =
   '/bahmni_config/openmrs/apps/command-palette/app.json';
 export const EXTENSION_BASE_URL = '/bahmni_config/openmrs/apps';


### PR DESCRIPTION


## Summary by CodeRabbit

* **New Features**
  * The command palette now follows a persisted on/off preference, showing or hiding the palette experience accordingly.

* **Bug Fixes**
  * When disabled, page content renders normally without the palette provider wrapper.
  * Updated and strengthened tests to isolate local preference state and verify both enabled/disabled rendering behavior.

**in home/app.json** keep this   enableCommandPalette as true to enable command palette

  "config": {
    "homeUrl": "/bahmni-v2/home",
    **"enableCommandPalette": true**
  }
