### PR TITLE
BAH-4799 | Fix. Error handling for dashboard config loading erros

### DIFF
--- a/apps/clinical/public/locales/locale_en.json
+++ b/apps/clinical/public/locales/locale_en.json
@@ -193,6 +193,7 @@
   "ERROR_INVALID_PATIENT_UUID": "Invalid patient UUID",
   "ERROR_LOADING_ALLERGIES": "Error loading allergies",
   "ERROR_LOADING_DASHBOARD": "Error loading dashboard",
+  "ERROR_LOADING_DASHBOARD_CONFIG": "Error loading dashboard configuration",
   "ERROR_LOADING_IMMUNIZATION_DETAILS": "Error loading immunization details",
   "ERROR_LOADING_OBSERVATIONS": "Error loading observations",
   "ERROR_LOADING_PINNED_FORMS": "Error loading Pinned Forms",

--- a/apps/clinical/public/locales/locale_es.json
+++ b/apps/clinical/public/locales/locale_es.json
@@ -193,6 +193,7 @@
   "ERROR_INVALID_PATIENT_UUID": "UUID de paciente inválido",
   "ERROR_LOADING_ALLERGIES": "Error al cargar alergias",
   "ERROR_LOADING_DASHBOARD": "Error al cargar el panel",
+  "ERROR_LOADING_DASHBOARD_CONFIG": "Error al cargar la configuración del panel",
   "ERROR_LOADING_IMMUNIZATION_DETAILS": "Error al cargar los detalles de la inmunización",
   "ERROR_LOADING_OBSERVATIONS": "Error al cargar observaciones",
   "ERROR_LOADING_PINNED_FORMS": "Error al cargar Formularios Anclados",

--- a/apps/clinical/src/pages/ConsultationPage.tsx
+++ b/apps/clinical/src/pages/ConsultationPage.tsx
@@ -193,7 +193,7 @@ const ConsultationPage: React.FC = () => {
     if (dashboardConfigError) {
       addNotification({
         title: t('ERROR_LOADING_DASHBOARD_CONFIG'),
-        message: dashboardConfigError.message,
+        message: t(dashboardConfigError.message),
         type: 'error',
       });
     }
@@ -271,6 +271,16 @@ const ConsultationPage: React.FC = () => {
         description={t('LOADING_DASHBOARD_CONFIG')}
         role="status"
       />
+    );
+  }
+  if (dashboardConfigError || !filteredDashboardConfig) {
+    return (
+      <div
+        id="error-loading-dashboard-config"
+        data-testid="error-loading-dashboard-config-test-id"
+      >
+        {t('ERROR_LOADING_DASHBOARD_CONFIG')}
+      </div>
     );
   }
 

--- a/apps/clinical/src/pages/__tests__/ConsultationPage.test.tsx
+++ b/apps/clinical/src/pages/__tests__/ConsultationPage.test.tsx
@@ -621,6 +621,71 @@ describe('ConsultationPage', () => {
     });
   });
 
+  describe('Dashboard config error handling', () => {
+    it('should show error div and call addNotification when dashboard config fetch fails', async () => {
+      const mockAddNotification = jest.fn();
+      (useNotification as jest.Mock).mockReturnValue({
+        addNotification: mockAddNotification,
+        notifications: [],
+        removeNotification: jest.fn(),
+        clearAllNotifications: jest.fn(),
+      });
+      (getConfig as jest.Mock).mockRejectedValue(new Error('Network error'));
+
+      renderWithProvider();
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId('error-loading-dashboard-config-test-id'),
+        ).toBeInTheDocument();
+      });
+
+      expect(mockAddNotification).toHaveBeenCalledWith({
+        title: 'Error loading dashboard configuration',
+        message: 'Network error',
+        type: 'error',
+      });
+    });
+
+    it('should show error div when dashboard config resolves to null', async () => {
+      (getConfig as jest.Mock).mockResolvedValue(null);
+
+      renderWithProvider();
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId('error-loading-dashboard-config-test-id'),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('should not call addNotification for dashboard config error when fetch succeeds', async () => {
+      const mockAddNotification = jest.fn();
+      (useNotification as jest.Mock).mockReturnValue({
+        addNotification: mockAddNotification,
+        notifications: [],
+        removeNotification: jest.fn(),
+        clearAllNotifications: jest.fn(),
+      });
+
+      renderWithProvider();
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('carbon-loading')).not.toBeInTheDocument();
+      });
+
+      expect(mockAddNotification).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'error',
+          title: 'Error loading dashboard configuration',
+        }),
+      );
+      expect(
+        screen.queryByTestId('error-loading-dashboard-config-test-id'),
+      ).not.toBeInTheDocument();
+    });
+  });
+
   describe('Scroll trigger on sidebar click', () => {
     it('should increment scrollTrigger when sidebar item is clicked', async () => {
       renderWithProvider();

--- a/apps/clinical/src/pages/schema.json
+++ b/apps/clinical/src/pages/schema.json
@@ -47,32 +47,7 @@
                 },
                 "config": {
                   "type": "object",
-                  "description": "Configuration for the control. For 'programs' type, see programsConfig definition.",
-                  "properties": {
-                    "pageSize": {
-                      "type": "number",
-                      "description": "Number of rows per page"
-                    },
-                    "fields": {
-                      "type": "array",
-                      "description": "Fields to display. Each entry must be an object with 'name' and optional 'enableTranslation'.",
-                      "items": {
-                        "type": "object",
-                        "required": ["name"],
-                        "additionalProperties": false,
-                        "properties": {
-                          "name": {
-                            "type": "string",
-                            "description": "Field or program attribute name to display. Built-in values: 'programName', 'startDate', 'endDate', 'outcome', 'state'. Any other value is treated as a program attribute name."
-                          },
-                          "enableTranslation": {
-                            "type": "boolean",
-                            "description": "When true, the cell value is translated via i18n key PROGRAM_ATTRIBUTE_VALUE_<FIELD>_<VALUE>"
-                          }
-                        }
-                      }
-                    }
-                  }
+                  "description": "Configuration for the control. For 'programs' type, see programsConfig definition."
                 }
               }
             }


### PR DESCRIPTION

**JIRA** → [BAH-4799](https://bahmni.atlassian.net/browse/BAH-4799)

### **Description**

This PR handles the error handling when the dashboard config loading fails. It can be due to network errors or due to config schema validation.

Also reverted the schema changes added as part of #513 which added a specific display controls validation to clinical dashboard config validation. These validations are responsibility of the individual display controls.

---


> [!IMPORTANT]
> **Checklist**
>
> - [x] Code adheres to project linting and formatting standards.
> - [x] New components added to Storybook.
> - [x] Tests written and passing (unit + integration).
> - [x] Labels and text support i18n.
> - [x] Follows accessibility and responsive design guidelines.
> - [x] PR reviewed by at least one other developer.

---

### **Reviewer(s)**

@bahnew/developers 
_Kindly review the proposed changes when convenient. Your feedback is appreciated._

---


[BAH-4799]: https://bahmni.atlassian.net/browse/BAH-4799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dashboard configuration error handling on the consultation page.
  * Users now see a clear error state if dashboard settings fail to load or are unavailable.
  * Error messages are now shown in the correct language when supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->