### PR TITLE
BAH-4826 | Fix.  Show API error message in appointment action notification

### DIFF
--- a/apps/registration/src/pages/patientSearchPage/__tests__/appointmentSearchResultActionHandler.test.ts
+++ b/apps/registration/src/pages/patientSearchPage/__tests__/appointmentSearchResultActionHandler.test.ts
@@ -639,7 +639,7 @@ describe('appointmentSearchResultActionHandler', () => {
       });
     });
 
-    it('should show error notification when changeStatus API fails', async () => {
+    it('should show the API error message when changeStatus fails with a message', async () => {
       const action: SearchActionConfig = {
         type: 'changeStatus',
         translationKey: 'Mark Arrived',
@@ -648,7 +648,7 @@ describe('appointmentSearchResultActionHandler', () => {
       };
 
       (updateAppointmentStatus as jest.Mock).mockRejectedValue(
-        new Error('API error'),
+        'Server error occurred',
       );
 
       await handleActionButtonClick(
@@ -661,25 +661,24 @@ describe('appointmentSearchResultActionHandler', () => {
         mockT,
       );
 
-      expect(mockAddNotification).toHaveBeenCalledWith(
-        expect.objectContaining({ type: 'error' }),
-      );
+      expect(mockAddNotification).toHaveBeenCalledWith({
+        title: 'Server error occurred',
+        message: '',
+        type: 'error',
+        timeout: 5000,
+      });
       expect(mockSetPatientSearchData).not.toHaveBeenCalled();
     });
 
-    it('should show error notification when checkInAndStartVisit API fails', async () => {
+    it('should show generic error notification when changeStatus fails without a message', async () => {
       const action: SearchActionConfig = {
-        type: 'checkInAndStartVisit',
-        translationKey: 'Check In',
-        onAction: {
-          submit: '/bahmni/appointment/checkin',
-        },
+        type: 'changeStatus',
+        translationKey: 'Mark Arrived',
+        onAction: { status: 'Arrived' },
         enabledRule: [],
       };
 
-      (checkInAppointment as jest.Mock).mockRejectedValue(
-        new Error('API error'),
-      );
+      (updateAppointmentStatus as jest.Mock).mockRejectedValue(null);
 
       await handleActionButtonClick(
         action,
@@ -691,10 +690,69 @@ describe('appointmentSearchResultActionHandler', () => {
         mockT,
       );
 
-      expect(mockAddNotification).toHaveBeenCalledWith(
-        expect.objectContaining({ type: 'error' }),
+      expect(mockAddNotification).toHaveBeenCalledWith({
+        title: 'REGISTRATION_ACTION_BUTTON_GENERIC_ERROR',
+        message: '',
+        type: 'error',
+        timeout: 5000,
+      });
+    });
+
+    it('should show the API error message when checkInAndStartVisit fails with a message', async () => {
+      const action: SearchActionConfig = {
+        type: 'checkInAndStartVisit',
+        translationKey: 'Check In',
+        onAction: { submit: '/bahmni/appointment/checkin' },
+        enabledRule: [],
+      };
+
+      (checkInAppointment as jest.Mock).mockRejectedValue('Check-in failed');
+
+      await handleActionButtonClick(
+        action,
+        mockRow,
+        mockPatientSearchData,
+        mockSetPatientSearchData,
+        mockNavigate,
+        mockAddNotification,
+        mockT,
       );
+
+      expect(mockAddNotification).toHaveBeenCalledWith({
+        title: 'Check-in failed',
+        message: '',
+        type: 'error',
+        timeout: 5000,
+      });
       expect(mockSetPatientSearchData).not.toHaveBeenCalled();
+    });
+
+    it('should show generic error notification when checkInAndStartVisit fails without a message', async () => {
+      const action: SearchActionConfig = {
+        type: 'checkInAndStartVisit',
+        translationKey: 'Check In',
+        onAction: { submit: '/bahmni/appointment/checkin' },
+        enabledRule: [],
+      };
+
+      (checkInAppointment as jest.Mock).mockRejectedValue(null);
+
+      await handleActionButtonClick(
+        action,
+        mockRow,
+        mockPatientSearchData,
+        mockSetPatientSearchData,
+        mockNavigate,
+        mockAddNotification,
+        mockT,
+      );
+
+      expect(mockAddNotification).toHaveBeenCalledWith({
+        title: 'REGISTRATION_ACTION_BUTTON_GENERIC_ERROR',
+        message: '',
+        type: 'error',
+        timeout: 5000,
+      });
     });
   });
 

--- a/apps/registration/src/pages/patientSearchPage/appointmentSearchResultActionHandler.ts
+++ b/apps/registration/src/pages/patientSearchPage/appointmentSearchResultActionHandler.ts
@@ -83,9 +83,12 @@ export const handleActionButtonClick = async (
     }
   };
 
-  const showErrorNotification = () => {
+  const showErrorNotification = (error: unknown) => {
     addNotification({
-      title: t('REGISTRATION_ACTION_BUTTON_GENERIC_ERROR'),
+      title:
+        typeof error === 'string'
+          ? error
+          : t('REGISTRATION_ACTION_BUTTON_GENERIC_ERROR'),
       message: '',
       type: 'error',
       timeout: 5000,
@@ -106,8 +109,8 @@ export const handleActionButtonClick = async (
         ),
       });
       showSuccessNotification();
-    } catch {
-      showErrorNotification();
+    } catch (error) {
+      showErrorNotification(error);
     }
   };
 


### PR DESCRIPTION
When appointment actions (changeStatus, checkInAndStartVisit) failed, the error notification always showed a generic fallback message, discarding any specific error message returned by the API.

Changes

- Updated showErrorNotification to accept the caught error and display it as the notification title when it is a string, falling back to the generic i18n key otherwise
- Updated tests to assert on the exact notification payload and cover both the "error with message" and "error without message" cases for each action type


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages shown when appointment actions fail, so users now see the specific server message when available.
  * Added a clearer generic fallback message when no error details are returned.
  * Kept patient search results from updating when an action fails, preventing confusing or incorrect updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->