### PR TITLE
BAH-4828 | Kanchi | Add. Disable already-submitted observation forms …

### DIFF
--- a/apps/clinical/src/components/forms/observations/ObservationForms.tsx
+++ b/apps/clinical/src/components/forms/observations/ObservationForms.tsx
@@ -31,6 +31,8 @@ interface ObservationFormsProps {
   allForms: ObservationForm[];
   isAllFormsLoading: boolean;
   observationFormsError: Error | null;
+  // Set of form UUIDs already submitted in the active encounter (BAH-4828)
+  submittedFormUuids?: Set<string>;
 }
 
 /**
@@ -58,6 +60,7 @@ const ObservationForms: React.FC<ObservationFormsProps> = React.memo(
     allForms,
     isAllFormsLoading,
     observationFormsError,
+    submittedFormUuids = new Set(),
   }) => {
     const { t } = useTranslation();
     const canAddObservations = useHasPrivilege(
@@ -197,18 +200,20 @@ const ObservationForms: React.FC<ObservationFormsProps> = React.memo(
         ];
       }
 
-      // Map forms to ComboBox items with proper labeling for already selected forms
+      // Map forms to ComboBox items with proper labeling for already-selected or already-submitted forms
       const results = availableForms.map((form: ObservationForm) => {
         const isAlreadySelected = selectedForms.some(
           (selected: ObservationForm) => selected.uuid === form.uuid,
         );
+        const isSubmitted = submittedFormUuids.has(form.uuid);
+        const disabled = isAlreadySelected || isSubmitted;
 
         return {
           id: form.uuid,
-          label: isAlreadySelected
+          label: disabled
             ? `${form.name} (${t('OBSERVATION_FORMS_FORM_ALREADY_ADDED')})`
             : form.name,
-          disabled: isAlreadySelected,
+          disabled,
         };
       });
 
@@ -219,6 +224,7 @@ const ObservationForms: React.FC<ObservationFormsProps> = React.memo(
       searchTerm,
       availableForms,
       selectedForms,
+      submittedFormUuids,
       t,
     ]);
 

--- a/apps/clinical/src/components/forms/observations/ObservationForms.tsx
+++ b/apps/clinical/src/components/forms/observations/ObservationForms.tsx
@@ -19,6 +19,8 @@ import {
 import { useObservationFormsStore } from '../../../stores/observationFormsStore';
 import styles from './styles/ObservationForms.module.scss';
 
+const EMPTY_SET = new Set<string>();
+
 interface ObservationFormsProps {
   onFormSelect?: (form: ObservationForm) => void;
   selectedForms?: ObservationForm[];
@@ -31,7 +33,6 @@ interface ObservationFormsProps {
   allForms: ObservationForm[];
   isAllFormsLoading: boolean;
   observationFormsError: Error | null;
-  // Set of form UUIDs already submitted in the active encounter (BAH-4828)
   submittedFormUuids?: Set<string>;
 }
 
@@ -60,7 +61,7 @@ const ObservationForms: React.FC<ObservationFormsProps> = React.memo(
     allForms,
     isAllFormsLoading,
     observationFormsError,
-    submittedFormUuids = new Set(),
+    submittedFormUuids = EMPTY_SET,
   }) => {
     const { t } = useTranslation();
     const canAddObservations = useHasPrivilege(

--- a/apps/clinical/src/components/forms/observations/ObservationFormsPanel.tsx
+++ b/apps/clinical/src/components/forms/observations/ObservationFormsPanel.tsx
@@ -5,6 +5,7 @@ import type { EncounterSessionStartContext } from '../../../events/startConsulta
 import { useClinicalAppData } from '../../../hooks/useClinicalAppData';
 import useObservationFormsSearch from '../../../hooks/useObservationFormsSearch';
 import { usePinnedObservationForms } from '../../../hooks/usePinnedObservationForms';
+import { useSubmittedEncounterForms } from '../../../hooks/useSubmittedEncounterForms';
 import { useObservationFormsStore } from '../../../stores/observationFormsStore';
 import ObservationForms from './ObservationForms';
 
@@ -37,6 +38,8 @@ const ObservationFormsPanel: React.FC<ObservationFormsPanelProps> = ({
 
   const { selectedForms, addForm, removeForm, viewingForm } =
     useObservationFormsStore();
+
+  const submittedFormUuids = useSubmittedEncounterForms(allForms);
 
   const prevViewingFormRef = useRef(viewingForm);
   useEffect(() => {
@@ -81,6 +84,7 @@ const ObservationFormsPanel: React.FC<ObservationFormsPanelProps> = ({
       allForms={allForms}
       isAllFormsLoading={isAllFormsLoading}
       observationFormsError={observationFormsError}
+      submittedFormUuids={submittedFormUuids}
     />
   );
 };

--- a/apps/clinical/src/components/forms/observations/__tests__/ObservationForms.test.tsx
+++ b/apps/clinical/src/components/forms/observations/__tests__/ObservationForms.test.tsx
@@ -487,6 +487,93 @@ describe('ObservationForms', () => {
     });
   });
 
+  describe('Submitted Encounter Forms (BAH-4828)', () => {
+    it('should show a submitted form as disabled with (Already added) label', () => {
+      const submittedFormUuids = new Set(['form-1']); // Admission Letter already submitted
+      render(
+        <ObservationForms
+          {...defaultProps}
+          submittedFormUuids={submittedFormUuids}
+        />,
+      );
+
+      const submittedFormButton = screen.getByTestId('combobox-item-form-1');
+      const nonSubmittedFormButton = screen.getByTestId('combobox-item-form-2');
+
+      expect(submittedFormButton).toBeDisabled();
+      expect(nonSubmittedFormButton).not.toBeDisabled();
+
+      expect(
+        screen.getByText(
+          'Admission Letter (translated_OBSERVATION_FORMS_FORM_ALREADY_ADDED)',
+        ),
+      ).toBeInTheDocument();
+      expect(screen.getByText('Death Note')).toBeInTheDocument();
+    });
+
+    it('should disable all forms in submittedFormUuids while keeping others selectable', () => {
+      const submittedFormUuids = new Set(['form-1', 'form-2']); // both submitted
+      render(
+        <ObservationForms
+          {...defaultProps}
+          submittedFormUuids={submittedFormUuids}
+        />,
+      );
+
+      expect(screen.getByTestId('combobox-item-form-1')).toBeDisabled();
+      expect(screen.getByTestId('combobox-item-form-2')).toBeDisabled();
+    });
+
+    it('should not call onFormSelect when clicking a submitted form', async () => {
+      const user = userEvent.setup();
+      const mockOnFormSelect = jest.fn();
+      const submittedFormUuids = new Set(['form-1']);
+
+      render(
+        <ObservationForms
+          {...defaultProps}
+          onFormSelect={mockOnFormSelect}
+          submittedFormUuids={submittedFormUuids}
+        />,
+      );
+
+      const disabledButton = screen.getByTestId('combobox-item-form-1');
+      expect(disabledButton).toBeDisabled();
+      await user.click(disabledButton);
+
+      expect(mockOnFormSelect).not.toHaveBeenCalled();
+    });
+
+    it('should disable and label form that is both selected and submitted', () => {
+      // A form that is in selectedForms AND submittedFormUuids should still be disabled
+      const selectedForms = [mockForms[0]];
+      const submittedFormUuids = new Set(['form-1']);
+
+      render(
+        <ObservationForms
+          {...defaultProps}
+          selectedForms={selectedForms}
+          submittedFormUuids={submittedFormUuids}
+        />,
+      );
+
+      expect(screen.getByTestId('combobox-item-form-1')).toBeDisabled();
+      expect(
+        screen.getByText(
+          'Admission Letter (translated_OBSERVATION_FORMS_FORM_ALREADY_ADDED)',
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it('should default to no submitted forms when submittedFormUuids is not provided', () => {
+      render(<ObservationForms {...defaultProps} />);
+
+      // Both forms should be enabled when no submittedFormUuids prop
+      expect(screen.getByTestId('combobox-item-form-1')).not.toBeDisabled();
+      expect(screen.getByTestId('combobox-item-form-2')).not.toBeDisabled();
+    });
+  });
+
   describe('Loading and Error States', () => {
     it('should show loading state in dropdown', () => {
       render(

--- a/apps/clinical/src/components/forms/observations/__tests__/ObservationFormsPanel.test.tsx
+++ b/apps/clinical/src/components/forms/observations/__tests__/ObservationFormsPanel.test.tsx
@@ -5,6 +5,7 @@ import { axe, toHaveNoViolations } from 'jest-axe';
 import { useClinicalAppData } from '../../../../hooks/useClinicalAppData';
 import useObservationFormsSearch from '../../../../hooks/useObservationFormsSearch';
 import { usePinnedObservationForms } from '../../../../hooks/usePinnedObservationForms';
+import { useSubmittedEncounterForms } from '../../../../hooks/useSubmittedEncounterForms';
 import { useObservationFormsStore } from '../../../../stores/observationFormsStore';
 import ObservationForms from '../ObservationForms';
 import ObservationFormsPanel from '../ObservationFormsPanel';
@@ -44,6 +45,10 @@ jest.mock('../../../../hooks/useObservationFormsSearch', () => ({
 
 jest.mock('../../../../hooks/usePinnedObservationForms', () => ({
   usePinnedObservationForms: jest.fn(),
+}));
+
+jest.mock('../../../../hooks/useSubmittedEncounterForms', () => ({
+  useSubmittedEncounterForms: jest.fn(() => new Set<string>()),
 }));
 
 jest.mock('../../../../stores/observationFormsStore', () => ({
@@ -124,6 +129,16 @@ describe('ObservationFormsPanel', () => {
       [mockForm1, mockForm2],
       { userUuid: 'practitioner-uuid', isFormsLoading: false },
     );
+  });
+
+  it('passes submittedFormUuids from useSubmittedEncounterForms to ObservationForms', () => {
+    const mockSubmittedUuids = new Set(['form-uuid-1']);
+    jest.mocked(useSubmittedEncounterForms).mockReturnValue(mockSubmittedUuids);
+
+    render(<ObservationFormsPanel />);
+
+    const receivedProps = MockObservationForms.mock.calls[0][0];
+    expect(receivedProps.submittedFormUuids).toBe(mockSubmittedUuids);
   });
 
   it('calls addForm when onFormSelect is invoked', () => {

--- a/apps/clinical/src/hooks/__tests__/useSubmittedEncounterForms.test.tsx
+++ b/apps/clinical/src/hooks/__tests__/useSubmittedEncounterForms.test.tsx
@@ -1,0 +1,435 @@
+import {
+  FHIR_OBSERVATION_FORM_NAMESPACE_PATH_URL,
+  getObservationsBundleByEncounterUuid,
+  useEncounterSessionStore,
+  useSubscribeConsultationSaved,
+  ObservationForm,
+} from '@bahmni/services';
+import { usePatientUUID } from '@bahmni/widgets';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import type { Bundle, Observation } from 'fhir/r4';
+import React from 'react';
+import { useSubmittedEncounterForms } from '../useSubmittedEncounterForms';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+jest.mock('@bahmni/services', () => ({
+  ...jest.requireActual('@bahmni/services'),
+  getObservationsBundleByEncounterUuid: jest.fn(),
+  useEncounterSessionStore: jest.fn(),
+  useSubscribeConsultationSaved: jest.fn(),
+}));
+
+jest.mock('@bahmni/widgets', () => ({
+  usePatientUUID: jest.fn(),
+}));
+
+const mockGetObservationsBundleByEncounterUuid =
+  getObservationsBundleByEncounterUuid as jest.MockedFunction<
+    typeof getObservationsBundleByEncounterUuid
+  >;
+const mockUseEncounterSessionStore =
+  useEncounterSessionStore as jest.MockedFunction<
+    typeof useEncounterSessionStore
+  >;
+const mockUseSubscribeConsultationSaved =
+  useSubscribeConsultationSaved as jest.MockedFunction<
+    typeof useSubscribeConsultationSaved
+  >;
+const mockUsePatientUUID = usePatientUUID as jest.MockedFunction<
+  typeof usePatientUUID
+>;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const PATIENT_UUID = 'patient-abc';
+const ENCOUNTER_UUID = 'encounter-123';
+
+const allForms: ObservationForm[] = [
+  { uuid: 'form-uuid-vitals', name: 'Vitals', id: 1, privileges: [] },
+  { uuid: 'form-uuid-history', name: 'History', id: 2, privileges: [] },
+  { uuid: 'form-uuid-notes', name: 'Progress Notes', id: 3, privileges: [] },
+];
+
+/** Build a FHIR Observation with a form-namespace-path extension. */
+function makeObservation(valueString: string): Observation {
+  return {
+    resourceType: 'Observation',
+    id: `obs-${valueString}`,
+    status: 'final',
+    code: { coding: [] },
+    extension: [
+      {
+        url: FHIR_OBSERVATION_FORM_NAMESPACE_PATH_URL,
+        valueString,
+      },
+    ],
+  };
+}
+
+/** Build an empty Bundle or a Bundle with the given observations. */
+function makeBundle(observations: Observation[]): Bundle<Observation> {
+  return {
+    resourceType: 'Bundle',
+    type: 'searchset',
+    entry: observations.map((obs) => ({ resource: obs })),
+  };
+}
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        staleTime: Infinity,
+        gcTime: Infinity,
+      },
+    },
+  });
+
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  Wrapper.displayName = 'QueryClientWrapper';
+  return Wrapper;
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useSubmittedEncounterForms', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Default: MATCHED encounter session
+    mockUseEncounterSessionStore.mockReturnValue({
+      activeEncounter: { id: ENCOUNTER_UUID },
+      matchReasons: ['MATCHED'],
+    } as unknown as ReturnType<typeof useEncounterSessionStore>);
+
+    mockUsePatientUUID.mockReturnValue(PATIENT_UUID);
+    mockUseSubscribeConsultationSaved.mockImplementation(() => {});
+  });
+
+  describe('bundle → uuid set mapping', () => {
+    it('returns a Set containing the uuid of a submitted form', async () => {
+      mockGetObservationsBundleByEncounterUuid.mockResolvedValue(
+        makeBundle([makeObservation('Vitals.1/10-0')]),
+      );
+
+      const { result } = renderHook(
+        () => useSubmittedEncounterForms(allForms),
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() =>
+        expect(mockGetObservationsBundleByEncounterUuid).toHaveBeenCalledWith(
+          ENCOUNTER_UUID,
+        ),
+      );
+
+      await waitFor(() => expect(result.current.size).toBe(1));
+      expect(result.current.has('form-uuid-vitals')).toBe(true);
+    });
+
+    it('handles namespace-prefixed valueString (Bahmni^Vitals.1/10-0)', async () => {
+      mockGetObservationsBundleByEncounterUuid.mockResolvedValue(
+        makeBundle([makeObservation('Bahmni^Vitals.1/10-0')]),
+      );
+
+      const { result } = renderHook(
+        () => useSubmittedEncounterForms(allForms),
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() => expect(result.current.size).toBe(1));
+      expect(result.current.has('form-uuid-vitals')).toBe(true);
+    });
+
+    it('returns uuids for multiple submitted forms', async () => {
+      mockGetObservationsBundleByEncounterUuid.mockResolvedValue(
+        makeBundle([
+          makeObservation('Vitals.1/1-0'),
+          makeObservation('History.2/3-0'),
+        ]),
+      );
+
+      const { result } = renderHook(
+        () => useSubmittedEncounterForms(allForms),
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() => expect(result.current.size).toBe(2));
+      expect(result.current.has('form-uuid-vitals')).toBe(true);
+      expect(result.current.has('form-uuid-history')).toBe(true);
+    });
+
+    it('ignores observations whose parsed form name does not match any allForms entry', async () => {
+      mockGetObservationsBundleByEncounterUuid.mockResolvedValue(
+        makeBundle([makeObservation('UnknownForm.1/1-0')]),
+      );
+
+      const { result } = renderHook(
+        () => useSubmittedEncounterForms(allForms),
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() =>
+        expect(mockGetObservationsBundleByEncounterUuid).toHaveBeenCalledTimes(
+          1,
+        ),
+      );
+
+      expect(result.current.size).toBe(0);
+    });
+
+    it('deduplicates: returns one uuid even when multiple obs reference the same form', async () => {
+      mockGetObservationsBundleByEncounterUuid.mockResolvedValue(
+        makeBundle([
+          makeObservation('Vitals.1/1-0'),
+          makeObservation('Vitals.1/2-0'),
+        ]),
+      );
+
+      const { result } = renderHook(
+        () => useSubmittedEncounterForms(allForms),
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() => expect(result.current.size).toBe(1));
+      expect(result.current.has('form-uuid-vitals')).toBe(true);
+    });
+  });
+
+  describe('no MATCHED session → empty set', () => {
+    it('returns empty set when matchReasons does not include MATCHED', () => {
+      mockUseEncounterSessionStore.mockReturnValue({
+        activeEncounter: { id: ENCOUNTER_UUID },
+        matchReasons: ['SESSION_EXPIRED'],
+      } as unknown as ReturnType<typeof useEncounterSessionStore>);
+
+      const { result } = renderHook(
+        () => useSubmittedEncounterForms(allForms),
+        { wrapper: createWrapper() },
+      );
+
+      // Query is disabled — fetch must NOT be called
+      expect(mockGetObservationsBundleByEncounterUuid).not.toHaveBeenCalled();
+      expect(result.current.size).toBe(0);
+    });
+
+    it('returns empty set when matchReasons is empty (new encounter)', () => {
+      mockUseEncounterSessionStore.mockReturnValue({
+        activeEncounter: null,
+        matchReasons: [],
+      } as unknown as ReturnType<typeof useEncounterSessionStore>);
+
+      const { result } = renderHook(
+        () => useSubmittedEncounterForms(allForms),
+        { wrapper: createWrapper() },
+      );
+
+      expect(mockGetObservationsBundleByEncounterUuid).not.toHaveBeenCalled();
+      expect(result.current.size).toBe(0);
+    });
+
+    it('returns empty set when patientUUID is null', () => {
+      mockUsePatientUUID.mockReturnValue(null);
+
+      const { result } = renderHook(
+        () => useSubmittedEncounterForms(allForms),
+        { wrapper: createWrapper() },
+      );
+
+      expect(mockGetObservationsBundleByEncounterUuid).not.toHaveBeenCalled();
+      expect(result.current.size).toBe(0);
+    });
+  });
+
+  describe('encounter duration completed (SESSION_EXPIRED) → no forms greyed', () => {
+    it('returns empty set even when the expired encounter has submitted observations', async () => {
+      mockUseEncounterSessionStore.mockReturnValue({
+        activeEncounter: { id: ENCOUNTER_UUID },
+        matchReasons: ['SESSION_EXPIRED'],
+      } as unknown as ReturnType<typeof useEncounterSessionStore>);
+
+      mockGetObservationsBundleByEncounterUuid.mockResolvedValue(
+        makeBundle([
+          makeObservation('Vitals.1/1-0'),
+          makeObservation('History.2/3-0'),
+        ]),
+      );
+
+      const { result } = renderHook(
+        () => useSubmittedEncounterForms(allForms),
+        { wrapper: createWrapper() },
+      );
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(mockGetObservationsBundleByEncounterUuid).not.toHaveBeenCalled();
+      expect(result.current.size).toBe(0);
+    });
+  });
+
+  describe('empty bundle → empty set', () => {
+    it('returns empty set when bundle has no entries', async () => {
+      mockGetObservationsBundleByEncounterUuid.mockResolvedValue(
+        makeBundle([]),
+      );
+
+      const { result } = renderHook(
+        () => useSubmittedEncounterForms(allForms),
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() =>
+        expect(mockGetObservationsBundleByEncounterUuid).toHaveBeenCalledTimes(
+          1,
+        ),
+      );
+
+      expect(result.current.size).toBe(0);
+    });
+
+    it('returns empty set when bundle entry has no resource', async () => {
+      mockGetObservationsBundleByEncounterUuid.mockResolvedValue({
+        resourceType: 'Bundle',
+        type: 'searchset',
+        entry: [{ fullUrl: 'http://example.com/obs/1' }], // no resource
+      } as Bundle<Observation>);
+
+      const { result } = renderHook(
+        () => useSubmittedEncounterForms(allForms),
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() =>
+        expect(mockGetObservationsBundleByEncounterUuid).toHaveBeenCalledTimes(
+          1,
+        ),
+      );
+
+      expect(result.current.size).toBe(0);
+    });
+  });
+
+  describe('namespace and version parsing', () => {
+    it.each([
+      ['Bahmni^Vitals.1/10-0', 'form-uuid-vitals'],
+      ['Vitals.1/1-0', 'form-uuid-vitals'],
+      ['History.2/3-0', 'form-uuid-history'],
+      ['Bahmni^History.3/1-0', 'form-uuid-history'],
+    ])('parses "%s" to form uuid %s', async (valueString, expectedUuid) => {
+      mockGetObservationsBundleByEncounterUuid.mockResolvedValue(
+        makeBundle([makeObservation(valueString)]),
+      );
+
+      const { result } = renderHook(
+        () => useSubmittedEncounterForms(allForms),
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() => expect(result.current.size).toBe(1));
+      expect(result.current.has(expectedUuid)).toBe(true);
+    });
+  });
+
+  describe('consultationSaved refetch', () => {
+    it('calls refetch when consultationSaved fires for the current patient', async () => {
+      mockGetObservationsBundleByEncounterUuid.mockResolvedValue(
+        makeBundle([]),
+      );
+
+      // Capture the callback registered with useSubscribeConsultationSaved
+      let capturedCallback: ((payload: any) => void) | null = null;
+      mockUseSubscribeConsultationSaved.mockImplementation((cb) => {
+        capturedCallback = cb;
+      });
+
+      const { result } = renderHook(
+        () => useSubmittedEncounterForms(allForms),
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() =>
+        expect(mockGetObservationsBundleByEncounterUuid).toHaveBeenCalledTimes(
+          1,
+        ),
+      );
+
+      // After first fetch, simulate a saved bundle with a Vitals form
+      mockGetObservationsBundleByEncounterUuid.mockResolvedValue(
+        makeBundle([makeObservation('Vitals.1/1-0')]),
+      );
+
+      // Fire the consultation-saved event for the current patient
+      act(() => {
+        capturedCallback!({
+          patientUUID: PATIENT_UUID,
+          updatedResources: {
+            conditions: false,
+            allergies: false,
+            medications: false,
+            serviceRequests: {},
+          },
+          updatedConcepts: new Map(),
+        });
+      });
+
+      await waitFor(() =>
+        expect(mockGetObservationsBundleByEncounterUuid).toHaveBeenCalledTimes(
+          2,
+        ),
+      );
+
+      await waitFor(() => expect(result.current.size).toBe(1));
+      expect(result.current.has('form-uuid-vitals')).toBe(true);
+    });
+
+    it('does NOT refetch when consultationSaved fires for a different patient', async () => {
+      mockGetObservationsBundleByEncounterUuid.mockResolvedValue(
+        makeBundle([]),
+      );
+
+      let capturedCallback: ((payload: any) => void) | null = null;
+      mockUseSubscribeConsultationSaved.mockImplementation((cb) => {
+        capturedCallback = cb;
+      });
+
+      renderHook(() => useSubmittedEncounterForms(allForms), {
+        wrapper: createWrapper(),
+      });
+
+      await waitFor(() =>
+        expect(mockGetObservationsBundleByEncounterUuid).toHaveBeenCalledTimes(
+          1,
+        ),
+      );
+
+      act(() => {
+        capturedCallback!({
+          patientUUID: 'different-patient',
+          updatedResources: {
+            conditions: false,
+            allergies: false,
+            medications: false,
+            serviceRequests: {},
+          },
+          updatedConcepts: new Map(),
+        });
+      });
+
+      // Should still be called only once (no refetch for different patient)
+      expect(mockGetObservationsBundleByEncounterUuid).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/apps/clinical/src/hooks/__tests__/useSubmittedEncounterForms.test.tsx
+++ b/apps/clinical/src/hooks/__tests__/useSubmittedEncounterForms.test.tsx
@@ -25,15 +25,24 @@ jest.mock('@bahmni/services', () => ({
 
 jest.mock('@bahmni/widgets', () => ({
   usePatientUUID: jest.fn(),
-  extractFormFieldPath: (observation?: {
+  extractFormName: (observation?: {
     extension?: { url: string; valueString?: string }[];
-  }) =>
-    observation?.extension?.find(
+  }) => {
+    const valueString = observation?.extension?.find(
       (ext) =>
         ext.url ===
         jest.requireActual('@bahmni/services')
           .FHIR_OBSERVATION_FORM_NAMESPACE_PATH_URL,
-    )?.valueString,
+    )?.valueString;
+    if (!valueString) return undefined;
+    const name = valueString
+      .split('/')[0]
+      .split('^')
+      .pop()
+      ?.replace(/\.\d+$/, '');
+    if (!name) return undefined;
+    return name;
+  },
 }));
 
 const mockGetObservationsBundleByEncounterUuid =
@@ -63,6 +72,7 @@ const allForms: ObservationForm[] = [
   { uuid: 'form-uuid-vitals', name: 'Vitals', id: 1, privileges: [] },
   { uuid: 'form-uuid-history', name: 'History', id: 2, privileges: [] },
   { uuid: 'form-uuid-notes', name: 'Progress Notes', id: 3, privileges: [] },
+  { uuid: 'form-uuid-covid', name: 'COVID.19', id: 4, privileges: [] },
 ];
 
 /** Build a FHIR Observation with a form-namespace-path extension. */
@@ -360,9 +370,10 @@ describe('useSubmittedEncounterForms', () => {
     it.each([
       ['Bahmni^Vitals.1/10-0', 'form-uuid-vitals'],
       ['Vitals.1/1-0', 'form-uuid-vitals'],
-      ['Vitals.1.2/1-0', 'form-uuid-vitals'],
       ['History.2/3-0', 'form-uuid-history'],
       ['Bahmni^History.3/1-0', 'form-uuid-history'],
+      ['COVID.19.1/1-0', 'form-uuid-covid'],
+      ['Bahmni^COVID.19.2/1-0', 'form-uuid-covid'],
     ])('parses "%s" to form uuid %s', async (valueString, expectedUuid) => {
       mockGetObservationsBundleByEncounterUuid.mockResolvedValue(
         makeBundle([makeObservation(valueString)]),

--- a/apps/clinical/src/hooks/__tests__/useSubmittedEncounterForms.test.tsx
+++ b/apps/clinical/src/hooks/__tests__/useSubmittedEncounterForms.test.tsx
@@ -25,6 +25,15 @@ jest.mock('@bahmni/services', () => ({
 
 jest.mock('@bahmni/widgets', () => ({
   usePatientUUID: jest.fn(),
+  extractFormFieldPath: (observation?: {
+    extension?: { url: string; valueString?: string }[];
+  }) =>
+    observation?.extension?.find(
+      (ext) =>
+        ext.url ===
+        jest.requireActual('@bahmni/services')
+          .FHIR_OBSERVATION_FORM_NAMESPACE_PATH_URL,
+    )?.valueString,
 }));
 
 const mockGetObservationsBundleByEncounterUuid =
@@ -322,10 +331,36 @@ describe('useSubmittedEncounterForms', () => {
     });
   });
 
+  describe('fetch error → fail-open (empty set)', () => {
+    it('returns an empty set and does not throw when the fetch rejects', async () => {
+      const consoleerrorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      mockGetObservationsBundleByEncounterUuid.mockRejectedValue(
+        new Error('network error'),
+      );
+
+      const { result } = renderHook(
+        () => useSubmittedEncounterForms(allForms),
+        { wrapper: createWrapper() },
+      );
+
+      await waitFor(() =>
+        expect(mockGetObservationsBundleByEncounterUuid).toHaveBeenCalledTimes(
+          1,
+        ),
+      );
+
+      expect(result.current.size).toBe(0);
+      consoleerrorSpy.mockRestore();
+    });
+  });
+
   describe('namespace and version parsing', () => {
     it.each([
       ['Bahmni^Vitals.1/10-0', 'form-uuid-vitals'],
       ['Vitals.1/1-0', 'form-uuid-vitals'],
+      ['Vitals.1.2/1-0', 'form-uuid-vitals'],
       ['History.2/3-0', 'form-uuid-history'],
       ['Bahmni^History.3/1-0', 'form-uuid-history'],
     ])('parses "%s" to form uuid %s', async (valueString, expectedUuid) => {

--- a/apps/clinical/src/hooks/useSubmittedEncounterForms.ts
+++ b/apps/clinical/src/hooks/useSubmittedEncounterForms.ts
@@ -4,20 +4,10 @@ import {
   useEncounterSessionStore,
   useSubscribeConsultationSaved,
 } from '@bahmni/services';
-import { usePatientUUID, extractFormFieldPath } from '@bahmni/widgets';
+import { usePatientUUID, extractFormName } from '@bahmni/widgets';
 import { useQuery } from '@tanstack/react-query';
 import type { Observation } from 'fhir/r4';
-import { useMemo } from 'react';
-
-function parseFormName(valueString: string | undefined): string | undefined {
-  if (!valueString) return undefined;
-  const beforeSlash = valueString.split('/')[0];
-  const name = beforeSlash
-    .split('^')
-    .pop()
-    ?.replace(/(\.\d+)+$/, '');
-  return name ?? undefined;
-}
+import { useEffect, useMemo } from 'react';
 
 /**
  * Returns the set of form UUIDs that have already been submitted in the active encounter.
@@ -47,10 +37,12 @@ export function useSubmittedEncounterForms(
     queryFn: () => getObservationsBundleByEncounterUuid(activeEncounterUuid!),
   });
 
-  if (error) {
-    // eslint-disable-next-line no-console
-    console.error('Failed to fetch submitted encounter forms', error);
-  }
+  useEffect(() => {
+    if (error) {
+      // eslint-disable-next-line no-console
+      console.error('Failed to fetch submitted encounter forms', error);
+    }
+  }, [error]);
 
   useSubscribeConsultationSaved(
     (payload) => {
@@ -71,8 +63,7 @@ export function useSubmittedEncounterForms(
     const submittedUuids = new Set<string>();
 
     for (const obs of observations) {
-      const valueString = extractFormFieldPath(obs);
-      const formName = parseFormName(valueString);
+      const formName = extractFormName(obs);
       if (!formName) continue;
 
       const matched = allForms.find((f) => f.name === formName);

--- a/apps/clinical/src/hooks/useSubmittedEncounterForms.ts
+++ b/apps/clinical/src/hooks/useSubmittedEncounterForms.ts
@@ -1,0 +1,103 @@
+import {
+  FHIR_OBSERVATION_FORM_NAMESPACE_PATH_URL,
+  ObservationForm,
+  getObservationsBundleByEncounterUuid,
+  useEncounterSessionStore,
+  useSubscribeConsultationSaved,
+} from '@bahmni/services';
+import { usePatientUUID } from '@bahmni/widgets';
+import { useQuery } from '@tanstack/react-query';
+import type { Observation } from 'fhir/r4';
+import { useMemo } from 'react';
+
+/**
+ * Parse the form name from an observation's form-namespace-path valueString.
+ *
+ * The valueString format is either:
+ *   - `{namespace}^{formName}.{version}/{fieldPath}`  e.g. `Bahmni^Vitals.1/10-0`
+ *   - `{formName}.{version}/{fieldPath}`              e.g. `Vitals.1/1-0`
+ *
+ * Returns the bare form name (e.g. `Vitals`), or undefined if the value is absent/malformed.
+ */
+function parseFormName(valueString: string | undefined): string | undefined {
+  if (!valueString) return undefined;
+  const beforeSlash = valueString.split('/')[0];
+  // Strip optional `{namespace}^` prefix, then strip trailing `.{version}`
+  const name = beforeSlash
+    .split('^')
+    .pop()
+    ?.replace(/\.\d+$/, '');
+  return name ?? undefined;
+}
+
+/**
+ * Extract the form-namespace-path valueString from a FHIR Observation extension.
+ * Uses the canonical URL constant from @bahmni/services to avoid hardcoding.
+ * This inlines the same logic as `extractFormFieldPath` from @bahmni/widgets/src/forms/utils
+ * to avoid a cross-package deep import.
+ */
+function getFormNamespacePath(obs: Observation): string | undefined {
+  return obs.extension?.find(
+    (ext) => ext.url === FHIR_OBSERVATION_FORM_NAMESPACE_PATH_URL,
+  )?.valueString;
+}
+
+/**
+ * Returns the set of form UUIDs that have already been submitted in the active encounter.
+ *
+ * - Returns an empty set when there is no MATCHED encounter session (new encounter → all forms selectable).
+ * - Automatically refetches after any consultation save for the current patient (handles the
+ *   "Continue Consultation" multi-bundle flow).
+ *
+ * Mirrors the pattern in InvestigationsForm.tsx lines 43-92.
+ */
+export function useSubmittedEncounterForms(
+  allForms: ObservationForm[],
+): Set<string> {
+  const patientUUID = usePatientUUID();
+  const { activeEncounter, matchReasons } = useEncounterSessionStore();
+
+  // Only consider an encounter if the session is actively MATCHED
+  const activeEncounterUuid = matchReasons.includes('MATCHED')
+    ? activeEncounter?.id
+    : undefined;
+
+  const { data: bundle, refetch } = useQuery({
+    queryKey: ['submittedEncounterForms', activeEncounterUuid],
+    enabled: !!activeEncounterUuid && !!patientUUID,
+    staleTime: 30_000,
+    queryFn: () => getObservationsBundleByEncounterUuid(activeEncounterUuid!),
+  });
+
+  useSubscribeConsultationSaved(
+    (payload) => {
+      if (payload.patientUUID === patientUUID) {
+        refetch();
+      }
+    },
+    [patientUUID, refetch],
+  );
+
+  return useMemo(() => {
+    const observations: Observation[] =
+      bundle?.entry
+        ?.map((e) => e.resource)
+        .filter((r): r is Observation => r?.resourceType === 'Observation') ??
+      [];
+
+    const submittedUuids = new Set<string>();
+
+    for (const obs of observations) {
+      const valueString = getFormNamespacePath(obs);
+      const formName = parseFormName(valueString);
+      if (!formName) continue;
+
+      const matched = allForms.find((f) => f.name === formName);
+      if (matched) {
+        submittedUuids.add(matched.uuid);
+      }
+    }
+
+    return submittedUuids;
+  }, [bundle, allForms]);
+}

--- a/apps/clinical/src/hooks/useSubmittedEncounterForms.ts
+++ b/apps/clinical/src/hooks/useSubmittedEncounterForms.ts
@@ -1,45 +1,22 @@
 import {
-  FHIR_OBSERVATION_FORM_NAMESPACE_PATH_URL,
   ObservationForm,
   getObservationsBundleByEncounterUuid,
   useEncounterSessionStore,
   useSubscribeConsultationSaved,
 } from '@bahmni/services';
-import { usePatientUUID } from '@bahmni/widgets';
+import { usePatientUUID, extractFormFieldPath } from '@bahmni/widgets';
 import { useQuery } from '@tanstack/react-query';
 import type { Observation } from 'fhir/r4';
 import { useMemo } from 'react';
 
-/**
- * Parse the form name from an observation's form-namespace-path valueString.
- *
- * The valueString format is either:
- *   - `{namespace}^{formName}.{version}/{fieldPath}`  e.g. `Bahmni^Vitals.1/10-0`
- *   - `{formName}.{version}/{fieldPath}`              e.g. `Vitals.1/1-0`
- *
- * Returns the bare form name (e.g. `Vitals`), or undefined if the value is absent/malformed.
- */
 function parseFormName(valueString: string | undefined): string | undefined {
   if (!valueString) return undefined;
   const beforeSlash = valueString.split('/')[0];
-  // Strip optional `{namespace}^` prefix, then strip trailing `.{version}`
   const name = beforeSlash
     .split('^')
     .pop()
-    ?.replace(/\.\d+$/, '');
+    ?.replace(/(\.\d+)+$/, '');
   return name ?? undefined;
-}
-
-/**
- * Extract the form-namespace-path valueString from a FHIR Observation extension.
- * Uses the canonical URL constant from @bahmni/services to avoid hardcoding.
- * This inlines the same logic as `extractFormFieldPath` from @bahmni/widgets/src/forms/utils
- * to avoid a cross-package deep import.
- */
-function getFormNamespacePath(obs: Observation): string | undefined {
-  return obs.extension?.find(
-    (ext) => ext.url === FHIR_OBSERVATION_FORM_NAMESPACE_PATH_URL,
-  )?.valueString;
 }
 
 /**
@@ -48,8 +25,6 @@ function getFormNamespacePath(obs: Observation): string | undefined {
  * - Returns an empty set when there is no MATCHED encounter session (new encounter → all forms selectable).
  * - Automatically refetches after any consultation save for the current patient (handles the
  *   "Continue Consultation" multi-bundle flow).
- *
- * Mirrors the pattern in InvestigationsForm.tsx lines 43-92.
  */
 export function useSubmittedEncounterForms(
   allForms: ObservationForm[],
@@ -57,17 +32,25 @@ export function useSubmittedEncounterForms(
   const patientUUID = usePatientUUID();
   const { activeEncounter, matchReasons } = useEncounterSessionStore();
 
-  // Only consider an encounter if the session is actively MATCHED
   const activeEncounterUuid = matchReasons.includes('MATCHED')
     ? activeEncounter?.id
     : undefined;
 
-  const { data: bundle, refetch } = useQuery({
-    queryKey: ['submittedEncounterForms', activeEncounterUuid],
+  const {
+    data: bundle,
+    refetch,
+    error,
+  } = useQuery({
+    queryKey: ['submittedEncounterForms', patientUUID, activeEncounterUuid],
     enabled: !!activeEncounterUuid && !!patientUUID,
     staleTime: 30_000,
     queryFn: () => getObservationsBundleByEncounterUuid(activeEncounterUuid!),
   });
+
+  if (error) {
+    // eslint-disable-next-line no-console
+    console.error('Failed to fetch submitted encounter forms', error);
+  }
 
   useSubscribeConsultationSaved(
     (payload) => {
@@ -75,7 +58,7 @@ export function useSubmittedEncounterForms(
         refetch();
       }
     },
-    [patientUUID, refetch],
+    [patientUUID],
   );
 
   return useMemo(() => {
@@ -88,7 +71,7 @@ export function useSubmittedEncounterForms(
     const submittedUuids = new Set<string>();
 
     for (const obs of observations) {
-      const valueString = getFormNamespacePath(obs);
+      const valueString = extractFormFieldPath(obs);
       const formName = parseFormName(valueString);
       if (!formName) continue;
 

--- a/packages/bahmni-widgets/src/forms/__tests__/utils.test.ts
+++ b/packages/bahmni-widgets/src/forms/__tests__/utils.test.ts
@@ -1,6 +1,6 @@
 import { FHIR_OBSERVATION_FORM_NAMESPACE_PATH_URL } from '@bahmni/services';
 import { Observation } from 'fhir/r4';
-import { extractFormFieldPath } from '../utils';
+import { extractFormFieldPath, extractFormName } from '../utils';
 
 const makeObservation = (
   id: string,
@@ -55,6 +55,33 @@ describe('forms/utils', () => {
 
     it('should return undefined for undefined observation', () => {
       expect(extractFormFieldPath(undefined)).toBeUndefined();
+    });
+  });
+
+  describe('extractFormName', () => {
+    const withPath = (valueString: string): Observation =>
+      makeObservation('obs-1', 'x', {
+        extension: [
+          { url: FHIR_OBSERVATION_FORM_NAMESPACE_PATH_URL, valueString },
+        ],
+      });
+
+    it.each([
+      ['Vitals.1/1-0', 'Vitals'],
+      ['Bahmni^Vitals.1/10-0', 'Vitals'],
+      ['History.2/3-0', 'History'],
+      ['COVID.19.1/1-0', 'COVID.19'],
+      ['Bahmni^COVID.19.2/1-0', 'COVID.19'],
+    ])('parses "%s" to form name "%s"', (valueString, expected) => {
+      expect(extractFormName(withPath(valueString))).toBe(expected);
+    });
+
+    it('returns undefined for undefined observation', () => {
+      expect(extractFormName(undefined)).toBeUndefined();
+    });
+
+    it('returns undefined when the form-namespace-path extension is absent', () => {
+      expect(extractFormName(makeObservation('obs-1', 'x'))).toBeUndefined();
     });
   });
 });

--- a/packages/bahmni-widgets/src/forms/utils.ts
+++ b/packages/bahmni-widgets/src/forms/utils.ts
@@ -17,3 +17,28 @@ export const extractFormFieldPath = (
 
   return formPathExt?.valueString;
 };
+
+/**
+ * Extract the form name from an observation's form-namespace-path extension.
+ *
+ * The path value is `{namespace}^{formName}.{version}/{fieldPath}`
+ * (e.g. `Bahmni^Vitals.1/10-0`) or `{formName}.{version}/{fieldPath}`
+ * (e.g. `Vitals.1/1-0`). Returns the bare form name (e.g. `Vitals`), stripping
+ * a single trailing `.{version}` segment (OpenMRS form versions are integers),
+ * or undefined if the value is absent/malformed.
+ */
+export const extractFormName = (
+  observation: Observation | undefined,
+): string | undefined => {
+  const valueString = extractFormFieldPath(observation);
+  if (!valueString) return undefined;
+
+  const name = valueString
+    .split('/')[0]
+    .split('^')
+    .pop()
+    ?.replace(/\.\d+$/, '');
+
+  if (!name) return undefined;
+  return name;
+};

--- a/packages/bahmni-widgets/src/index.ts
+++ b/packages/bahmni-widgets/src/index.ts
@@ -31,6 +31,7 @@ export { TaskList } from './tasks';
 export { PatientProgramsTable } from './patientPrograms';
 export { ImmunizationHistory } from './immunizationHistory';
 export { ProgramDetails } from './programDetails';
+export { extractFormFieldPath } from './forms/utils';
 
 export {
   CommandPaletteProvider,

--- a/packages/bahmni-widgets/src/index.ts
+++ b/packages/bahmni-widgets/src/index.ts
@@ -31,7 +31,7 @@ export { TaskList } from './tasks';
 export { PatientProgramsTable } from './patientPrograms';
 export { ImmunizationHistory } from './immunizationHistory';
 export { ProgramDetails } from './programDetails';
-export { extractFormFieldPath } from './forms/utils';
+export { extractFormName } from './forms/utils';
 
 export {
   CommandPaletteProvider,


### PR DESCRIPTION
**BAH-4828 | Disable Already-Submitted Observation Forms in ConsultationPad Form Selector**

**What & Why**

In the ConsultationPad form selector, an observation form already submitted in the current encounter was still selectable — a clinician could pick it again and create a duplicate submission.

This PR disables such forms in the search dropdown: they appear greyed out with an "(Already added)" label and can't be re-selected. A brand-new encounter (or an expired/mismatched session) shows all forms as selectable — no carry-over.

**How It Works**

1. New hook useSubmittedEncounterForms(allForms) reads the active encounter from useEncounterSessionStore(), gated on matchReasons.includes('MATCHED') — the same gate ConsultationPad uses to decide encounterForSubmission.
2. It fetches that encounter's observations (getObservationsBundleByEncounterUuid), reads each observation's form-namespace-path extension, and resolves the form name via the shared extractFormName util → maps to the loaded forms' UUIDs → returns a memoized Set<string>.
3. It refetches on consultationSaved (for the current patient) so newly-submitted forms disable correctly in the "Continue Consultation" multi-bundle flow.
4. ObservationFormsPanel passes submittedFormUuids into ObservationForms, which disables + relabels matching ComboBox items.

▎ Mirrors the existing Investigations/Orders selector pattern (InvestigationsForm.tsx) — a proven approach, not a new one.

**Changes**

- apps/clinical/src/hooks/useSubmittedEncounterForms.ts — New. Derives the set of submitted form UUIDs for the active encounter.
- apps/clinical/src/hooks/__tests__/useSubmittedEncounterForms.test.tsx — New. Unit tests (fetch-gating, mapping, dedup, fail-open, refetch).
- apps/clinical/src/components/forms/observations/ObservationFormsPanel.tsx — Calls the hook, passes submittedFormUuids down.
- apps/clinical/src/components/forms/observations/ObservationForms.tsx — New optional submittedFormUuids prop; a form is disabled when already selected or already submitted.
- apps/clinical/src/components/forms/observations/__tests__/* — Updated selector + panel tests.
- packages/bahmni-widgets/src/forms/utils.ts — New extractFormName(observation) util (wraps extractFormFieldPath, parses the form name).
- packages/bahmni-widgets/src/forms/__tests__/utils.test.ts — Tests for extractFormName.
- packages/bahmni-widgets/src/index.ts — Export extractFormName.

**Out of Scope**

- Edit flow for submitted forms (separate story per the ticket).
- Pinned/default form cards — only the search dropdown is affected.
- No changes to the store, ConsultationPad, or design system; reuses the existing OBSERVATION_FORMS_FORM_ALREADY_ADDED i18n key.

**Acceptance Criteria**

- [x] Submitted form appears disabled/greyed and cannot be selected
- [x] Only submitted forms disabled; unsubmitted remain selectable
- [x] Multiple submitted forms all disabled
- [x] Feedback: (Already added) label, matching Orders & Procedures
- [x] New encounter / expired session → all forms selectable (no carry-over)


Review Follow-ups Addressed

- Shared parsing util: co-located form-name parsing into @bahmni/widgets as extractFormName (removes duplication with extractFormFieldPath).
- Version parsing: single-segment strip (/\.\d+$/) so dotted form names aren't over-stripped.
- Error handling: useQuery error is surfaced via console.error in a useEffect.
- Minor: stable EMPTY_SET default, patient-scoped query key, trimmed useSubscribeConsultationSaved deps.

Reviewer Notes

- Fail-open by design: if the observations fetch fails, no forms are disabled (degrades to prior behaviour) rather than blocking form entry — disabling is a convenience guard, not a hard gate.
- MATCHED-only gate is intentional: it mirrors ConsultationPad's encounterForSubmission. Under LOCATION_MISMATCH/PROVIDER_MISMATCH the pad creates a new encounter, so those forms should stay selectable.




**Screenshots:** 

<img width="3456" height="1920" alt="image" src="https://github.com/user-attachments/assets/698b369a-be04-4a42-bf39-22a1f38f8403" />

<img width="3446" height="1834" alt="image" src="https://github.com/user-attachments/assets/a4983f77-04c5-438a-9411-532332a10e06" />

<img width="3446" height="1914" alt="image" src="https://github.com/user-attachments/assets/4c2e72cd-13f5-457f-bcd9-4a76feb031c5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Observation form picker now detects forms already submitted in the current active matched encounter and marks them unavailable.
  * Added support for extracting form names from observation namespace information to power this behavior.
* **Bug Fixes**
  * Disabled submitted forms can’t be selected/added, and the UI updates when saved-consultation events occur.
* **Tests**
  * Expanded unit/integration coverage for the picker/panel behavior, the submitted-forms hook, and new form-name extraction logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->