### PR TITLE
BAH-4831 | task actions fixes, fix for encounter resource start period

### DIFF
--- a/apps/clinical/src/components/consultationPad/services.ts
+++ b/apps/clinical/src/components/consultationPad/services.ts
@@ -44,7 +44,7 @@ export async function submitConsultation(
     activeVisit!.id,
     deps.episodeOfCareUuids,
     selectedLocation!.uuid,
-    consultationDate,
+    deps.activeEncounter?.period?.start ?? null,
   );
 
   const encounterBundleEntry = createEncounterBundleEntry(

--- a/apps/clinical/src/components/consultationPad/services.ts
+++ b/apps/clinical/src/components/consultationPad/services.ts
@@ -32,7 +32,6 @@ export async function submitConsultation(
     encounterParticipants,
     activeVisit,
     selectedLocation,
-    consultationDate,
     practitioner,
   } = useEncounterDetailsStore.getState();
 
@@ -63,7 +62,7 @@ export async function submitConsultation(
     encounterSubject: encounterResource.subject!,
     encounterReference,
     practitionerUUID: practitioner!.uuid,
-    consultationDate,
+    consultationDate: new Date(),
     statDurationInMilliseconds: deps.statDurationInMilliseconds,
   };
 

--- a/apps/clinical/src/components/forms/encounterDetails/EncounterDetails.tsx
+++ b/apps/clinical/src/components/forms/encounterDetails/EncounterDetails.tsx
@@ -327,13 +327,16 @@ const EncounterDetails: React.FC = () => {
       </Column>
 
       <Column sm={4} md={8} lg={5} className={styles.column}>
-        <DatePicker datePickerType="single" data-testid="encounter-date-picker">
+        <DatePicker
+          datePickerType="single"
+          data-testid="encounter-date-picker"
+          value={formattedDate.formattedResult}
+        >
           <DatePickerInput
             id="encounter-date-picker-input"
             data-testid="encounter-date-picker-input"
             title={t('ENCOUNTER_DATE')}
             labelText={t('ENCOUNTER_DATE')}
-            defaultValue={formattedDate.formattedResult}
             disabled
           />
         </DatePicker>

--- a/apps/clinical/src/components/forms/observations/ObservationFormsPanel.tsx
+++ b/apps/clinical/src/components/forms/observations/ObservationFormsPanel.tsx
@@ -52,27 +52,19 @@ const ObservationFormsPanel: React.FC<ObservationFormsPanelProps> = ({
   const directFormMode = encounterSessionStartContext?.directFormMode as
     | boolean
     | undefined;
+
   useEffect(() => {
     if (taskFormName && directFormMode && !isAllFormsLoading) {
+      useObservationFormsStore.getState().reset();
       const matchingForm = allForms.find(
         (form) => form.name.toLowerCase() === taskFormName.toLowerCase(),
       );
 
-      if (
-        matchingForm &&
-        !selectedForms.some((f) => f.uuid === matchingForm.uuid)
-      ) {
+      if (matchingForm) {
         addForm(matchingForm);
       }
     }
-  }, [
-    taskFormName,
-    directFormMode,
-    allForms,
-    isAllFormsLoading,
-    selectedForms,
-    addForm,
-  ]);
+  }, [taskFormName, directFormMode, allForms, isAllFormsLoading, addForm]);
 
   const handleFormSelect = (form: ObservationForm) => {
     addForm(form);

--- a/apps/clinical/src/components/forms/observations/__tests__/ObservationFormsPanel.test.tsx
+++ b/apps/clinical/src/components/forms/observations/__tests__/ObservationFormsPanel.test.tsx
@@ -181,4 +181,101 @@ describe('ObservationFormsPanel', () => {
     const { container } = render(<ObservationFormsPanel />);
     expect(await axe(container)).toHaveNoViolations();
   });
+
+  describe('DirectMode Form Handling', () => {
+    const mockReset = jest.fn();
+
+    beforeEach(() => {
+      (
+        useObservationFormsStore as unknown as { getState: jest.Mock }
+      ).getState = jest.fn(() => ({
+        reset: mockReset,
+      }));
+    });
+
+    it('should reset store and add matching form when directFormMode is true and taskFormName is provided', () => {
+      const encounterContext = {
+        taskFormName: 'Vitals',
+        directFormMode: true,
+      };
+
+      render(
+        <ObservationFormsPanel
+          encounterSessionStartContext={encounterContext}
+        />,
+      );
+
+      expect(mockReset).toHaveBeenCalledTimes(1);
+      expect(mockAddForm).toHaveBeenCalledWith(mockForm1);
+    });
+
+    it('should not reset store when directFormMode is false', () => {
+      const encounterContext = {
+        taskFormName: 'Vitals',
+        directFormMode: false,
+      };
+
+      render(
+        <ObservationFormsPanel
+          encounterSessionStartContext={encounterContext}
+        />,
+      );
+
+      expect(mockReset).not.toHaveBeenCalled();
+      expect(mockAddForm).not.toHaveBeenCalled();
+    });
+
+    it('should not reset store when taskFormName is not provided', () => {
+      const encounterContext = {
+        directFormMode: true,
+      };
+
+      render(
+        <ObservationFormsPanel
+          encounterSessionStartContext={encounterContext}
+        />,
+      );
+
+      expect(mockReset).not.toHaveBeenCalled();
+      expect(mockAddForm).not.toHaveBeenCalled();
+    });
+
+    it('should not add form when matching form is not found', () => {
+      const encounterContext = {
+        taskFormName: 'Non-existent Form',
+        directFormMode: true,
+      };
+
+      render(
+        <ObservationFormsPanel
+          encounterSessionStartContext={encounterContext}
+        />,
+      );
+
+      expect(mockReset).toHaveBeenCalledTimes(1);
+      expect(mockAddForm).not.toHaveBeenCalled();
+    });
+
+    it('should not reset store when forms are still loading', () => {
+      jest.mocked(useObservationFormsSearch).mockReturnValue({
+        forms: [mockForm1, mockForm2],
+        isLoading: true,
+        error: null,
+      });
+
+      const encounterContext = {
+        taskFormName: 'Vitals',
+        directFormMode: true,
+      };
+
+      render(
+        <ObservationFormsPanel
+          encounterSessionStartContext={encounterContext}
+        />,
+      );
+
+      expect(mockReset).not.toHaveBeenCalled();
+      expect(mockAddForm).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/apps/clinical/src/utils/fhir/__tests__/encounterResourceCreator.test.ts
+++ b/apps/clinical/src/utils/fhir/__tests__/encounterResourceCreator.test.ts
@@ -9,7 +9,6 @@ import {
   createPatientReference,
 } from '../referenceCreator';
 
-// Mock the imported functions
 jest.mock('../codeableConceptCreator', () => ({
   createCodeableConcept: jest.fn(),
   createCoding: jest.fn(),
@@ -27,7 +26,6 @@ describe('encounterResourceCreator utility functions', () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
-    // Setup mock return values
     (createCoding as jest.Mock).mockReturnValue({ code: 'mock-code' });
     (createCodeableConcept as jest.Mock).mockReturnValue({
       coding: [{ code: 'mock-code' }],
@@ -58,7 +56,6 @@ describe('encounterResourceCreator utility functions', () => {
       const visitUUID = 'visit-uuid';
       const episodeOfCareUUID = ['episode-uuid'];
       const encounterLocationUUID = 'location-uuid';
-      const encounterStartTimestamp = new Date('2023-01-01T12:00:00Z');
 
       const result = createEncounterResource(
         encounterTypeUUID,
@@ -68,7 +65,6 @@ describe('encounterResourceCreator utility functions', () => {
         visitUUID,
         episodeOfCareUUID,
         encounterLocationUUID,
-        encounterStartTimestamp,
       );
 
       expect(result).toEqual({
@@ -97,12 +93,11 @@ describe('encounterResourceCreator utility functions', () => {
         partOf: { reference: 'Encounter/mock-visit' },
         location: [{ location: { reference: 'Location/mock' } }],
         period: {
-          start: encounterStartTimestamp.toISOString(),
+          start: undefined,
         },
         episodeOfCare: [{ reference: 'EpisodeOfCare/mock' }],
       });
 
-      // Verify mock calls
       expect(createCoding).toHaveBeenCalledWith(
         encounterTypeUUID,
         FHIR_ENCOUNTER_TYPE_CODE_SYSTEM,
@@ -134,7 +129,6 @@ describe('encounterResourceCreator utility functions', () => {
       const visitUUID = 'visit-uuid';
       const episodeOfCareUUID = ['episode-uuid'];
       const encounterLocationUUID = 'location-uuid';
-      const encounterStartTimestamp = new Date('2023-01-01T12:00:00Z');
 
       const result = createEncounterResource(
         encounterTypeUUID,
@@ -144,11 +138,58 @@ describe('encounterResourceCreator utility functions', () => {
         visitUUID,
         episodeOfCareUUID,
         encounterLocationUUID,
-        encounterStartTimestamp,
       );
 
       expect(result.participant).toEqual([]);
       expect(createEncounterParticipantReference).not.toHaveBeenCalled();
+    });
+
+    it('should use existing period start when provided (PUT request)', () => {
+      const encounterTypeUUID = 'encounter-type-uuid';
+      const encounterTypeDisplayText = 'Consultation';
+      const patientUUID = 'patient-uuid';
+      const participantUUIDs = ['practitioner-uuid-1'];
+      const visitUUID = 'visit-uuid';
+      const episodeOfCareUUID = ['episode-uuid'];
+      const encounterLocationUUID = 'location-uuid';
+      const existingPeriodStart = '2023-01-01T10:00:00.000Z';
+
+      const result = createEncounterResource(
+        encounterTypeUUID,
+        encounterTypeDisplayText,
+        patientUUID,
+        participantUUIDs,
+        visitUUID,
+        episodeOfCareUUID,
+        encounterLocationUUID,
+        existingPeriodStart,
+      );
+
+      expect(result.period?.start).toEqual(existingPeriodStart);
+    });
+
+    it('should use undefined for period start when null is passed (POST request - backend handles)', () => {
+      const encounterTypeUUID = 'encounter-type-uuid';
+      const encounterTypeDisplayText = 'Consultation';
+      const patientUUID = 'patient-uuid';
+      const participantUUIDs = ['practitioner-uuid-1'];
+      const visitUUID = 'visit-uuid';
+      const episodeOfCareUUID = ['episode-uuid'];
+      const encounterLocationUUID = 'location-uuid';
+      const existingPeriodStart = null;
+
+      const result = createEncounterResource(
+        encounterTypeUUID,
+        encounterTypeDisplayText,
+        patientUUID,
+        participantUUIDs,
+        visitUUID,
+        episodeOfCareUUID,
+        encounterLocationUUID,
+        existingPeriodStart,
+      );
+
+      expect(result.period?.start).toBeUndefined();
     });
   });
 });

--- a/apps/clinical/src/utils/fhir/encounterResourceCreator.ts
+++ b/apps/clinical/src/utils/fhir/encounterResourceCreator.ts
@@ -17,7 +17,7 @@ export const createEncounterResource = (
   visitUUID: string,
   episodeOfCareUUID: string[],
   encounterLocationUUID: string,
-  encounterStartTimestamp: Date,
+  existingEncounterStartTime?: string | null,
 ): Encounter => {
   return {
     resourceType: 'Encounter',
@@ -52,7 +52,7 @@ export const createEncounterResource = (
     partOf: createEncounterReference(visitUUID),
     location: [createEncounterLocationReference(encounterLocationUUID)],
     period: {
-      start: encounterStartTimestamp.toISOString(),
+      start: (existingEncounterStartTime ?? undefined) as string,
     },
     //TODO : link correct episode of care uuid to the current encounter
     episodeOfCare: episodeOfCareUUID.map((uuid) =>

--- a/packages/bahmni-widgets/src/tasks/components/TaskActions.tsx
+++ b/packages/bahmni-widgets/src/tasks/components/TaskActions.tsx
@@ -3,6 +3,7 @@ import {
   fetchObservationForms,
   hasPrivilege,
   type ObservationForm,
+  useTranslation,
 } from '@bahmni/services';
 import { useQuery } from '@tanstack/react-query';
 import React, { useMemo } from 'react';
@@ -25,6 +26,7 @@ const TaskActions: React.FC<TaskActionsProps> = ({
   episodeOfCareUuids,
 }) => {
   const { userPrivileges } = useUserPrivilege();
+  const { t } = useTranslation();
 
   const shouldFetchForms = hasLaunchFormActions(actionConfig, task.code);
 
@@ -64,7 +66,7 @@ const TaskActions: React.FC<TaskActionsProps> = ({
 
   return (
     <IconButton
-      label={action.label}
+      label={t(action.label)}
       kind="ghost"
       size="sm"
       onClick={() => handleTaskAction(action, task)}


### PR DESCRIPTION
> [!NOTE]
> Thank you for your contribution. Please find the details of this pull request below.

**JIRA** → [BAH-#](https://bahmni.atlassian.net/browse/BAH-4831)

 ###Summary
  This PR fixes multiple date/time handling issues and form state management problems related to encounter creation
  and updates in the clinical consultation workflow.

  Key fixes:
  - Encounter timestamp handling: Differentiates between POST (new encounters) and PUT (updating encounters)
  requests. For new encounters, the backend now handles timestamp generation. For updates, the existing encounter
  period start time is preserved.
  - Consultation date accuracy: Uses the current date (new Date()) for observations instead of the store-initialized
   consultation date which was lagging by several minutes.
  - Form state cleanup: Resets the observation forms store when opening a new form from the left panel to prevent
  stale state and error toasts.
  - Encounter details form: Fixed date picker to use value prop instead of deprecated defaultValue for proper
  controlled component behavior.
  - Task actions translation: Added missing translation wrapper for action labels.

  Changes

  Core Fixes

  1. Encounter Resource Creation (apps/clinical/src/utils/fhir/encounterResourceCreator.ts)
    - Changed encounterStartTimestamp: Date parameter to existingEncounterStartTime?: string | null
    - POST requests (null): period.start is undefined, allowing backend to set timestamp
    - PUT requests (existing timestamp): period.start preserves the original encounter start time
  2. Consultation Submission (apps/clinical/src/components/consultationPad/services.ts)
    - Removed consultationDate from store state usage
    - For encounter creation: passes deps.activeEncounter?.period?.start ?? null (preserves existing or lets backend
   handle)
    - For observations: uses new Date() for accurate current timestamp instead of stale store date
  3. Form Store Cleanup (apps/clinical/src/components/forms/observations/ObservationFormsPanel.tsx)
    - Added useObservationFormsStore.getState().reset() before adding task-related forms
    - Removed redundant check for duplicate forms in selectedForms
    - Cleaned up useEffect dependencies
  4. UI Improvements
    - Fixed date picker in EncounterDetails to use value prop for controlled component behavior
    - Added translation support for task action labels


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Task action buttons now display localized labels.
* **Bug Fixes**
  * Encounter dates are now saved with improved accuracy when creating or updating encounters.
  * The encounter date field now behaves as a fully controlled input for more reliable edits.
  * Direct form selection now properly resets before choosing a matching form, preventing stale form state.
* **Tests**
  * Updated encounter resource creation coverage for start-date behavior in create vs update scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->