### PR TITLE
docs: expand README guide index

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,13 @@ For a comprehensive setup guide including development environments, Docker confi
 - [Frontend Architecture](docs/architecture.md) - A comprehensive overview of the Bahmni Apps Frontend architecture
 - [Project Structure](docs/project-structure.md) - A high-level overview of the project structure
 - [i18n Guide](docs/i18n-guide.md) - Internationalization implementation details
+- [Command Palette Guide](docs/command-palette-guide.md) - Configuring command palette actions and navigation
+- [Data Table Guide](docs/data-table-guide.md) - Usage of the reusable data table component
 - [Sortable Data Table Guide](docs/sortable-data-table-guide.md) - Usage of the sortable data table component
 - [Global Notification Guide](docs/global-notification-guide.md) - Using the notification system
+- [Document Print Button Guide](docs/document-print-button-guide.md) - Printing documents from Bahmni apps
+- [Icon Guide](docs/bahmni-icon-guide.md) - Using Bahmni icon components
+- [Colour Token System](docs/bahmni-colour-token-system.md) - Design token usage for color styling
 
 ### Building for Production
 


### PR DESCRIPTION
> [!NOTE]
> Thank you for your contribution. Please find the details of this pull request below.

**JIRA** -> N/A (documentation index cleanup)

### **Description**
Adds missing documentation links to the README so contributors can discover existing guides from the project landing page.

---

### **Key Features**
- Documentation-only change; no user-facing runtime behavior changes.

---

### **Implementation Details**

* **UI Components**
  N/A

* **State Management**
  N/A

* **Custom Hooks**
  N/A

* **API Integration**
  N/A

* **Performance & Optimization**
  N/A

* **Internationalisation**
  N/A

* **Accessibility**
  N/A

* **Limitations**
  None known.

---

### **Testing & Type Definitions**

* **Unit Tests**
  Not run; documentation-only change.

* **Integration Tests**
  Not run; documentation-only change.

* **Type Definitions**
  N/A

Validation run:
- git diff --check
- verified each newly linked guide exists in docs/

---

### **Screenshots**
N/A

---

### **Next Steps**
N/A

---

> [!IMPORTANT]
> **Checklist**
>
> - [x] Code adheres to project linting and formatting standards for the touched files.
> - [ ] New components added to Storybook. N/A
> - [ ] Tests written and passing (unit + integration). N/A; documentation-only change.
> - [ ] Labels and text support i18n. N/A
> - [ ] Follows accessibility and responsive design guidelines. N/A
> - [ ] PR reviewed by at least one other developer.

---

### **Reviewer(s)**
@bahnew/developers