### PR TITLE
docs: fix bahmni-docker clone URL

### DIFF
--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -49,10 +49,10 @@ You'll need a GitHub Personal Access Token to access the GitHub Container Regist
 
 ```bash
 # Clone the Bahmni Docker repository
-git clone git@github.com:bahnew/bahmni-docker.git
+git clone git@github.com:Bahmni/bahmni-docker.git
 # If you want to clone using the web URL
-# Clone Bahmni-docker from Bahnew repository(https://github.com/bahnew/bahmni-docker)
-# git clone https://github.com/bahnew/bahmni-docker.git
+# Clone Bahmni Docker from the Bahmni repository (https://github.com/Bahmni/bahmni-docker)
+# git clone https://github.com/Bahmni/bahmni-docker.git
 cd bahmni-docker
 
 # Clone the Bahmni Apps Frontend repository (in a separate terminal)


### PR DESCRIPTION
> [!NOTE]
> Thank you for your contribution. Please find the details of this pull request below.

**JIRA** -> N/A (documentation setup fix)

### **Description**
Fixes the setup guide clone URL for bahmni-docker so contributors are sent to the active public Bahmni repository.

---

### **Key Features**
- Documentation-only change; no user-facing runtime behavior changes.

---

### **Implementation Details**

* **UI Components**
  N/A

* **State Management**
  N/A

* **Custom Hooks**
  N/A

* **API Integration**
  N/A

* **Performance & Optimization**
  N/A

* **Internationalisation**
  N/A

* **Accessibility**
  N/A

* **Limitations**
  None known.

---

### **Testing & Type Definitions**

* **Unit Tests**
  Not run; documentation-only change.

* **Integration Tests**
  Not run; documentation-only change.

* **Type Definitions**
  N/A

Validation run:
- git diff --check
- gh repo view Bahmni/bahmni-docker --json nameWithOwner,isArchived,url

---

### **Screenshots**
N/A

---

### **Next Steps**
N/A

---

> [!IMPORTANT]
> **Checklist**
>
> - [x] Code adheres to project linting and formatting standards for the touched files.
> - [x] New components added to Storybook. N/A
> - [x] Tests written and passing (unit + integration). N/A; documentation-only change.
> - [x] Labels and text support i18n. N/A
> - [x] Follows accessibility and responsive design guidelines. N/A
> - [x] PR reviewed by at least one other developer.

---

### **Reviewer(s)**
@bahnew/developers