### PR TITLE
docs: clarify development server URL

### DIFF
--- a/docs/setup-guide.md
+++ b/docs/setup-guide.md
@@ -159,7 +159,7 @@ This method provides a faster development experience with hot reloading:
    yarn nx serve distro
    ```
 
-   This will start the development server and automatically open your browser at [http://localhost:3000](http://localhost:3000).
+   This will start the development server at [http://localhost:3000](http://localhost:3000).
 
 2. **Set Up Authentication**:
 


### PR DESCRIPTION
> [!NOTE]
> Thank you for your contribution. Please find the details of this pull request below.

**JIRA** -> N/A (documentation setup clarification)

### **Description**
Clarifies that the local dev command starts the development server at localhost:3000 instead of promising that the browser opens automatically.

---

### **Key Features**
- Documentation-only change; no user-facing runtime behavior changes.

---

### **Implementation Details**

* **UI Components**
  N/A

* **State Management**
  N/A

* **Custom Hooks**
  N/A

* **API Integration**
  N/A

* **Performance & Optimization**
  N/A

* **Internationalisation**
  N/A

* **Accessibility**
  N/A

* **Limitations**
  None known.

---

### **Testing & Type Definitions**

* **Unit Tests**
  Not run; documentation-only change.

* **Integration Tests**
  Not run; documentation-only change.

* **Type Definitions**
  N/A

Validation run:
- git diff --check
- rg -n devServer|open:|localhost:3000 distro/webpack.config.js README.md docs/setup-guide.md

---

### **Screenshots**
N/A

---

### **Next Steps**
N/A

---

> [!IMPORTANT]
> **Checklist**
>
> - [x] Code adheres to project linting and formatting standards for the touched files.
> - [ ] New components added to Storybook. N/A
> - [ ] Tests written and passing (unit + integration). N/A; documentation-only change.
> - [ ] Labels and text support i18n. N/A
> - [ ] Follows accessibility and responsive design guidelines. N/A
> - [ ] PR reviewed by at least one other developer.

---

### **Reviewer(s)**
@bahnew/developers