### PR TITLE
BAH-4859 | Fix. Disable wheel events by default for NumberInput element

### DIFF
--- a/packages/bahmni-design-system/src/atoms/numberInput/__tests__/index.test.tsx
+++ b/packages/bahmni-design-system/src/atoms/numberInput/__tests__/index.test.tsx
@@ -1,0 +1,30 @@
+import { createEvent, fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { NumberInput } from '..';
+
+const defaultProps = {
+  id: 'test-number-input',
+  label: 'Quantity',
+};
+
+describe('NumberInput', () => {
+  describe('disableWheel', () => {
+    it('should prevent wheel events by default', () => {
+      render(<NumberInput {...defaultProps} />);
+      const input = screen.getByRole('spinbutton');
+      fireEvent.focus(input);
+      const wheelEvent = createEvent.wheel(input);
+      fireEvent(input, wheelEvent);
+      expect(wheelEvent.defaultPrevented).toBe(true);
+    });
+
+    it('should allow wheel events when disableWheel is false', () => {
+      render(<NumberInput {...defaultProps} disableWheel={false} />);
+      const input = screen.getByRole('spinbutton');
+      fireEvent.focus(input);
+      const wheelEvent = createEvent.wheel(input);
+      fireEvent(input, wheelEvent);
+      expect(wheelEvent.defaultPrevented).toBe(false);
+    });
+  });
+});

--- a/packages/bahmni-design-system/src/atoms/numberInput/index.tsx
+++ b/packages/bahmni-design-system/src/atoms/numberInput/index.tsx
@@ -12,9 +12,14 @@ export type NumberInputProps = CarbonNumberInputProps & {
 export const NumberInput: React.FC<NumberInputProps> = ({
   testId,
   'data-testid': dataTestId,
+  disableWheel = true,
   ...carbonProps
 }) => {
   return (
-    <CarbonNumberInput {...carbonProps} data-testid={testId ?? dataTestId} />
+    <CarbonNumberInput
+      {...carbonProps}
+      disableWheel={disableWheel}
+      data-testid={testId ?? dataTestId}
+    />
   );
 };


### PR DESCRIPTION

**JIRA** → [BAH-4859](https://bahmni.atlassian.net/browse/BAH-4859)

### **Description**

This PR disables the default wheel events on the Numeric Input Control design system atom to avoid values changing when the user scrolls on the parent component.


---

### **Implementation Details**

* **UI Components**
- The NumberInput component by default listens onto the scroll events which causes the values to change when the user scrolls on the screen.


> [!IMPORTANT]
> **Checklist**
>
> - [X] Code adheres to project linting and formatting standards.
> - [X] New components added to Storybook.
> - [X] Tests written and passing (unit + integration).
> - [X] Labels and text support i18n.
> - [X] Follows accessibility and responsive design guidelines.
> - [X] PR reviewed by at least one other developer.

---

### **Reviewer(s)**

@bahnew/developers 
_Kindly review the proposed changes when convenient. Your feedback is appreciated._

---


[BAH-4859]: https://bahmni.atlassian.net/browse/BAH-4859?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ