### PR TITLE
BAH-4870 | Fix. Broken Styles In DataTable

### DIFF
--- a/packages/bahmni-design-system/src/organisms/dataTable/styles/DataTable.module.scss
+++ b/packages/bahmni-design-system/src/organisms/dataTable/styles/DataTable.module.scss
@@ -13,7 +13,7 @@
     @include type-style("heading-compact-02");
   }
 
-  > div:first-of-type {
+  > div:first-child {
     flex: 1;
     align-content: center;
     border-bottom: none;
@@ -30,6 +30,10 @@
       min-height: auto;
       justify-content: flex-end;
     }
+  }
+
+  > section:first-child {
+    flex: 0 0 100%;
   }
 
   table {

--- a/packages/bahmni-widgets/src/search/commonSearch/__tests__/__snapshots__/ResultsTable.test.tsx.snap
+++ b/packages/bahmni-widgets/src/search/commonSearch/__tests__/__snapshots__/ResultsTable.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`ResultsTable Snapshot matches snapshot for empty state 1`] = `
 <div>
   <section
-    class="dataTable _dataTableBody_sw2cd_1 cds--data-table-container"
+    class="dataTable _dataTableBody_aje5l_1 cds--data-table-container"
     data-testid="common-search-results-table"
     id="common-search-results-table-data-table"
   >
@@ -60,7 +60,7 @@ exports[`ResultsTable Snapshot matches snapshot for empty state 1`] = `
         >
           <tr>
             <td
-              class="_emptyStateCell_sw2cd_78"
+              class="_emptyStateCell_aje5l_81"
               colspan="2"
             >
               COMMON_SEARCH_NO_RESULTS
@@ -76,7 +76,7 @@ exports[`ResultsTable Snapshot matches snapshot for empty state 1`] = `
 exports[`ResultsTable Snapshot matches snapshot for evaluation error state 1`] = `
 <div>
   <p
-    class="_statePlaceholder_sw2cd_67"
+    class="_statePlaceholder_aje5l_70"
     data-testid="common-search-results-table-error"
   >
     COMMON_SEARCH_EVALUATION_ERROR
@@ -87,7 +87,7 @@ exports[`ResultsTable Snapshot matches snapshot for evaluation error state 1`] =
 exports[`ResultsTable Snapshot matches snapshot with data 1`] = `
 <div>
   <section
-    class="dataTable _dataTableBody_sw2cd_1 cds--data-table-container"
+    class="dataTable _dataTableBody_aje5l_1 cds--data-table-container"
     data-testid="common-search-results-table"
     id="common-search-results-table-data-table"
   >
@@ -144,7 +144,7 @@ exports[`ResultsTable Snapshot matches snapshot with data 1`] = `
         >
           <tr>
             <td
-              class="_emptyStateCell_sw2cd_78"
+              class="_emptyStateCell_aje5l_81"
               colspan="2"
             >
               COMMON_SEARCH_NO_RESULTS


### PR DESCRIPTION
Fixing the broken style in DataTable.

## **Bug Fixes**
  * Improved data table layout behavior when content begins with different element types.
  * Ensured the first section within the table body spans the full available width.

<img width="1916" height="954" alt="Screenshot 2026-07-20 at 2 43 29 PM" src="https://github.com/user-attachments/assets/b0124cb5-6a13-4cd5-9cd8-19c0db9247fa" />
<img width="1916" height="954" alt="Screenshot 2026-07-20 at 2 42 06 PM" src="https://github.com/user-attachments/assets/e27fd0f9-4ab6-473b-af60-e64ed619ed4c" />
