### PR TITLE
Refactor. Mock formatDateTime to return a fixed date string for testi…

### DIFF
--- a/packages/bahmni-widgets/src/radiologyInvestigation/__tests__/RadiologyInvestigationTable.test.tsx
+++ b/packages/bahmni-widgets/src/radiologyInvestigation/__tests__/RadiologyInvestigationTable.test.tsx
@@ -21,15 +21,31 @@ import RadiologyInvestigationTable from '../RadiologyInvestigationTable';
 
 expect.extend(toHaveNoViolations);
 
-jest.mock('@bahmni/services', () => ({
-  ...jest.requireActual('@bahmni/services'),
-  useTranslation: jest.fn(),
-  getCategoryUuidFromOrderTypes: jest.fn(),
-  getPatientRadiologyInvestigationBundleWithImagingStudy: jest.fn(),
-  getDiagnosticReports: jest.fn(),
-  dispatchAuditEvent: jest.fn(),
-  useSubscribeConsultationSaved: jest.fn(),
-}));
+jest.mock('@bahmni/services', () => {
+  const actualServices = jest.requireActual('@bahmni/services');
+  return {
+    ...actualServices,
+    useTranslation: jest.fn(),
+    getCategoryUuidFromOrderTypes: jest.fn(),
+    getPatientRadiologyInvestigationBundleWithImagingStudy: jest.fn(),
+    getDiagnosticReports: jest.fn(),
+    dispatchAuditEvent: jest.fn(),
+    useSubscribeConsultationSaved: jest.fn(),
+    // Mock formatDateTime to return a fixed date string for testing to avoid local machine date-time format issue
+    formatDateTime: (
+      date: string | Date | number,
+      t?: (key: string, options?: { count?: number }) => string,
+      includeTime = false,
+      dateFormat?: string,
+    ) =>
+      actualServices.formatDateTime(
+        date,
+        t,
+        includeTime,
+        dateFormat ?? (includeTime ? 'MM/dd/yyyy h:mm a' : 'MM/dd/yyyy'),
+      ),
+  };
+});
 
 jest.mock('../../genericServiceRequest/utils', () => ({
   getStatusDotClassName: jest.fn().mockReturnValue(''),


### PR DESCRIPTION
Refactoring to avoid local machine date-time format issue

> [!NOTE]
> Thank you for your contribution. Please find the details of this pull request below.

### **Description**

Bahmni widget tests were failing on fresh pull because of date format mismatch. This adds a mock of formate Date function in the test file

> [!IMPORTANT]
> **Checklist**
>
> - [X] Code adheres to project linting and formatting standards.
> - [ ] New components added to Storybook.
> - [X] Tests written and passing (unit + integration).
> - [ ] Labels and text support i18n.
> - [ ] Follows accessibility and responsive design guidelines.
> - [ ] PR reviewed by at least one other developer.

---

### **Reviewer(s)**

@bahnew/developers 
_Kindly review the proposed changes when convenient. Your feedback is appreciated._

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved radiology investigation test coverage by standardizing date and time formatting in test scenarios.
  * Ensured displayed dates remain consistent whether or not time information is included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->