### PR TITLE
Form edit fix

### DIFF
--- a/apps/clinical/src/components/forms/observations/ObservationFormsContainer.tsx
+++ b/apps/clinical/src/components/forms/observations/ObservationFormsContainer.tsx
@@ -210,11 +210,13 @@ const ObservationFormsContainer: React.FC<ObservationFormsContainerProps> = ({
   // so the comparison correctly detects only genuine user changes.
   const hasFormChanges = React.useMemo(() => {
     if (!isEditMode) return true; // non-edit forms are always saveable
-    // Baseline not yet captured (init still settling) — wait for capture.
-    // Note: initSettledRef will be true once baseline is captured, even if empty.
     if (!initSettledRef.current) return false;
-    // If we have observations but baseline is empty, that's a change (new data added).
-    // If baseline has data, compare to detect changes.
+    if (observations.length === 0) return false;
+
+    // Baseline not yet captured (init still settling) — wait for capture.
+    if (baselineObservations.length > 0 && observations.length === 0)
+      return false;
+    // Compare current against baseline to detect changes.
     return detectFormChanges(observations, baselineObservations);
   }, [isEditMode, observations, baselineObservations]);
 

--- a/apps/clinical/src/components/forms/observations/ObservationFormsContainer.tsx
+++ b/apps/clinical/src/components/forms/observations/ObservationFormsContainer.tsx
@@ -210,9 +210,11 @@ const ObservationFormsContainer: React.FC<ObservationFormsContainerProps> = ({
   // so the comparison correctly detects only genuine user changes.
   const hasFormChanges = React.useMemo(() => {
     if (!isEditMode) return true; // non-edit forms are always saveable
-    // Baseline not yet captured (init still settling) or no user changes yet.
-    if (baselineObservations.length === 0 || observations.length === 0)
-      return false;
+    // Baseline not yet captured (init still settling) — wait for capture.
+    // Note: initSettledRef will be true once baseline is captured, even if empty.
+    if (!initSettledRef.current) return false;
+    // If we have observations but baseline is empty, that's a change (new data added).
+    // If baseline has data, compare to detect changes.
     return detectFormChanges(observations, baselineObservations);
   }, [isEditMode, observations, baselineObservations]);
 


### PR DESCRIPTION
> [!NOTE]
> Thank you for your contribution. Please find the details of this pull request below.

The Fix

  Changed the logic to:
  if (!initSettledRef.current) return false;  // Wait for init to settle
  if (observations.length === 0) return false;  // No current data yet
  if (baselineObservations.length > 0 && observations.length === 0) return false;  // Edit mode: wait for both to populate
  return detectFormChanges(observations, baselineObservations);  // Compare

  This now handles all three scenarios correctly:
  1. Task launch (new form): Baseline is [], once user adds data and observations.length > 0, detectFormChanges will detect the
   change
  2. Task edit (future): Will work same as regular edit
  3. Regular edit from FormsTable: Waits for both baseline and observations to be populated before comparing, preventing false
  positives