### PR TITLE
BAH-4911 | Fix. Broken Navigation In Registration

### DIFF
--- a/apps/registration/src/pages/patientSearchPage/index.tsx
+++ b/apps/registration/src/pages/patientSearchPage/index.tsx
@@ -25,6 +25,15 @@ const PatientSearchPage: React.FC = () => {
     });
   }, []);
 
+  const patientSearchConfig = registrationConfig?.patientSearch
+    ? {
+        ...registrationConfig.patientSearch,
+        patientDetailUrl:
+          registrationConfig.patientSearch.patientDetailUrl ??
+          '/registration/patient/{{patientUuid}}',
+      }
+    : undefined;
+
   const breadcrumbs = [
     {
       id: 'home',
@@ -59,7 +68,7 @@ const PatientSearchPage: React.FC = () => {
       main={
         <div className={styles.main}>
           <SearchPatient
-            patientSearch={registrationConfig?.patientSearch}
+            patientSearch={patientSearchConfig}
             buttonTitle={t('REGISTRATION_PATIENT_SEARCH_BUTTON_TITLE')}
             searchBarPlaceholder={t(
               'REGISTRATION_PATIENT_SEARCH_INPUT_PLACEHOLDER',

--- a/packages/bahmni-widgets/src/searchPatient/PatientSearchResults.tsx
+++ b/packages/bahmni-widgets/src/searchPatient/PatientSearchResults.tsx
@@ -1,5 +1,6 @@
 import {
   Button,
+  Link,
   SkeletonText,
   SortableDataTable,
   Stack,
@@ -31,6 +32,9 @@ const CELL_IDS = {
   GENDER: 'gender',
   ACTIONS: 'actions',
 } as const;
+
+const INTERNAL_PATH_PATTERN = /^\//;
+const EXTERNAL_OR_HASH_PATTERN = /^(https?:\/\/|#)/i;
 
 interface PatientSearchResultsProps {
   data: PatientSearchResultBundle | undefined;
@@ -119,11 +123,28 @@ const PatientSearchResults = ({
     if (!patientDetailUrl) {
       return <span>{identifier}</span>;
     }
-    const url = formatUrl(patientDetailUrl, { patientUuid: uuid }, true);
-    if (!/^(#|\/|https?:\/\/)/i.test(url.trim())) {
-      return <span>{identifier}</span>;
+    const url = formatUrl(patientDetailUrl, { patientUuid: uuid }, true).trim();
+
+    if (INTERNAL_PATH_PATTERN.test(url)) {
+      return (
+        <Link
+          href={url}
+          onClick={(e) => {
+            if (e.metaKey || e.ctrlKey || e.shiftKey || e.button !== 0) return;
+            e.preventDefault();
+            navigate(url);
+          }}
+        >
+          {identifier}
+        </Link>
+      );
     }
-    return <a href={url}>{identifier}</a>;
+
+    if (EXTERNAL_OR_HASH_PATTERN.test(url)) {
+      return <a href={url}>{identifier}</a>;
+    }
+
+    return <span>{identifier}</span>;
   };
 
   const renderAppointmentStatus = (uuid: string, status: string) => {

--- a/packages/bahmni-widgets/src/searchPatient/PatientSearchResults.tsx
+++ b/packages/bahmni-widgets/src/searchPatient/PatientSearchResults.tsx
@@ -130,7 +130,6 @@ const PatientSearchResults = ({
         <Link
           href={url}
           onClick={(e) => {
-            if (e.metaKey || e.ctrlKey || e.shiftKey || e.button !== 0) return;
             e.preventDefault();
             navigate(url);
           }}

--- a/packages/bahmni-widgets/src/searchPatient/SearchPatient.tsx
+++ b/packages/bahmni-widgets/src/searchPatient/SearchPatient.tsx
@@ -222,6 +222,12 @@ const SearchPatient = ({
 
   const selectedFieldType = getSelectedField()?.type ?? '';
 
+  const resultsFieldType = isAdvancedSearch ? selectedFieldType : '';
+  const resultsSearchFields =
+    resultsFieldType === 'appointment'
+      ? (patientSearch?.appointment ?? [])
+      : (patientSearch?.customAttributes ?? []);
+
   return (
     <div>
       <SearchPatientInput
@@ -248,8 +254,8 @@ const SearchPatient = ({
           isLoading={isLoading}
           isError={isError}
           isAdvancedSearch={isAdvancedSearch}
-          searchFields={isAdvancedSearch ? searchFields : []}
-          selectedFieldType={isAdvancedSearch ? selectedFieldType : ''}
+          searchFields={resultsSearchFields}
+          selectedFieldType={resultsFieldType}
           patientDetailUrl={patientSearch?.patientDetailUrl}
           setData={setPatientSearchData}
         />

--- a/packages/bahmni-widgets/src/searchPatient/__tests__/index.test.tsx
+++ b/packages/bahmni-widgets/src/searchPatient/__tests__/index.test.tsx
@@ -14,6 +14,7 @@ import {
   searchBarPlaceholder,
   validPatientSearchConfig,
   mockSearchPatientData,
+  mockPatient,
 } from '../__mocks__/mocks';
 import SearchPatient from '../SearchPatient';
 
@@ -26,9 +27,10 @@ jest.mock('@bahmni/services', () => ({
 }));
 jest.mock('../../notification');
 jest.mock('../../userPrivileges/useUserPrivilege');
+const mockNavigate = jest.fn();
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
-  useNavigate: jest.fn(() => jest.fn()),
+  useNavigate: () => mockNavigate,
 }));
 
 const mockAddNotification = jest.fn();
@@ -244,6 +246,71 @@ describe('SearchPatient', () => {
     await waitFor(() => {
       expect(container.querySelectorAll('a').length).toBeGreaterThan(0);
     });
+  });
+
+  it('should navigate via react-router (not a full page reload) when clicking an internal identifier link', async () => {
+    renderSearchPatient({
+      ...validPatientSearchConfig,
+      patientDetailUrl: '/registration/patient/{{patientUuid}}',
+    });
+    const searchInput = screen.getByPlaceholderText(searchBarPlaceholder);
+
+    (searchPatientByNameOrId as jest.Mock).mockResolvedValue({
+      pageOfResults: [mockPatient],
+      totalCount: 1,
+    });
+
+    fireEvent.input(searchInput, { target: { value: 'Steffi' } });
+    fireEvent.click(screen.getByTestId('search-patient-search-button'));
+
+    const identifier = await screen.findByText('ABC200000');
+    fireEvent.click(identifier);
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      `/registration/patient/${mockPatient.uuid}`,
+    );
+  });
+
+  it('should render the configured custom-attribute columns for a name/ID search', async () => {
+    const configWithColumns = {
+      customAttributes: [
+        {
+          translationKey: 'REGISTRATION_PATIENT_SEARCH_DROPDOWN_PHONE_NUMBER',
+          fields: ['phoneNumber', 'alternatePhoneNumber'],
+          columnTranslationKeys: [],
+          expectedFields: [
+            {
+              field: 'phoneNumber',
+              translationKey: 'REGISTRATION_PATIENT_SEARCH_HEADER_PHONE_NUMBER',
+            },
+            {
+              field: 'alternatePhoneNumber',
+              translationKey:
+                'REGISTRATION_PATIENT_SEARCH_HEADER_ALTERNATE_PHONE_NUMBER',
+            },
+          ],
+          type: 'person' as const,
+        },
+      ],
+      appointment: [],
+    };
+
+    renderSearchPatient(configWithColumns);
+    const searchInput = screen.getByPlaceholderText(searchBarPlaceholder);
+
+    (searchPatientByNameOrId as jest.Mock).mockResolvedValue({
+      pageOfResults: [mockPatient],
+      totalCount: 1,
+    });
+
+    fireEvent.input(searchInput, { target: { value: 'Steffi' } });
+    fireEvent.click(screen.getByTestId('search-patient-search-button'));
+    expect(
+      await screen.findByTestId('table-header-phoneNumber'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('table-header-alternatePhoneNumber'),
+    ).toBeInTheDocument();
   });
 
   it.each([


### PR DESCRIPTION
JIRA -> [BAH-4911](https://bahmni.atlassian.net/browse/BAH-4911)

Fixes two regressions introduced by the "Move Patient Search Results Into Widget" refactor (#583), where the results table in the Registration patient search rendered with missing columns and a non-functional patient identifier link.

This PR restores the pre-refactor behaviour (category-aware fields, columns visible for name/ID searches, working client-side navigation) while keeping the refactor's config-driven patientDetailUrl approach.

[BAH-4911]: https://bahmni.atlassian.net/browse/BAH-4911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Patient search results now support clickable internal patient links and navigate within the application.
  * External and hash-based links open using standard browser behavior, while unsupported URLs remain readable as text.
  * Search results display the appropriate configured fields for appointment, advanced, and standard searches.

* **Bug Fixes**
  * Patient detail links now use a reliable default destination when no custom URL is configured.
  * Search results now correctly display configured custom attributes in name and ID searches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->