### PR TITLE
BAH-4939 | Add. logic to show spinner during program state change

### DIFF
--- a/apps/clinical/src/pages/ConsultationPage.tsx
+++ b/apps/clinical/src/pages/ConsultationPage.tsx
@@ -279,6 +279,8 @@ const ConsultationPage: React.FC = () => {
           programUUID={programUUID}
           config={{
             fields: clinicalConfig.contextInformation?.program?.fields ?? [],
+            overlayStates:
+              clinicalConfig.contextInformation?.program?.overlayStates ?? [],
           }}
         />
       );

--- a/apps/clinical/src/providers/clinicalConfig/models.ts
+++ b/apps/clinical/src/providers/clinicalConfig/models.ts
@@ -50,6 +50,7 @@ export interface ProgramField {
 
 export interface ProgramConfig {
   fields: ProgramField[];
+  overlayStates?: string[];
 }
 
 export interface ContextInformation {

--- a/apps/clinical/src/providers/clinicalConfig/schema.json
+++ b/apps/clinical/src/providers/clinicalConfig/schema.json
@@ -136,6 +136,13 @@
                   }
                 }
               }
+            },
+            "overlayStates": {
+              "type": "array",
+              "description": "Program workflow state names that should show a blocking loading overlay while the transition to that state is in progress",
+              "items": {
+                "type": "string"
+              }
             }
           }
         }

--- a/packages/bahmni-widgets/src/programDetails/ProgramDetails.tsx
+++ b/packages/bahmni-widgets/src/programDetails/ProgramDetails.tsx
@@ -8,6 +8,7 @@ import {
   Button,
   MenuButton,
   MenuItem,
+  Loading,
 } from '@bahmni/design-system';
 import {
   useTranslation,
@@ -44,6 +45,7 @@ interface ProgramDetailsProps {
   programUUID: string;
   config: {
     fields: ProgramField[];
+    overlayStates?: string[];
   };
 }
 
@@ -57,6 +59,9 @@ const ProgramDetails: React.FC<ProgramDetailsProps> = ({
   const { t } = useTranslation();
   const { addNotification } = useNotification();
   const [isUpdatingState, setIsUpdatingState] = useState(false);
+  const [pendingStateDisplay, setPendingStateDisplay] = useState<string | null>(
+    null,
+  );
   const { userPrivileges } = useUserPrivilege();
   const hasEditPatientProgramsPrivilege = hasPrivilege(
     userPrivileges,
@@ -74,9 +79,10 @@ const ProgramDetails: React.FC<ProgramDetailsProps> = ({
     enabled: !!programUUID,
   });
 
-  const handleButtonClick = (stateUuid: string) => {
+  const handleButtonClick = (state: { uuid: string; display: string }) => {
     setIsUpdatingState(true);
-    updateProgramState(programUUID, stateUuid)
+    setPendingStateDisplay(state.display);
+    updateProgramState(programUUID, state.uuid)
       .then(() => {
         refetch();
         addNotification({
@@ -102,6 +108,7 @@ const ProgramDetails: React.FC<ProgramDetailsProps> = ({
       })
       .finally(() => {
         setIsUpdatingState(false);
+        setPendingStateDisplay(null);
       });
   };
 
@@ -118,7 +125,7 @@ const ProgramDetails: React.FC<ProgramDetailsProps> = ({
     );
   }, [config?.fields]);
 
-  if (isLoading || isUpdatingState) {
+  if (isLoading) {
     return (
       <div
         id="patient-programs-table-loading"
@@ -155,7 +162,7 @@ const ProgramDetails: React.FC<ProgramDetailsProps> = ({
           kind="ghost"
           key={state.uuid}
           disabled={isUpdatingState}
-          onClick={() => handleButtonClick(state.uuid)}
+          onClick={() => handleButtonClick(state)}
         >
           {t(
             `PROGRAMS_STATE_BUTTON_${camelToScreamingSnakeCase(state.display)}`,
@@ -181,12 +188,17 @@ const ProgramDetails: React.FC<ProgramDetailsProps> = ({
               `PROGRAMS_STATE_BUTTON_${camelToScreamingSnakeCase(state.display)}`,
               state.display,
             )}
-            onClick={() => handleButtonClick(state.uuid)}
+            onClick={() => handleButtonClick(state)}
           />
         ))}
       </MenuButton>
     );
   };
+
+  const showLoadingOverlay =
+    isUpdatingState &&
+    !!pendingStateDisplay &&
+    (config?.overlayStates ?? []).includes(pendingStateDisplay);
 
   const enableButtons =
     data.allowedStates &&
@@ -279,6 +291,15 @@ const ProgramDetails: React.FC<ProgramDetailsProps> = ({
           </Column>
         ))}
       </Grid>
+      {showLoadingOverlay && (
+        <div
+          id="program-details-loading-overlay"
+          data-testid="program-details-loading-overlay-test-id"
+          aria-label="program-details-loading-overlay-aria-label"
+        >
+          <Loading active withOverlay />
+        </div>
+      )}
     </div>
   );
 };

--- a/packages/bahmni-widgets/src/programDetails/__tests__/ProgramDetails.test.tsx
+++ b/packages/bahmni-widgets/src/programDetails/__tests__/ProgramDetails.test.tsx
@@ -70,6 +70,7 @@ describe('ProgramDetails', () => {
             { name: 'state' },
             { name: 'outcome' },
           ],
+          overlayStates: ['Follow-up Phase'],
         }}
       />
     </QueryClientProvider>
@@ -455,7 +456,10 @@ describe('ProgramDetails', () => {
     await userEvent.click(button);
 
     expect(
-      screen.getByTestId('patient-programs-table-loading-test-id'),
+      screen.getByTestId('program-details-loading-overlay-test-id'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('patient-programs-tile-test-id'),
     ).toBeInTheDocument();
 
     await waitFor(() => {
@@ -475,6 +479,61 @@ describe('ProgramDetails', () => {
       expect(
         screen.getByTestId('patient-programs-allowed-state-2-button-test-id'),
       ).toHaveTextContent('Follow-up Phase');
+    });
+  });
+
+  it('should not show the loading overlay when the target state is not in overlayStates', async () => {
+    const mockRefetch = jest.fn();
+    (useQuery as jest.Mock).mockReturnValue({
+      data: {
+        id: 'program-1',
+        uuid: 'program-uuid-1',
+        programName: 'TB Program',
+        dateEnrolled: '2023-01-15T10:30:00.000+00:00',
+        dateCompleted: null,
+        outcomeName: null,
+        outcomeDetails: null,
+        currentStateName: 'Treatment Phase',
+        attributes: {},
+        allowedStates: [
+          { uuid: 'allowed-state-2', display: 'Follow-up Phase' },
+          { uuid: 'allowed-state-3', display: 'Completed' },
+        ],
+      },
+      error: null,
+      isError: false,
+      isLoading: false,
+      refetch: mockRefetch,
+    });
+
+    (updateProgramState as jest.Mock).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          setTimeout(() => resolve(mockProgramWithAttributes), 100);
+        }),
+    );
+
+    render(wrapper);
+
+    const button = screen.getByTestId(
+      'patient-programs-allowed-state-3-button-test-id',
+    );
+
+    await userEvent.click(button);
+
+    expect(
+      screen.queryByTestId('program-details-loading-overlay-test-id'),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByTestId('patient-programs-tile-test-id'),
+    ).toBeInTheDocument();
+    expect(button).toBeDisabled();
+
+    await waitFor(() => {
+      expect(updateProgramState).toHaveBeenCalledWith(
+        'test-program-uuid',
+        'allowed-state-3',
+      );
     });
   });
 


### PR DESCRIPTION
**JIRA** → [BAH-4939](https://bahmni.atlassian.net/browse/BAH-4939) <!-- link once the story is created on the product board -->

### **Description**

Program state-transition buttons (e.g. Finalize, Submit) on the Program Details widget currently disable on click but give no other feedback while the update request is in flight, so users have no clear signal that their action registered. This PR adds a full-screen loading overlay that displays for state transitions explicitly configured to need it, until the update request resolves.

---

### **Key Features**

* Clicking a state-transition button that is configured for it now shows a blocking, full-screen loading spinner immediately, which disappears once the request succeeds or fails.
* Which target state(s) trigger the overlay is driven by app config (`contextInformation.program.overlayStates`), not hardcoded — so different transitions (e.g. Submit vs Finalize) can opt in independently per deployment.
* All state-transition buttons continue to disable while any transition is pending, regardless of whether that specific transition shows the overlay — unchanged from current behavior.
* Existing success/error notification behavior after the update completes is unchanged.

---

### **Implementation Details**

* **UI Components**
  `ProgramDetails` (`packages/bahmni-widgets/src/programDetails/ProgramDetails.tsx`) now renders the existing `Loading` atom (`@bahmni/design-system`, wrapping Carbon's `Loading` with `withOverlay`) as a sibling of the widget content instead of replacing the entire widget with a skeleton on every update — no new component introduced.

* **State Management**
  Added `pendingStateDisplay` state to track which specific target state was clicked. `handleButtonClick` now receives the full `{ uuid, display }` state object (previously just the `uuid`) so it can record `display` for the pending transition and clear it in `finally()`. A derived `showLoadingOverlay` flag combines `isUpdatingState`, `pendingStateDisplay`, and the configured `overlayStates` list to decide whether to render the overlay.

* **Configuration**
  `ProgramDetailsProps.config` gains an optional `overlayStates?: string[]` field. Threaded through `ClinicalConfig`'s `ProgramConfig` (`apps/clinical/src/providers/clinicalConfig/models.ts`) and passed from `ConsultationPage.tsx`'s `renderContextInformation`. Also added the corresponding property to the AJV `schema.json` used to validate the fetched clinical config at runtime, since it's a separate source of truth from the TS interface and would otherwise reject the new key.

* **Limitations**
  The widget only knows which target states to overlay via the raw (untranslated) `state.display` name passed in config — this assumes config authors use the same fully-specified state name the backend returns.

PS: If we do not the config then it doesn't show any spinner

Screenshot Example: In the below screenshot, we configured the overlay spinner for "Assessment Submitted" so it is showing spinner after clicking on the Submit button.

### **Screenshots**
<img width="1524" height="1024" alt="image (3)" src="https://github.com/user-attachments/assets/db31e85c-96ea-47e3-b50a-e8bb0765bff8" />

[BAH-4939]: https://bahmni.atlassian.net/browse/BAH-4939?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable loading overlays for selected program state transitions.
  * Displays the pending state name while an update is in progress.
* **Bug Fixes**
  * Prevented unnecessary full-page loading screens during program state updates.
  * States without overlay configuration remain interactive with focused loading feedback.
* **Tests**
  * Added coverage for transitions with and without loading overlays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->