### PR TITLE
BAH-4939 | Add. overlay spinner for application state change

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
   "resolutions": {
     "path-to-regexp": "0.1.13",
     "picomatch": "4.0.4",
-    "fast-uri": "3.1.4",
+    "fast-uri": "3.1.5",
     "immutable": "4.3.9"
   },
   "workspaces": [

--- a/packages/bahmni-widgets/src/programDetails/ProgramDetails.tsx
+++ b/packages/bahmni-widgets/src/programDetails/ProgramDetails.tsx
@@ -20,6 +20,7 @@ import {
 } from '@bahmni/services';
 import { useQuery } from '@tanstack/react-query';
 import React, { useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { useNotification } from '../notification';
 import { useUserPrivilege } from '../userPrivileges/useUserPrivilege';
 import { EDIT_PATIENT_PROGRAMS_PRIVILEGE, KNOWN_FIELDS } from './constants';
@@ -280,15 +281,17 @@ const ProgramDetails: React.FC<ProgramDetailsProps> = ({
           </Column>
         ))}
       </Grid>
-      {isUpdatingState && (
-        <div
-          id="program-details-loading-overlay"
-          data-testid="program-details-loading-overlay-test-id"
-          aria-label="program-details-loading-overlay-aria-label"
-        >
-          <Loading active withOverlay />
-        </div>
-      )}
+      {isUpdatingState &&
+        createPortal(
+          <div
+            id="program-details-loading-overlay"
+            data-testid="program-details-loading-overlay-test-id"
+            aria-label="program-details-loading-overlay-aria-label"
+          >
+            <Loading active withOverlay />
+          </div>,
+          document.body,
+        )}
     </div>
   );
 };

--- a/packages/bahmni-widgets/src/programDetails/ProgramDetails.tsx
+++ b/packages/bahmni-widgets/src/programDetails/ProgramDetails.tsx
@@ -8,6 +8,7 @@ import {
   Button,
   MenuButton,
   MenuItem,
+  Loading,
 } from '@bahmni/design-system';
 import {
   useTranslation,
@@ -118,7 +119,7 @@ const ProgramDetails: React.FC<ProgramDetailsProps> = ({
     );
   }, [config?.fields]);
 
-  if (isLoading || isUpdatingState) {
+  if (isLoading) {
     return (
       <div
         id="patient-programs-table-loading"
@@ -279,6 +280,15 @@ const ProgramDetails: React.FC<ProgramDetailsProps> = ({
           </Column>
         ))}
       </Grid>
+      {isUpdatingState && (
+        <div
+          id="program-details-loading-overlay"
+          data-testid="program-details-loading-overlay-test-id"
+          aria-label="program-details-loading-overlay-aria-label"
+        >
+          <Loading active withOverlay />
+        </div>
+      )}
     </div>
   );
 };

--- a/packages/bahmni-widgets/src/programDetails/__tests__/ProgramDetails.test.tsx
+++ b/packages/bahmni-widgets/src/programDetails/__tests__/ProgramDetails.test.tsx
@@ -455,7 +455,10 @@ describe('ProgramDetails', () => {
     await userEvent.click(button);
 
     expect(
-      screen.getByTestId('patient-programs-table-loading-test-id'),
+      screen.getByTestId('program-details-loading-overlay-test-id'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('patient-programs-tile-test-id'),
     ).toBeInTheDocument();
 
     await waitFor(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8857,10 +8857,10 @@ fast-levenshtein@^2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
-fast-uri@3.1.4, fast-uri@^3.0.1:
-  version "3.1.4"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.4.tgz#3b3daf9ce68f41f956df0b505132c0cfce9ec7af"
-  integrity sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==
+fast-uri@3.1.5, fast-uri@^3.0.1:
+  version "3.1.5"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.5.tgz#610f37419a030270430cecd68d74e3d4d96725d0"
+  integrity sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==
 
 fastest-levenshtein@^1.0.12:
   version "1.0.16"


### PR DESCRIPTION
**JIRA** → [BAH-4939](https://bahmni.atlassian.net/browse/BAH-4939) <!-- link once the story is created on the product board -->

### **Description**

Program state-transition buttons (e.g. Finalize, Submit) on the Program Details widget currently disable on click but give no other feedback while the update request is in flight, so users have no clear signal that their action registered. This PR adds a full-screen loading overlay that displays for state transitions until the update request resolves.
<img width="1524" height="1024" alt="image (3)" src="https://github.com/user-attachments/assets/159d5e4f-dba3-47fb-a8f4-00b3fbe55b6a" />


[BAH-4939]: https://bahmni.atlassian.net/browse/BAH-4939?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved program details loading behavior during state updates.
  * Existing program information remains visible while updates are processing.
  * Added a clear loading overlay to indicate in-progress updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->