### PR TITLE
BAH-4878 |Fix. for sortOrder default-sort arrow direction

### DIFF
--- a/packages/bahmni-widgets/src/search/commonSearch/ResultsTable.tsx
+++ b/packages/bahmni-widgets/src/search/commonSearch/ResultsTable.tsx
@@ -164,9 +164,7 @@ const ResultsTable = ({
         key: id,
         header: t(field.translationKey),
         enableSorting: field.enableSort ?? false,
-        defaultSortDirection: field.enableSort
-          ? (field.sortOrder ?? undefined)
-          : field.sortOrder,
+        defaultSortDirection: field.sortOrder,
         enableFiltering: !!field.filterType,
         filterType: field.filterType,
       })),

--- a/packages/bahmni-widgets/src/search/commonSearch/__tests__/ResultsTable.test.tsx
+++ b/packages/bahmni-widgets/src/search/commonSearch/__tests__/ResultsTable.test.tsx
@@ -233,6 +233,49 @@ describe('ResultsTable', () => {
       expect(rows[0]).toHaveTextContent('Alice');
       expect(rows[1]).toHaveTextContent('Bob');
       expect(rows[2]).toHaveTextContent('Charlie');
+
+      expect(
+        screen.getByRole('columnheader', { name: /PATIENT_NAME/ }),
+      ).toHaveAttribute('aria-sort', 'ascending');
+      expect(
+        screen.getByRole('columnheader', { name: 'PATIENT_AGE' }),
+      ).not.toHaveAttribute('aria-sort', 'ascending');
+    });
+
+    it('does not apply a default sort or show a sort indicator when sortOrder is omitted for a sortable field', async () => {
+      mockJsonata.mockImplementation((expression: string) => ({
+        evaluate: async (item: Record<string, unknown>) => item[expression],
+      }));
+
+      const resultFieldsWithOmittedSortOrder: ResultFieldConfig[] = [
+        {
+          translationKey: 'PATIENT_NAME',
+          expression: 'name',
+          enableSort: true,
+        },
+      ];
+
+      renderTable({
+        resultFields: resultFieldsWithOmittedSortOrder,
+        results: [
+          { id: '1', name: 'Charlie' },
+          { id: '2', name: 'Alice' },
+          { id: '3', name: 'Bob' },
+        ],
+      });
+
+      await waitFor(() => {
+        expect(screen.getAllByTestId(/^table-row-/)).toHaveLength(3);
+      });
+
+      const rows = screen.getAllByTestId(/^table-row-/);
+      expect(rows[0]).toHaveTextContent('Charlie');
+      expect(rows[1]).toHaveTextContent('Alice');
+      expect(rows[2]).toHaveTextContent('Bob');
+
+      expect(
+        screen.getByRole('columnheader', { name: /PATIENT_NAME/ }),
+      ).toHaveAttribute('aria-sort', 'none');
     });
 
     it('uses declaration order as the tiebreak when multiple columns declare sortOrder', async () => {


### PR DESCRIPTION
A fix for default sort direction for Column fields in common search page. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved search results sorting to consistently respect the configured sort order.
  - Fields without a configured sort order now retain their original row order and correctly indicate that no sorting is applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->